### PR TITLE
feat: pure-Rust VBAP backend (no SAF/SPARTA dependency)

### DIFF
--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -60,27 +60,18 @@ impl VbapTopologyBuildPlan {
         &self,
         _evaluation_mode: LiveEvaluationMode,
     ) -> Result<Box<dyn GainModel>> {
-        #[cfg(not(feature = "saf_vbap"))]
-        {
-            anyhow::bail!(
-                "VBAP backend construction requires the `saf_vbap` feature; use from-file evaluation or enable saf_vbap"
-            );
-        }
-        #[cfg(feature = "saf_vbap")]
-        {
-            let vbap = crate::spatial_vbap::VbapPanner::new_with_mode(
-                &self.positions,
-                self.azimuth_resolution,
-                self.elevation_resolution,
-                0.0,
-                self.table_mode,
-            )
-            .map_err(|e| anyhow::anyhow!("Failed to create VBAP panner: {}", e))?
-            .with_negative_z(self.allow_negative_z)
-            .with_position_interpolation(self.position_interpolation);
+        let vbap = crate::spatial_vbap::VbapPanner::new_with_mode(
+            &self.positions,
+            self.azimuth_resolution,
+            self.elevation_resolution,
+            0.0,
+            self.table_mode,
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to create VBAP panner: {}", e))?
+        .with_negative_z(self.allow_negative_z)
+        .with_position_interpolation(self.position_interpolation);
 
-            Ok(Box::new(crate::render_backend::VbapBackend::new(vbap)))
-        }
+        Ok(Box::new(crate::render_backend::VbapBackend::new(vbap)))
     }
 }
 

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -20,15 +20,13 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
-#[cfg(feature = "saf_vbap")]
 use crate::backend_registry::{TopologyBuildPlan, prepare_topology_build_plan};
 use crate::render_backend::backend_descriptor_by_id;
 use crate::render_backend::{
-    BackendRestoreSnapshot, GainModelKind, LoadedEvaluationArtifact, PreparedRenderEngine,
-    RenderBackendKind, SerializedEvaluationMode, build_from_artifact_render_engine,
+    BackendRestoreSnapshot, EvaluationBuildConfig, GainModelKind, LoadedEvaluationArtifact,
+    PreparedRenderEngine, RenderBackendKind, RenderRequest, SerializedEvaluationMode,
+    build_from_artifact_render_engine,
 };
-#[cfg(feature = "saf_vbap")]
-use crate::render_backend::{EvaluationBuildConfig, RenderRequest};
 use crate::spatial_vbap::VbapTableMode;
 use crate::speaker_layout::SpeakerLayout;
 
@@ -364,12 +362,10 @@ impl BackendRebuildParams {
     }
 }
 
-#[cfg(feature = "saf_vbap")]
 fn rebuild_params_allow_negative_z(params: Option<BackendRebuildParams>) -> bool {
     params.map(|value| value.allow_negative_z).unwrap_or(false)
 }
 
-#[cfg(feature = "saf_vbap")]
 fn evaluation_build_config_from_live(
     live: &LiveParams,
     allow_negative_z: bool,
@@ -615,7 +611,6 @@ impl RendererControl {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    #[cfg(feature = "saf_vbap")]
     pub fn prepare_topology_rebuild(&self) -> Option<TopologyBuildPlan> {
         let layout = self.editable_layout();
         let live = self.live.read().unwrap();

--- a/omniphony-renderer/renderer/src/spatial_renderer.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer.rs
@@ -72,28 +72,21 @@ use crate::ramp_strategy::{
     ChannelRampState, GainTableRampStrategy, PositionRampStrategy, RampContext, RampProgress,
     RampRenderParams, RampStatus, RampStrategy, RampTarget,
 };
-#[cfg(feature = "saf_vbap")]
+use crate::live_params::PreferredEvaluationMode;
 use crate::render_backend::RenderRequest;
 use crate::render_backend::{
-    LoadedEvaluationArtifact, LoadedVbapFile, RenderBackendKind, SerializedEvaluationMode,
-    build_from_artifact_render_engine, build_from_file_render_engine,
+    CartesianEvaluationConfig, EffectiveEvaluationMode, EvaluationBuildConfig,
+    LoadedEvaluationArtifact, LoadedVbapFile, PolarEvaluationConfig, RenderBackendKind,
+    SerializedEvaluationMode, VbapBackend, build_from_artifact_render_engine,
+    build_from_file_render_engine, build_prepared_render_engine,
 };
+use crate::spatial_vbap::VbapPanner;
 use crate::spatial_vbap::VbapTableMode;
 use crate::spatial_vbap::{DistanceModel, Gains, adm_to_spherical};
 use crate::speaker_layout::SpeakerLayout;
 use anyhow::Result;
 use std::str::FromStr;
 use std::sync::Arc;
-
-#[cfg(feature = "saf_vbap")]
-use crate::live_params::PreferredEvaluationMode;
-#[cfg(feature = "saf_vbap")]
-use crate::render_backend::{
-    CartesianEvaluationConfig, EffectiveEvaluationMode, EvaluationBuildConfig,
-    PolarEvaluationConfig, VbapBackend, build_prepared_render_engine,
-};
-#[cfg(feature = "saf_vbap")]
-use crate::spatial_vbap::VbapPanner;
 
 /// Output of a single rendered frame.
 pub struct RenderedFrame {
@@ -105,7 +98,6 @@ pub struct RenderedFrame {
     pub object_gains: Vec<(usize, Gains)>,
 }
 
-#[cfg(feature = "saf_vbap")]
 fn evaluation_build_config(
     request_template: RenderRequest,
     position_interpolation: bool,
@@ -352,7 +344,6 @@ impl SpatialRenderer {
     ///
     /// **Note:** This method requires the `saf_vbap` feature to generate VBAP tables.
     /// Without saf_vbap, use `from_vbap_file()` to load pre-generated tables.
-    #[cfg(feature = "saf_vbap")]
     pub fn new(
         speaker_layout: SpeakerLayout,
         sample_rate: u32,
@@ -1893,10 +1884,8 @@ impl SpatialRenderer {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "saf_vbap")]
     use super::*;
 
-    #[cfg(feature = "saf_vbap")]
     #[test]
     fn test_renderer_creation() {
         let layout = SpeakerLayout::preset("7.1.4").unwrap();

--- a/omniphony-renderer/renderer/src/spatial_vbap/convhull.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/convhull.rs
@@ -1,0 +1,355 @@
+// Used only when saf_vbap feature is disabled; suppress warnings in the default build.
+#![allow(dead_code)]
+
+// Ported from convhull_3d.c
+// Copyright (c) 2017-2018 Leo McCormack, MIT License
+// Originally derived from "computational-geometry-toolbox" by
+// George Papazafeiropoulos (c) 2014, BSD-2-Clause License
+//
+// Reference: Barber, Dobkin, Huhdanpaa, "The Quickhull Algorithm for Convex Hull",
+// Geometry Center Technical Report GCG53, July 30, 1993.
+//
+// Compute the 3-D convex hull of a set of points using the incremental Quickhull
+// algorithm. Used by `find_ls_triplets` to triangulate loudspeaker positions.
+
+const D: usize = 3; // Dimensions
+const S: usize = 4; // Stride = D+1 (homogeneous coordinate)
+const NOISE_VAL: f64 = 1e-7; // Small noise to avoid degenerate configurations
+const MAX_FACES: usize = 50_000; // Safety cap matching the original C code
+
+// ── Deterministic pseudo-random noise (XorShift32) ──────────────────────────
+
+struct Xorshift32(u32);
+impl Xorshift32 {
+    #[inline]
+    fn next(&mut self) -> f64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.0 = x;
+        (x as f64) / (u32::MAX as f64 + 1.0)
+    }
+}
+
+// ── Plane helpers ────────────────────────────────────────────────────────────
+
+/// 4×4 determinant (explicit expansion). Input is a row-major flat array of 16 doubles.
+#[inline]
+fn det_4x4(m: &[f64; 16]) -> f64 {
+    m[3]  * m[6]  * m[9]  * m[12] - m[2]  * m[7]  * m[9]  * m[12]
+  - m[3]  * m[5]  * m[10] * m[12] + m[1]  * m[7]  * m[10] * m[12]
+  + m[2]  * m[5]  * m[11] * m[12] - m[1]  * m[6]  * m[11] * m[12]
+  - m[3]  * m[6]  * m[8]  * m[13] + m[2]  * m[7]  * m[8]  * m[13]
+  + m[3]  * m[4]  * m[10] * m[13] - m[0]  * m[7]  * m[10] * m[13]
+  - m[2]  * m[4]  * m[11] * m[13] + m[0]  * m[6]  * m[11] * m[13]
+  + m[3]  * m[5]  * m[8]  * m[14] - m[1]  * m[7]  * m[8]  * m[14]
+  - m[3]  * m[4]  * m[9]  * m[14] + m[0]  * m[7]  * m[9]  * m[14]
+  + m[1]  * m[4]  * m[11] * m[14] - m[0]  * m[5]  * m[11] * m[14]
+  - m[2]  * m[5]  * m[8]  * m[15] + m[1]  * m[6]  * m[8]  * m[15]
+  + m[2]  * m[4]  * m[9]  * m[15] - m[0]  * m[6]  * m[9]  * m[15]
+  - m[1]  * m[4]  * m[10] * m[15] + m[0]  * m[5]  * m[10] * m[15]
+}
+
+/// Compute the plane coefficients (normal `c`, offset `d`) for a triangle
+/// specified by three row-major 3-D points stored in `p[0..9]`
+/// (p[0..3] = point 0, p[3..6] = point 1, p[6..9] = point 2).
+///
+/// The plane equation is:  c · x + d = 0.
+fn plane_3d(p: &[f64; 9]) -> ([f64; 3], f64) {
+    // Edge vectors
+    let pdiff = [
+        [p[3] - p[0], p[4] - p[1], p[5] - p[2]], // p1 - p0
+        [p[6] - p[3], p[7] - p[4], p[8] - p[5]], // p2 - p1
+    ];
+
+    let mut c = [0.0f64; 3];
+    let mut sign = 1.0f64;
+    for i in 0..3usize {
+        // 2×2 minor of pdiff, excluding column i
+        let cols: [usize; 2] = match i {
+            0 => [1, 2],
+            1 => [0, 2],
+            _ => [0, 1],
+        };
+        let det = pdiff[0][cols[0]] * pdiff[1][cols[1]]
+                - pdiff[1][cols[0]] * pdiff[0][cols[1]];
+        c[i] = sign * det;
+        sign = -sign;
+    }
+
+    let norm = (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt();
+    if norm < 1e-15 {
+        return ([0.0, 0.0, 1.0], 0.0);
+    }
+    let c = [c[0] / norm, c[1] / norm, c[2] / norm];
+    let d = -(p[0] * c[0] + p[1] * c[1] + p[2] * c[2]);
+    (c, d)
+}
+
+// ── Main public function ─────────────────────────────────────────────────────
+
+/// Compute the 3-D convex hull of `in_vertices` and return the triangle face
+/// indices, or `None` if the triangulation fails (too few points, degenerate
+/// point set, or exceeded `MAX_FACES`).
+///
+/// Each returned face is `[i0, i1, i2]` where the indices index into
+/// `in_vertices`. Face normals are oriented outward.
+pub fn convhull_3d_build(in_vertices: &[[f64; 3]]) -> Option<Vec<[usize; 3]>> {
+    let n_vert = in_vertices.len();
+    if n_vert <= D {
+        return None;
+    }
+
+    let mut rng = Xorshift32(12345);
+
+    // ── Build padded point matrix: each row = [x+ε, y+ε, z+ε, 1.0] ──────────
+    let mut points = vec![0.0f64; n_vert * S];
+    for i in 0..n_vert {
+        for j in 0..D {
+            points[i * S + j] = in_vertices[i][j] + NOISE_VAL * rng.next();
+        }
+        points[i * S + D] = 1.0;
+    }
+
+    // ── Span check ────────────────────────────────────────────────────────────
+    let mut span = [0.0f64; D];
+    for j in 0..D {
+        let mut max_p = f64::NEG_INFINITY;
+        let mut min_p = f64::INFINITY;
+        for i in 0..n_vert {
+            let v = points[i * S + j];
+            if v > max_p { max_p = v; }
+            if v < min_p { min_p = v; }
+        }
+        span[j] = max_p - min_p;
+        if span[j] <= 1e-7 { return None; }
+    }
+
+    // ── Initial simplex: D+1 = 4 faces using vertices 0..4 ───────────────────
+    let mut n_faces = D + 1;
+    // Face i contains all initial vertices except vertex i
+    let mut faces: Vec<usize> = vec![0; n_faces * D];
+    for i in 0..n_faces {
+        let mut k = 0;
+        for j in 0..=D {
+            if j != i {
+                faces[i * D + k] = j;
+                k += 1;
+            }
+        }
+    }
+
+    // ── Plane coefficients for initial faces ──────────────────────────────────
+    let mut cf = vec![0.0f64; n_faces * D]; // normal components (row-major per face)
+    let mut df = vec![0.0f64; n_faces];     // plane offsets
+    let mut p_s = [0.0f64; 9];             // 3×3 workspace
+
+    for i in 0..n_faces {
+        for j in 0..D {
+            for k in 0..D {
+                p_s[j * D + k] = points[faces[i * D + j] * S + k];
+            }
+        }
+        let (cfi, dfi) = plane_3d(&p_s);
+        cf[i * D..i * D + D].copy_from_slice(&cfi);
+        df[i] = dfi;
+    }
+
+    // ── Orient initial simplex faces outward ──────────────────────────────────
+    let mut a_mat = [0.0f64; 16]; // 4×4 workspace
+    for k in 0..=D {
+        // Face k is opposite vertex k; rows 0..D = face vertices, row D = vertex k
+        for i in 0..D {
+            for l in 0..=D {
+                a_mat[i * S + l] = points[faces[k * D + i] * S + l];
+            }
+        }
+        for l in 0..=D {
+            a_mat[D * S + l] = points[k * S + l]; // opposite vertex = k
+        }
+        if det_4x4(&a_mat) < 0.0 {
+            faces.swap(k * D + 1, k * D + 2);
+            for j in 0..D { cf[k * D + j] = -cf[k * D + j]; }
+            df[k] = -df[k];
+        }
+    }
+
+    // ── Early exit for minimal input ──────────────────────────────────────────
+    let remaining = n_vert - D - 1;
+    if remaining == 0 {
+        return Some(to_face_array(&faces, n_faces));
+    }
+
+    // ── Sort remaining points by squared relative distance (descending) ───────
+    let mut mean_p = [0.0f64; D];
+    for i in (D + 1)..n_vert {
+        for j in 0..D { mean_p[j] += points[i * S + j]; }
+    }
+    for j in 0..D { mean_p[j] /= remaining as f64; }
+
+    let mut order: Vec<(f64, usize)> = ((D + 1)..n_vert)
+        .map(|i| {
+            let dist: f64 = (0..D)
+                .map(|j| { let v = (points[i * S + j] - mean_p[j]) / span[j]; v * v })
+                .sum();
+            (dist, i)
+        })
+        .collect();
+    order.sort_unstable_by(|a, b| {
+        b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut pleft: Vec<usize> = order.into_iter().map(|(_, i)| i).collect();
+
+    // ── Main incremental hull loop ────────────────────────────────────────────
+    let mut fucked = false;
+
+    while !pleft.is_empty() {
+        let pt = pleft.remove(0);
+
+        let px = points[pt * S];
+        let py = points[pt * S + 1];
+        let pz = points[pt * S + 2];
+
+        // Which faces are visible from pt?
+        let visible_ind: Vec<bool> = (0..n_faces)
+            .map(|fi| {
+                px * cf[fi * D] + py * cf[fi * D + 1] + pz * cf[fi * D + 2] + df[fi] > 0.0
+            })
+            .collect();
+
+        let num_visible = visible_ind.iter().filter(|&&v| v).count();
+        if num_visible == 0 {
+            continue;
+        }
+        let num_nonvisible = n_faces - num_visible;
+
+        let visible: Vec<usize> = (0..n_faces).filter(|&i| visible_ind[i]).collect();
+        // nonvisible_faces: flat array [num_nonvisible × D] of vertex indices
+        let nonvisible_faces: Vec<usize> = (0..n_faces)
+            .filter(|&i| !visible_ind[i])
+            .flat_map(|i| [faces[i * D], faces[i * D + 1], faces[i * D + 2]])
+            .collect();
+
+        // ── Find horizon edges ─────────────────────────────────────────────────
+        // A horizon edge is shared by exactly one visible and one nonvisible face.
+        let mut horizon: Vec<[usize; 2]> = Vec::new();
+        for &vis in &visible {
+            let mut face_s = [faces[vis * D], faces[vis * D + 1], faces[vis * D + 2]];
+            face_s.sort_unstable();
+
+            for ni in 0..num_nonvisible {
+                let nf = [
+                    nonvisible_faces[ni * D],
+                    nonvisible_faces[ni * D + 1],
+                    nonvisible_faces[ni * D + 2],
+                ];
+                // f0[l] = true iff nf[l] is a vertex of face vis
+                let f0 = [
+                    face_s.binary_search(&nf[0]).is_ok(),
+                    face_s.binary_search(&nf[1]).is_ok(),
+                    face_s.binary_search(&nf[2]).is_ok(),
+                ];
+                if f0.iter().filter(|&&v| v).count() == D - 1 {
+                    // Shared edge = the 2 common vertices
+                    let mut edge = [0usize; 2];
+                    let mut h = 0;
+                    for l in 0..D {
+                        if f0[l] { edge[h] = nf[l]; h += 1; }
+                    }
+                    horizon.push(edge);
+                }
+            }
+        }
+        let horizon_size = horizon.len();
+
+        // ── Delete visible faces ───────────────────────────────────────────────
+        let new_n = num_nonvisible;
+        let mut new_faces = vec![0usize; new_n * D];
+        let mut new_cf    = vec![0.0f64;  new_n * D];
+        let mut new_df    = vec![0.0f64;  new_n];
+        let mut j = 0;
+        for i in 0..n_faces {
+            if !visible_ind[i] {
+                new_faces[j * D..j * D + D].copy_from_slice(&faces[i * D..i * D + D]);
+                new_cf[j * D..j * D + D].copy_from_slice(&cf[i * D..i * D + D]);
+                new_df[j] = df[i];
+                j += 1;
+            }
+        }
+        faces = new_faces;
+        cf    = new_cf;
+        df    = new_df;
+        n_faces = new_n;
+
+        // Safety: prevent unbounded growth
+        if n_faces + horizon_size > MAX_FACES {
+            fucked = true;
+            break;
+        }
+
+        let start = n_faces;
+
+        // ── Add new faces connecting each horizon edge to pt ───────────────────
+        for h in 0..horizon_size {
+            let new_face = [horizon[h][0], horizon[h][1], pt];
+            faces.extend_from_slice(&new_face);
+            for j in 0..D {
+                for k in 0..D {
+                    p_s[j * D + k] = points[new_face[j] * S + k];
+                }
+            }
+            let (cfi, dfi) = plane_3d(&p_s);
+            cf.extend_from_slice(&cfi);
+            df.push(dfi);
+        }
+        n_faces += horizon_size;
+
+        // ── Orient each new face outward ───────────────────────────────────────
+        for k in start..n_faces {
+            let mut face_s = [faces[k * D], faces[k * D + 1], faces[k * D + 2]];
+            face_s.sort_unstable();
+
+            // pp: face-indices that are not vertex-indices of face k.
+            // Used as a pool of reference point-indices for the determinant test.
+            // This mirrors the original C code's hVec-based approach.
+            let pp: Vec<usize> = (0..n_faces)
+                .filter(|j| face_s.binary_search(j).is_err())
+                .collect();
+
+            let mut index = 0;
+            let mut det_a = 0.0f64;
+
+            while det_a == 0.0 && index < pp.len() {
+                let p_idx = pp[index];
+                for i in 0..D {
+                    for l in 0..S {
+                        a_mat[i * S + l] = points[faces[k * D + i] * S + l];
+                    }
+                }
+                for l in 0..S {
+                    a_mat[D * S + l] = points[p_idx * S + l];
+                }
+                index += 1;
+                det_a = det_4x4(&a_mat);
+            }
+
+            if det_a < 0.0 {
+                faces.swap(k * D + 1, k * D + 2);
+                for j in 0..D { cf[k * D + j] = -cf[k * D + j]; }
+                df[k] = -df[k];
+            }
+        }
+    }
+
+    if fucked { return None; }
+
+    Some(to_face_array(&faces, n_faces))
+}
+
+#[inline]
+fn to_face_array(faces: &[usize], n_faces: usize) -> Vec<[usize; 3]> {
+    (0..n_faces)
+        .map(|i| [faces[i * D], faces[i * D + 1], faces[i * D + 2]])
+        .collect()
+}

--- a/omniphony-renderer/renderer/src/spatial_vbap/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/mod.rs
@@ -8,6 +8,8 @@
 mod coords;
 mod distance;
 mod panner;
+pub(crate) mod convhull;
+pub(crate) mod vbap_native;
 
 pub use coords::{adm_to_spherical, spherical_to_adm};
 pub use distance::{DistanceModel, calculate_distance_attenuation};

--- a/omniphony-renderer/renderer/src/spatial_vbap/panner.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/panner.rs
@@ -239,13 +239,17 @@ pub struct VbapPanner {
     allow_negative_z: bool,
     position_interpolation: bool,
     cartesian_cache: Option<CartesianCache>,
-    #[cfg(feature = "saf_vbap")]
+    /// Stored speaker directions — present when the panner was created from
+    /// speaker directions (both `saf_vbap` and native paths).  `None` when
+    /// the panner was loaded from a pre-computed `.vbap` file.
     speaker_dirs_deg: Option<Vec<[f32; 2]>>,
 }
 
 pub(crate) mod gain_source;
 #[cfg(feature = "saf_vbap")]
 pub(crate) mod saf_backend;
+#[cfg(not(feature = "saf_vbap"))]
+pub(crate) mod native_backend;
 
 mod io;
 mod runtime;

--- a/omniphony-renderer/renderer/src/spatial_vbap/panner/native_backend.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/panner/native_backend.rs
@@ -1,0 +1,89 @@
+//! Pure-Rust VBAP backend — drop-in replacement for `saf_backend.rs`.
+//!
+//! Used when the `saf_vbap` feature is disabled (no C FFI, no external library).
+
+use super::Gains;
+use super::gain_source::VbapGainSource;
+use crate::spatial_vbap::vbap_native::{find_ls_triplets, invert_ls_mtx_3d, vbap3d};
+
+/// Maximum spread in degrees accepted by `vbap3d`.
+/// Matches `SpartaVbapLayout::NORMALIZED_SPREAD_MAX_DEG` for parity.
+const NORMALIZED_SPREAD_MAX_DEG: f32 = 180.0;
+
+#[inline]
+fn normalized_spread_to_degrees(spread: f32) -> f32 {
+    spread.clamp(0.0, 1.0) * NORMALIZED_SPREAD_MAX_DEG
+}
+
+/// Pure-Rust equivalent of `SpartaVbapLayout`.
+///
+/// Owns the triangulation and inverse speaker matrices produced by
+/// `find_ls_triplets` + `invert_ls_mtx_3d`. Implements [`VbapGainSource`]
+/// so it can be used interchangeably with the SAF FFI backend.
+pub(crate) struct NativeVbapLayout {
+    pub(crate) n_speakers: usize,
+    pub(crate) n_faces: usize,
+    #[allow(dead_code)]
+    u_spkr: Vec<[f32; 3]>,
+    ls_groups: Vec<[usize; 3]>,
+    layout_inv_mtx: Vec<[f32; 9]>,
+}
+
+impl NativeVbapLayout {
+    /// Build a layout from speaker directions (azimuth, elevation in degrees).
+    ///
+    /// Calls `find_ls_triplets` → `invert_ls_mtx_3d` to prepare the data
+    /// needed for per-direction VBAP gain computation.
+    pub fn from_speaker_dirs(speaker_dirs_deg: &[[f32; 2]]) -> Result<Self, String> {
+        let (u_spkr, ls_groups) = find_ls_triplets(speaker_dirs_deg, true)
+            .ok_or_else(|| "find_ls_triplets failed".to_string())?;
+
+        if ls_groups.is_empty() {
+            return Err("No valid loudspeaker triangles found".to_string());
+        }
+
+        let layout_inv_mtx = invert_ls_mtx_3d(&u_spkr, &ls_groups);
+        let n_faces = ls_groups.len();
+        let n_speakers = speaker_dirs_deg.len();
+
+        Ok(Self {
+            n_speakers,
+            n_faces,
+            u_spkr,
+            ls_groups,
+            layout_inv_mtx,
+        })
+    }
+
+    /// Compute VBAP gains for a single source direction and spread.
+    pub fn vbap_gains(
+        &self,
+        azimuth_deg: f32,
+        elevation_deg: f32,
+        spread: f32,
+    ) -> Result<Gains, String> {
+        let spread_deg = normalized_spread_to_degrees(spread);
+        let src_dirs = [[azimuth_deg, elevation_deg]];
+
+        let gain_vec = vbap3d(
+            &src_dirs,
+            self.n_speakers,
+            &self.ls_groups,
+            spread_deg,
+            &self.layout_inv_mtx,
+        );
+
+        Ok(Gains::from_slice(&gain_vec))
+    }
+}
+
+impl VbapGainSource for NativeVbapLayout {
+    fn compute_gains(
+        &self,
+        azimuth_deg: f32,
+        elevation_deg: f32,
+        spread: f32,
+    ) -> Result<Gains, String> {
+        self.vbap_gains(azimuth_deg, elevation_deg, spread)
+    }
+}

--- a/omniphony-renderer/renderer/src/spatial_vbap/panner/runtime.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/panner/runtime.rs
@@ -21,7 +21,16 @@ impl VbapPanner {
         }
         #[cfg(not(feature = "saf_vbap"))]
         {
-            Ok(Box::new(gain_source::TableGainSource::new(self)))
+            // If speaker directions are available, use the native VBAP backend
+            // for direct gain computation (needed when gtable is empty).
+            // Otherwise, fall back to table interpolation.
+            if let Some(dirs) = self.speaker_dirs_deg.as_deref() {
+                Ok(Box::new(
+                    native_backend::NativeVbapLayout::from_speaker_dirs(dirs)?,
+                ))
+            } else {
+                Ok(Box::new(gain_source::TableGainSource::new(self)))
+            }
         }
     }
 
@@ -133,12 +142,67 @@ impl VbapPanner {
             allow_negative_z: true,
             position_interpolation: true,
             cartesian_cache: None,
-            #[cfg(feature = "saf_vbap")]
             speaker_dirs_deg: Some(speaker_dirs_deg.to_vec()),
         })
     }
 
     #[cfg(feature = "saf_vbap")]
+    pub fn new_with_mode(
+        speaker_dirs_deg: &[[f32; 2]],
+        az_res_deg: i32,
+        el_res_deg: i32,
+        spread: f32,
+        table_mode: VbapTableMode,
+    ) -> Result<Self, String> {
+        let p = Self::new(speaker_dirs_deg, az_res_deg, el_res_deg, spread)?;
+        p.with_table_mode(table_mode)
+    }
+
+    /// Create a new VBAP panner using the pure-Rust native backend.
+    ///
+    /// Used when the `saf_vbap` feature is disabled.
+    #[cfg(not(feature = "saf_vbap"))]
+    pub fn new(
+        speaker_dirs_deg: &[[f32; 2]],
+        az_res_deg: i32,
+        el_res_deg: i32,
+        spread: f32,
+    ) -> Result<Self, String> {
+        let n_speakers = speaker_dirs_deg.len();
+
+        if n_speakers < 3 {
+            return Err("VBAP requires at least 3 speakers".to_string());
+        }
+        if az_res_deg < 1 || az_res_deg > 360 {
+            return Err("Azimuth resolution must be between 1 and 360 degrees".to_string());
+        }
+        if el_res_deg < 1 || el_res_deg > 180 {
+            return Err("Elevation resolution must be between 1 and 180 degrees".to_string());
+        }
+
+        let layout = native_backend::NativeVbapLayout::from_speaker_dirs(speaker_dirs_deg)?;
+        let n_az = ((360.0 / az_res_deg as f32) + 1.5) as usize;
+        let n_el = ((180.0 / el_res_deg as f32) + 1.5) as usize;
+
+        Ok(VbapPanner {
+            spread_tables: vec![SpreadTable { spread, gtable: Vec::new() }],
+            spread_resolution: 0.0,
+            n_gtable: n_az * n_el,
+            n_triangles: layout.n_faces,
+            n_speakers,
+            az_res_deg,
+            el_res_deg,
+            n_az,
+            n_el,
+            table_mode: VbapTableMode::Polar,
+            allow_negative_z: true,
+            position_interpolation: true,
+            cartesian_cache: None,
+            speaker_dirs_deg: Some(speaker_dirs_deg.to_vec()),
+        })
+    }
+
+    #[cfg(not(feature = "saf_vbap"))]
     pub fn new_with_mode(
         speaker_dirs_deg: &[[f32; 2]],
         az_res_deg: i32,
@@ -291,20 +355,29 @@ impl VbapPanner {
         elevation_deg: f32,
         spread: f32,
     ) -> Gains {
-        #[cfg(feature = "saf_vbap")]
-        // Direct vbap3D is only used as a last-resort path while spread tables are absent.
+        // Direct gain computation path — used when the spread table hasn't been
+        // pre-computed yet (gtable is empty). Falls back to the appropriate backend.
         if self
             .spread_tables
             .first()
             .map(|t| t.gtable.is_empty())
             .unwrap_or(false)
         {
+            #[cfg(feature = "saf_vbap")]
             if let Some(dirs) = self.speaker_dirs_deg.as_deref() {
                 let layout = saf_backend::SpartaVbapLayout::from_speaker_dirs(dirs)
                     .expect("failed to initialize direct VBAP layout");
                 return layout
                     .vbap_gains(azimuth_deg, elevation_deg, spread)
                     .expect("vbap3D failed while computing gains");
+            }
+            #[cfg(not(feature = "saf_vbap"))]
+            if let Some(dirs) = self.speaker_dirs_deg.as_deref() {
+                let layout = native_backend::NativeVbapLayout::from_speaker_dirs(dirs)
+                    .expect("failed to initialize native VBAP layout");
+                return layout
+                    .vbap_gains(azimuth_deg, elevation_deg, spread)
+                    .expect("native vbap3d failed while computing gains");
             }
         }
 
@@ -561,7 +634,8 @@ impl VbapPanner {
 
     /// Get VBAP gains for a sound source at the specified direction (no spread).
     pub fn get_gains(&self, azimuth_deg: f32, elevation_deg: f32) -> Gains {
-        #[cfg(feature = "saf_vbap")]
+        // When the spread table hasn't been pre-computed (gtable is empty),
+        // delegate to `get_gains_with_spread` which handles both SAF and native paths.
         if self
             .spread_tables
             .first()

--- a/omniphony-renderer/renderer/src/spatial_vbap/vbap_native.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/vbap_native.rs
@@ -1,0 +1,479 @@
+// Used only when saf_vbap feature is disabled; suppress warnings in the default build.
+#![allow(dead_code)]
+
+// Ported from saf_vbap.c — Copyright (c) 2017-2018 Leo McCormack, ISC License
+// VBAP algorithm derived from https://github.com/polarch/Vector-Base-Amplitude-Panning
+// Copyright (c) 2015, Archontis Politis, BSD-3-Clause License
+//
+// Pure-Rust VBAP backend: findLsTriplets, invertLsMtx3D, getSpreadSrcDirs3D,
+// vbap3D, generateVBAPgainTable3D.  No unsafe code, no external dependencies.
+
+use super::convhull::convhull_3d_build;
+
+const ADD_DUMMY_LIMIT: f32 = 60.0;
+const APERTURE_LIMIT_RAD: f32 = std::f32::consts::PI; // 180 degrees
+
+// ── Coordinate helpers ───────────────────────────────────────────────────────
+
+#[inline]
+fn sph_to_cart(az_rad: f32, el_rad: f32) -> [f32; 3] {
+    let cos_el = el_rad.cos();
+    [cos_el * az_rad.cos(), cos_el * az_rad.sin(), el_rad.sin()]
+}
+
+/// 3-D cross product
+#[inline]
+fn cross3(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+/// Dot product of two 3-vectors
+#[inline]
+fn dot3(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// Normalise a 3-vector; returns the original vector if the norm is tiny.
+#[inline]
+fn normalise3(v: [f32; 3]) -> [f32; 3] {
+    let n = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    if n < 1e-30 { v } else { [v[0] / n, v[1] / n, v[2] / n] }
+}
+
+// ── Analytical 3×3 matrix inverse ───────────────────────────────────────────
+
+/// Compute the inverse of a 3×3 matrix stored row-major.
+/// Returns `None` if the determinant is too small (degenerate triangle).
+fn inv3x3(m: &[f32; 9]) -> Option<[f32; 9]> {
+    // Cofactors
+    let c00 = m[4] * m[8] - m[5] * m[7];
+    let c01 = -(m[3] * m[8] - m[5] * m[6]);
+    let c02 = m[3] * m[7] - m[4] * m[6];
+    let c10 = -(m[1] * m[8] - m[2] * m[7]);
+    let c11 = m[0] * m[8] - m[2] * m[6];
+    let c12 = -(m[0] * m[7] - m[1] * m[6]);
+    let c20 = m[1] * m[5] - m[2] * m[4];
+    let c21 = -(m[0] * m[5] - m[2] * m[3]);
+    let c22 = m[0] * m[4] - m[1] * m[3];
+
+    let det = m[0] * c00 + m[1] * c01 + m[2] * c02;
+    if det.abs() < 1e-30 {
+        return None;
+    }
+    let inv_det = 1.0 / det;
+
+    // Transpose of cofactor matrix (adjugate) divided by det
+    Some([
+        c00 * inv_det, c10 * inv_det, c20 * inv_det,
+        c01 * inv_det, c11 * inv_det, c21 * inv_det,
+        c02 * inv_det, c12 * inv_det, c22 * inv_det,
+    ])
+}
+
+// ── findLsTriplets ───────────────────────────────────────────────────────────
+
+/// Triangulate loudspeaker positions on the unit sphere (Delaunay via convex
+/// hull).  Returns:
+/// - Cartesian unit vectors for each speaker `u_spkr[i] = [x, y, z]`
+/// - Triangle face indices `ls_groups[n] = [i0, i1, i2]`
+///
+/// Faces whose outward normal opposes the triangle centroid (concave wrap) are
+/// discarded.  If `omit_large_triangles` is true, faces with any edge subtending
+/// ≥ 180° are also discarded.
+pub fn find_ls_triplets(
+    ls_dirs_deg: &[[f32; 2]],
+    omit_large_triangles: bool,
+) -> Option<(Vec<[f32; 3]>, Vec<[usize; 3]>)> {
+    let _n = ls_dirs_deg.len();
+
+    // Convert speaker directions to Cartesian unit vectors
+    let u_spkr: Vec<[f32; 3]> = ls_dirs_deg
+        .iter()
+        .map(|&[az, el]| {
+            let az_r = az * std::f32::consts::PI / 180.0;
+            let el_r = el * std::f32::consts::PI / 180.0;
+            sph_to_cart(az_r, el_r)
+        })
+        .collect();
+
+    // Build convex hull (using f64 vertices as required by convhull_3d_build)
+    let verts_f64: Vec<[f64; 3]> = u_spkr
+        .iter()
+        .map(|&[x, y, z]| [x as f64, y as f64, z as f64])
+        .collect();
+
+    let faces = convhull_3d_build(&verts_f64)?;
+
+    // Filter: keep faces whose normal × centroid angle < π/2
+    // (i.e. outward normal pointing away from origin)
+    let mut valid: Vec<[usize; 3]> = faces
+        .into_iter()
+        .filter(|&[i0, i1, i2]| {
+            let v0 = u_spkr[i0];
+            let v1 = u_spkr[i1];
+            let v2 = u_spkr[i2];
+
+            let a = [v1[0]-v0[0], v1[1]-v0[1], v1[2]-v0[2]];
+            let b = [v2[0]-v1[0], v2[1]-v1[1], v2[2]-v1[2]];
+            let cvec = cross3(a, b);
+
+            let centroid = [
+                (v0[0] + v1[0] + v2[0]) / 3.0,
+                (v0[1] + v1[1] + v2[1]) / 3.0,
+                (v0[2] + v1[2] + v2[2]) / 3.0,
+            ];
+
+            let dotcc = dot3(cvec, centroid);
+            // acos(clamp(dotcc, -1, 1)) < π/2  ⟺  dotcc > 0
+            // (since acos is monotonically decreasing and acos(0) = π/2)
+            // We clamp to avoid NaN, matching the SAF code's SAF_MAX/SAF_MIN clamp.
+            let dotcc_clamped = dotcc.clamp(-0.99999999, 0.99999999);
+            dotcc_clamped.acos() < std::f32::consts::FRAC_PI_2
+        })
+        .collect();
+
+    // Optional: discard faces with any edge subtending ≥ APERTURE_LIMIT_DEG
+    if omit_large_triangles {
+        valid.retain(|&[i0, i1, i2]| {
+            let v0 = u_spkr[i0];
+            let v1 = u_spkr[i1];
+            let v2 = u_spkr[i2];
+
+            let a01 = dot3(v0, v1).clamp(-1.0, 1.0).acos();
+            let a12 = dot3(v1, v2).clamp(-1.0, 1.0).acos();
+            let a20 = dot3(v2, v0).clamp(-1.0, 1.0).acos();
+
+            a01 < APERTURE_LIMIT_RAD && a12 < APERTURE_LIMIT_RAD && a20 < APERTURE_LIMIT_RAD
+        });
+    }
+
+    if valid.is_empty() {
+        return None;
+    }
+
+    Some((u_spkr, valid))
+}
+
+// ── invertLsMtx3D ────────────────────────────────────────────────────────────
+
+/// Pre-compute per-triangle inverse speaker matrices for VBAP.
+///
+/// `u_spkr`: Cartesian unit vectors for each speaker (length = n_speakers).
+/// `ls_groups`: triangle face indices into `u_spkr`.
+///
+/// Returns one row-major 3×3 inverse matrix per triangle, flattened to `[f32; 9]`.
+/// Triangles whose matrix is degenerate are returned as all-zero (never matched
+/// in VBAP since min_val check will fail).
+pub fn invert_ls_mtx_3d(
+    u_spkr: &[[f32; 3]],
+    ls_groups: &[[usize; 3]],
+) -> Vec<[f32; 9]> {
+    ls_groups
+        .iter()
+        .map(|&[i0, i1, i2]| {
+            let s0 = u_spkr[i0];
+            let s1 = u_spkr[i1];
+            let s2 = u_spkr[i2];
+
+            // Build transposed group matrix (column vectors of speaker directions)
+            // tempGroup[j*3+i] = U_spkr[ls_groups[n*3+i]*3 + j]
+            let m: [f32; 9] = [
+                s0[0], s1[0], s2[0],
+                s0[1], s1[1], s2[1],
+                s0[2], s1[2], s2[2],
+            ];
+
+            inv3x3(&m).unwrap_or([0.0; 9])
+        })
+        .collect()
+}
+
+// ── getSpreadSrcDirs3D ────────────────────────────────────────────────────────
+
+/// Generate a ring of spread directions around a source (MDAP helper).
+///
+/// Returns `num_rings * num_src + 1` Cartesian unit vectors.
+/// The last entry is the original source direction (central source).
+pub fn get_spread_src_dirs_3d(
+    az_rad: f32,
+    el_rad: f32,
+    spread_deg: f32,
+    num_src: usize,
+    num_rings: usize,
+) -> Vec<[f32; 3]> {
+    let u = sph_to_cart(az_rad, el_rad);
+
+    // Rodrigues rotation matrix R_θ around axis u, θ = 2π/num_src
+    let theta = 2.0 * std::f32::consts::PI / num_src as f32;
+    let sin_t = theta.sin();
+    let cos_t = theta.cos();
+
+    // u⊗u (outer product)
+    let uxu = [
+        [u[0]*u[0], u[0]*u[1], u[0]*u[2]],
+        [u[0]*u[1], u[1]*u[1], u[1]*u[2]],
+        [u[0]*u[2], u[1]*u[2], u[2]*u[2]],
+    ];
+    // [u]× (cross-product matrix)
+    let ux = [
+        [ 0.0, -u[2],  u[1]],
+        [ u[2],  0.0, -u[0]],
+        [-u[1],  u[0],  0.0],
+    ];
+    // R_θ[i][j] = sin_t * ux[i][j] + (1 - cos_t) * uxu[i][j] + cos_t * δ_ij
+    let mut r = [[0.0f32; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            r[i][j] = sin_t * ux[i][j]
+                + (1.0 - cos_t) * uxu[i][j]
+                + if i == j { cos_t } else { 0.0 };
+        }
+    }
+
+    // First spread base vector: perpendicular to u
+    let first_base: [f32; 3] = if el_rad > std::f32::consts::FRAC_PI_2 - 0.01
+        || el_rad < -(std::f32::consts::FRAC_PI_2 - 0.01)
+    {
+        [1.0, 0.0, 0.0] // near pole: use X axis
+    } else {
+        let u2 = [0.0f32, 0.0, 1.0];
+        normalise3(cross3(u, u2))
+    };
+
+    // Build ring by repeated rotation
+    let mut spreadbase = vec![[0.0f32; 3]; num_src];
+    spreadbase[0] = first_base;
+    for ns in 1..num_src {
+        let prev = spreadbase[ns - 1];
+        spreadbase[ns] = [
+            r[0][0]*prev[0] + r[0][1]*prev[1] + r[0][2]*prev[2],
+            r[1][0]*prev[0] + r[1][1]*prev[1] + r[1][2]*prev[2],
+            r[2][0]*prev[0] + r[2][1]*prev[1] + r[2][2]*prev[2],
+        ];
+    }
+
+    // Squeeze ring to desired spread; build output
+    let spread_rad = (spread_deg / 2.0) * std::f32::consts::PI / 180.0;
+    let ring_rad = spread_rad / num_rings as f32;
+
+    let total = num_rings * num_src + 1;
+    let mut out = vec![[0.0f32; 3]; total];
+
+    // Normalisation factor from first vector of first ring
+    let tan_r = ring_rad.tan();
+    let raw0 = [
+        u[0] + spreadbase[0][0] * tan_r,
+        u[1] + spreadbase[0][1] * tan_r,
+        u[2] + spreadbase[0][2] * tan_r,
+    ];
+    let norm0 = (raw0[0]*raw0[0] + raw0[1]*raw0[1] + raw0[2]*raw0[2]).sqrt();
+    let norm0 = if norm0 < 1e-30 { 1.0 } else { norm0 };
+
+    for nr in 0..num_rings {
+        let tan_ring = ((nr as f32 + 1.0) * ring_rad).tan();
+        for ns in 0..num_src {
+            let sb = spreadbase[ns];
+            out[nr * num_src + ns] = [
+                (u[0] + sb[0] * tan_ring) / norm0,
+                (u[1] + sb[1] * tan_ring) / norm0,
+                (u[2] + sb[2] * tan_ring) / norm0,
+            ];
+        }
+    }
+
+    // Append central source direction
+    out[num_rings * num_src] = u;
+
+    out
+}
+
+// ── vbap3D ───────────────────────────────────────────────────────────────────
+
+/// Compute VBAP (or MDAP with spread) gains for a batch of source directions.
+///
+/// `src_dirs`: `[azimuth_deg, elevation_deg]` per source direction.
+/// `n_speakers`: total number of speakers (gains vector length).
+/// `ls_groups`: triangle indices into speakers.
+/// `spread_deg`: spread in degrees; 0 = pure VBAP, >0 = MDAP.
+/// `layout_inv_mtx`: per-triangle 3×3 inverse speaker matrices.
+///
+/// Returns a flat `[n_sources × n_speakers]` gain matrix.
+pub fn vbap3d(
+    src_dirs: &[[f32; 2]],
+    n_speakers: usize,
+    ls_groups: &[[usize; 3]],
+    spread_deg: f32,
+    layout_inv_mtx: &[[f32; 9]],
+) -> Vec<f32> {
+    let n_src = src_dirs.len();
+    let _n_faces = ls_groups.len();
+    let mut gain_mtx = vec![0.0f32; n_src * n_speakers];
+
+    if spread_deg > 0.1 {
+        // MDAP
+        const N_SPREAD_SRCS: usize = 8;
+        const N_RINGS: usize = 1;
+
+        for (ns, &[az_deg, el_deg]) in src_dirs.iter().enumerate() {
+            let az_rad = az_deg * std::f32::consts::PI / 180.0;
+            let el_rad = el_deg * std::f32::consts::PI / 180.0;
+
+            let u_spread = get_spread_src_dirs_3d(az_rad, el_rad, spread_deg, N_SPREAD_SRCS, N_RINGS);
+
+            let mut gains = vec![0.0f32; n_speakers];
+
+            for u_vec in &u_spread {
+                let u = *u_vec;
+
+                // Find matching triangle and accumulate gains
+                for (fi, face) in ls_groups.iter().enumerate() {
+                    let inv = &layout_inv_mtx[fi];
+
+                    let g0 = inv[0]*u[0] + inv[1]*u[1] + inv[2]*u[2];
+                    let g1 = inv[3]*u[0] + inv[4]*u[1] + inv[5]*u[2];
+                    let g2 = inv[6]*u[0] + inv[7]*u[1] + inv[8]*u[2];
+
+                    let min_val = g0.min(g1).min(g2);
+                    if min_val > -0.001 {
+                        let rms = (g0*g0 + g1*g1 + g2*g2).sqrt();
+                        if rms > 1e-30 {
+                            gains[face[0]] += g0 / rms;
+                            gains[face[1]] += g1 / rms;
+                            gains[face[2]] += g2 / rms;
+                        }
+                    }
+                }
+            }
+
+            // Energy-normalise and clamp to ≥ 0
+            let gains_rms = gains.iter().map(|&g| g * g).sum::<f32>().sqrt();
+            let out = &mut gain_mtx[ns * n_speakers..(ns + 1) * n_speakers];
+            if gains_rms > 1e-30 {
+                for (o, &g) in out.iter_mut().zip(gains.iter()) {
+                    *o = (g / gains_rms).max(0.0);
+                }
+            }
+        }
+    } else {
+        // Pure VBAP
+        for (ns, &[az_deg, el_deg]) in src_dirs.iter().enumerate() {
+            let az_rad = az_deg * std::f32::consts::PI / 180.0;
+            let el_rad = el_deg * std::f32::consts::PI / 180.0;
+            let u = sph_to_cart(az_rad, el_rad);
+
+            let mut gains = vec![0.0f32; n_speakers];
+
+            'faces: for (fi, face) in ls_groups.iter().enumerate() {
+                let inv = &layout_inv_mtx[fi];
+
+                let g0 = inv[0]*u[0] + inv[1]*u[1] + inv[2]*u[2];
+                let g1 = inv[3]*u[0] + inv[4]*u[1] + inv[5]*u[2];
+                let g2 = inv[6]*u[0] + inv[7]*u[1] + inv[8]*u[2];
+
+                let min_val = g0.min(g1).min(g2);
+                if min_val > -0.001 {
+                    let rms = (g0*g0 + g1*g1 + g2*g2).sqrt();
+                    if rms > 1e-30 {
+                        gains[face[0]] = g0 / rms;
+                        gains[face[1]] = g1 / rms;
+                        gains[face[2]] = g2 / rms;
+                    }
+                    break 'faces;
+                }
+            }
+
+            // Energy-normalise
+            let gains_rms = gains.iter().map(|&g| g * g).sum::<f32>().sqrt();
+            let out = &mut gain_mtx[ns * n_speakers..(ns + 1) * n_speakers];
+            if gains_rms > 1e-30 {
+                for (o, &g) in out.iter_mut().zip(gains.iter()) {
+                    *o = (g / gains_rms).max(0.0);
+                }
+            }
+        }
+    }
+
+    gain_mtx
+}
+
+// ── generateVBAPgainTable3D ──────────────────────────────────────────────────
+
+/// Build a complete VBAP gain table over an azimuth × elevation grid.
+///
+/// Returns `(gtable, n_gtable, n_triangles)` where:
+/// - `gtable[dir_idx * n_speakers + spk_idx]` is the gain for that direction/speaker pair
+/// - `n_gtable = N_azi × N_el`
+/// - `n_triangles` is the number of valid Delaunay triangles found
+///
+/// `ls_dirs_deg`: speaker directions `[az, el]` in degrees.
+/// `az_res_deg` / `el_res_deg`: grid resolution.
+/// `omit_large_triangles`: filter faces with edge ≥ 180°.
+/// `enable_dummies`: add virtual ±90° elevation speakers if none exist near poles.
+/// `spread`: spread in degrees (0 = pure VBAP, >0 = MDAP).
+pub fn generate_vbap_gain_table_3d(
+    ls_dirs_deg: &[[f32; 2]],
+    az_res_deg: i32,
+    el_res_deg: i32,
+    omit_large_triangles: bool,
+    enable_dummies: bool,
+    spread: f32,
+) -> Option<(Vec<f32>, usize, usize)> {
+    let n_az = ((360.0 / az_res_deg as f32) + 1.5) as usize;
+    let n_el = ((180.0 / el_res_deg as f32) + 1.5) as usize;
+
+    // Build source direction grid [-180:az_res:180] × [-90:el_res:90]
+    let mut src_dirs: Vec<[f32; 2]> = Vec::with_capacity(n_az * n_el);
+    for el_i in 0..n_el {
+        let el = -90.0 + el_i as f32 * el_res_deg as f32;
+        for az_i in 0..n_az {
+            let az = -180.0 + az_i as f32 * az_res_deg as f32;
+            src_dirs.push([az, el]);
+        }
+    }
+
+    // Optionally add dummy speakers at ±90° elevation
+    let effective_dirs: Vec<[f32; 2]>;
+    let n_real = ls_dirs_deg.len();
+
+    if enable_dummies {
+        let need_dummy_neg = ls_dirs_deg.iter().all(|d| d[1] > -ADD_DUMMY_LIMIT);
+        let need_dummy_pos = ls_dirs_deg.iter().all(|d| d[1] < ADD_DUMMY_LIMIT);
+
+        if need_dummy_neg || need_dummy_pos {
+            let mut dirs = ls_dirs_deg.to_vec();
+            if need_dummy_neg { dirs.push([0.0, -90.0]); }
+            if need_dummy_pos { dirs.push([0.0,  90.0]); }
+            effective_dirs = dirs;
+        } else {
+            effective_dirs = ls_dirs_deg.to_vec();
+        }
+    } else {
+        effective_dirs = ls_dirs_deg.to_vec();
+    }
+
+    let (u_spkr, ls_groups) = find_ls_triplets(&effective_dirs, omit_large_triangles)?;
+    let layout_inv_mtx = invert_ls_mtx_3d(&u_spkr, &ls_groups);
+
+    let n_eff = effective_dirs.len();
+    let n_triangles = ls_groups.len();
+    let n_points = n_az * n_el;
+
+    // Compute gains for all grid directions (using effective speaker count)
+    let mut gtable = vbap3d(&src_dirs, n_eff, &ls_groups, spread, &layout_inv_mtx);
+
+    // Strip dummy speaker columns — shrink each row from n_eff to n_real
+    if n_eff > n_real {
+        let mut trimmed = vec![0.0f32; n_points * n_real];
+        for i in 0..n_points {
+            trimmed[i * n_real..(i + 1) * n_real]
+                .copy_from_slice(&gtable[i * n_eff..i * n_eff + n_real]);
+        }
+        gtable = trimmed;
+    }
+
+    Some((gtable, n_points, n_triangles))
+}

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -107,8 +107,6 @@ pub enum Commands {
     InputLive(InputLiveArgs),
 
     /// Generate VBAP gain table from speaker layout configuration
-    /// (Requires "saf_vbap" feature)
-    #[cfg(feature = "saf_vbap")]
     GenerateVbap(GenerateVbapArgs),
 
     /// List available ASIO output devices (Windows only)
@@ -554,7 +552,6 @@ pub struct InputLiveArgs {
     pub osc_rx_port: u16,
 }
 
-#[cfg(feature = "saf_vbap")]
 #[derive(Debug, Clone, Args)]
 pub struct GenerateVbapArgs {
     /// Speaker layout configuration file (YAML)

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -238,7 +238,6 @@ fn resolve_layout(
     }
 }
 
-#[cfg(feature = "saf_vbap")]
 fn resolve_evaluation_table_mode(
     args: &RenderArgs,
     vbap_cartesian_defaults: bridge_api::RVbapCartesianDefaults,
@@ -293,13 +292,6 @@ fn init_spatial_renderer(
     preferred_evaluation_mode: bridge_api::RVbapTableMode,
     evaluation_mode_explicit: bool,
 ) -> Result<()> {
-    #[cfg(not(feature = "saf_vbap"))]
-    let _ = (
-        preferred_evaluation_mode,
-        evaluation_mode_explicit,
-        vbap_cartesian_defaults,
-    );
-
     if !args.enable_vbap {
         return Ok(());
     }
@@ -314,17 +306,8 @@ fn init_spatial_renderer(
     let (room_ratio, room_ratio_rear, room_ratio_lower, room_ratio_center_blend) =
         parse_room_ratio(args)?;
 
-    #[cfg(feature = "saf_vbap")]
     let (vbap_table_mode, vbap_allow_negative_z) =
         resolve_evaluation_table_mode(args, vbap_cartesian_defaults)?;
-    #[cfg(not(feature = "saf_vbap"))]
-    let vbap_allow_negative_z = if args.vbap_allow_negative_z {
-        true
-    } else if args.no_vbap_allow_negative_z {
-        false
-    } else {
-        false
-    };
 
     log::info!("VBAP allow_negative_z: {}", vbap_allow_negative_z);
 
@@ -421,95 +404,83 @@ fn init_spatial_renderer(
             }
         }
     } else {
-        #[cfg(feature = "saf_vbap")]
-        {
-            let layout = resolve_layout(args, current_layout_from_config)?;
-            log::info!(
-                "Speaker layout: {} speakers ({})",
-                layout.num_speakers(),
-                layout.speaker_names().join(", ")
-            );
-            log::info!("Generating VBAP table at runtime (this may take a few seconds)...");
-            let start_time = std::time::Instant::now();
-            let azimuth_cells = args.evaluation_polar_azimuth_resolution.max(1);
-            let elevation_cells = args.evaluation_polar_elevation_resolution.max(1);
-            let distance_cells = args.evaluation_polar_distance_res.max(1);
-            let azimuth_step_deg = (360.0f32 / (azimuth_cells as f32)).max(1.0).round() as i32;
-            let elevation_step_deg = (((if vbap_allow_negative_z { 180.0 } else { 90.0 })
-                / (elevation_cells as f32))
-                .max(1.0)
-                .round()) as i32;
-            let distance_step =
-                args.evaluation_polar_distance_max.max(0.01) / (distance_cells as f32);
+        let layout = resolve_layout(args, current_layout_from_config)?;
+        log::info!(
+            "Speaker layout: {} speakers ({})",
+            layout.num_speakers(),
+            layout.speaker_names().join(", ")
+        );
+        log::info!("Generating VBAP table at runtime (this may take a few seconds)...");
+        let start_time = std::time::Instant::now();
+        let azimuth_cells = args.evaluation_polar_azimuth_resolution.max(1);
+        let elevation_cells = args.evaluation_polar_elevation_resolution.max(1);
+        let distance_cells = args.evaluation_polar_distance_res.max(1);
+        let azimuth_step_deg = (360.0f32 / (azimuth_cells as f32)).max(1.0).round() as i32;
+        let elevation_step_deg = (((if vbap_allow_negative_z { 180.0 } else { 90.0 })
+            / (elevation_cells as f32))
+            .max(1.0)
+            .round()) as i32;
+        let distance_step =
+            args.evaluation_polar_distance_max.max(0.01) / (distance_cells as f32);
 
-            let renderer = SpatialRenderer::new(
-                layout,
-                48000,
-                azimuth_step_deg,
-                elevation_step_deg,
-                distance_step,
-                args.evaluation_polar_distance_max,
-                vbap_table_mode,
-                vbap_allow_negative_z,
-                args.render_evaluation_position_interpolation,
-                distance_model,
-                args.spread_from_distance,
-                args.spread_distance_range,
-                args.spread_distance_curve,
-                args.vbap_spread_min,
-                args.vbap_spread_max,
-                args.log_object_positions,
-                room_ratio,
-                room_ratio_rear,
-                room_ratio_lower,
-                room_ratio_center_blend,
-                args.master_gain,
-                args.auto_gain,
-                args.use_loudness,
-                args.distance_diffuse,
-                args.distance_diffuse_threshold,
-                args.distance_diffuse_curve,
-                match preferred_evaluation_mode {
-                    bridge_api::RVbapTableMode::Polar => {
-                        renderer::live_params::PreferredEvaluationMode::PrecomputedPolar
+        let renderer = SpatialRenderer::new(
+            layout,
+            48000,
+            azimuth_step_deg,
+            elevation_step_deg,
+            distance_step,
+            args.evaluation_polar_distance_max,
+            vbap_table_mode,
+            vbap_allow_negative_z,
+            args.render_evaluation_position_interpolation,
+            distance_model,
+            args.spread_from_distance,
+            args.spread_distance_range,
+            args.spread_distance_curve,
+            args.vbap_spread_min,
+            args.vbap_spread_max,
+            args.log_object_positions,
+            room_ratio,
+            room_ratio_rear,
+            room_ratio_lower,
+            room_ratio_center_blend,
+            args.master_gain,
+            args.auto_gain,
+            args.use_loudness,
+            args.distance_diffuse,
+            args.distance_diffuse_threshold,
+            args.distance_diffuse_curve,
+            match preferred_evaluation_mode {
+                bridge_api::RVbapTableMode::Polar => {
+                    renderer::live_params::PreferredEvaluationMode::PrecomputedPolar
+                }
+                bridge_api::RVbapTableMode::Cartesian => {
+                    renderer::live_params::PreferredEvaluationMode::PrecomputedCartesian
+                }
+            },
+            if evaluation_mode_explicit {
+                match args.render_evaluation_mode {
+                    EvaluationModeArg::Polar => {
+                        renderer::live_params::LiveEvaluationMode::PrecomputedPolar
                     }
-                    bridge_api::RVbapTableMode::Cartesian => {
-                        renderer::live_params::PreferredEvaluationMode::PrecomputedCartesian
+                    EvaluationModeArg::Cartesian => {
+                        renderer::live_params::LiveEvaluationMode::PrecomputedCartesian
                     }
-                },
-                if evaluation_mode_explicit {
-                    match args.render_evaluation_mode {
-                        EvaluationModeArg::Polar => {
-                            renderer::live_params::LiveEvaluationMode::PrecomputedPolar
-                        }
-                        EvaluationModeArg::Cartesian => {
-                            renderer::live_params::LiveEvaluationMode::PrecomputedCartesian
-                        }
-                    }
-                } else {
-                    renderer::live_params::LiveEvaluationMode::Auto
-                },
-                args.evaluation_cartesian_x_size
-                    .unwrap_or(vbap_cartesian_defaults.x_size as usize),
-                args.evaluation_cartesian_y_size
-                    .unwrap_or(vbap_cartesian_defaults.y_size as usize),
-                args.evaluation_cartesian_z_size
-                    .unwrap_or(vbap_cartesian_defaults.z_size as usize),
-                args.evaluation_cartesian_z_neg_size.unwrap_or(0),
-            )?;
-            let elapsed = start_time.elapsed();
-            log::info!("VBAP table generated in {:.2}s", elapsed.as_secs_f64());
-            renderer
-        }
-        #[cfg(not(feature = "saf_vbap"))]
-        {
-            anyhow::bail!(
-                "VBAP table generation not available (built without 'saf_vbap' feature).\n\
-                 Please provide a pre-generated VBAP table using --vbap-table <file>.\n\
-                 Generate tables on a system with SAF VBAP support using:\n  \
-                 orender generate-vbap --speaker-layout <layout.yaml> --output <table.vbap>"
-            );
-        }
+                }
+            } else {
+                renderer::live_params::LiveEvaluationMode::Auto
+            },
+            args.evaluation_cartesian_x_size
+                .unwrap_or(vbap_cartesian_defaults.x_size as usize),
+            args.evaluation_cartesian_y_size
+                .unwrap_or(vbap_cartesian_defaults.y_size as usize),
+            args.evaluation_cartesian_z_size
+                .unwrap_or(vbap_cartesian_defaults.z_size as usize),
+            args.evaluation_cartesian_z_neg_size.unwrap_or(0),
+        )?;
+        let elapsed = start_time.elapsed();
+        log::info!("VBAP table generated in {:.2}s", elapsed.as_secs_f64());
+        renderer
     };
 
     log::info!("VBAP spatial rendering enabled");
@@ -741,9 +712,6 @@ pub fn init_render_handler(
     preferred_evaluation_mode: bridge_api::RVbapTableMode,
     evaluation_mode_explicit: bool,
 ) -> Result<()> {
-    #[cfg(not(feature = "saf_vbap"))]
-    let _ = (preferred_evaluation_mode, evaluation_mode_explicit);
-
     let render_cfg = render_config_from_path(config_path);
 
     #[cfg(target_os = "linux")]

--- a/omniphony-renderer/src/cli/mod.rs
+++ b/omniphony-renderer/src/cli/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) mod command;
 pub(crate) mod decode;
-#[cfg(feature = "saf_vbap")]
 pub(crate) mod generate_vbap;
 #[cfg(target_os = "windows")]
 pub(crate) mod list_asio_devices;

--- a/omniphony-renderer/src/main.rs
+++ b/omniphony-renderer/src/main.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use cli::command::{Commands, LogFormat, LogLevel, ParsedCli};
 use cli::decode::cmd_render;
-#[cfg(feature = "saf_vbap")]
 use cli::generate_vbap::cmd_generate_vbap;
 #[cfg(target_os = "windows")]
 use cli::list_asio_devices::cmd_list_asio_devices;
@@ -29,7 +28,6 @@ where
     let known_subcommands = [
         OsString::from("render"),
         OsString::from("input-live"),
-        #[cfg(feature = "saf_vbap")]
         OsString::from("generate-vbap"),
         #[cfg(target_os = "windows")]
         OsString::from("list-asio-devices"),
@@ -173,7 +171,6 @@ fn main() -> Result<()> {
         Commands::InputLive(_) => {
             anyhow::bail!("The 'input-live' command is defined but not implemented yet.")
         }
-        #[cfg(feature = "saf_vbap")]
         Commands::GenerateVbap(ref args) => cmd_generate_vbap(args),
         #[cfg(target_os = "windows")]
         Commands::ListAsioDevices => cmd_list_asio_devices(),

--- a/omniphony-renderer/src/runtime_osc/recompute.rs
+++ b/omniphony-renderer/src/runtime_osc/recompute.rs
@@ -11,17 +11,7 @@ pub(crate) fn trigger_layout_recompute(
     socket: &Arc<std::net::UdpSocket>,
     clients: &Arc<OscClientRegistry>,
 ) {
-    #[cfg(not(feature = "saf_vbap"))]
-    {
-        let _ = control;
-        log::warn!("OSC apply: VBAP recompute requires a build with the 'saf_vbap' feature");
-        broadcast_int(socket, clients, "/omniphony/state/speakers/recomputing", 0);
-        return;
-    }
-
-    #[cfg(feature = "saf_vbap")]
-    {
-        if control.prepare_topology_rebuild().is_none() {
+    if control.prepare_topology_rebuild().is_none() {
             log::warn!(
                 "OSC apply: speaker positions cannot be updated — requested backend rebuild could not be prepared"
             );
@@ -151,5 +141,4 @@ pub(crate) fn trigger_layout_recompute(
                 }
             })
             .expect("failed to spawn vbap-recompute thread");
-    }
 }


### PR DESCRIPTION
## Summary

- **Port SAF `saf_vbap.c` (ISC) and `convhull_3d.c` (MIT) to pure Rust**, eliminating the mandatory SAF/SPARTA static library for VBAP
- Add three new files: `convhull.rs` (Quickhull 3D), `vbap_native.rs` (findLsTriplets, invertLsMtx3D, vbap3D, generateVBAPgainTable3D), `panner/native_backend.rs` (NativeVbapLayout)
- Remove all `#[cfg(feature="saf_vbap")]` gates from the main rendering pipeline (`SpatialRenderer::new`, `prepare_topology_rebuild`, `VbapTopologyBuildPlan::build_gain_model`, CLI `generate-vbap`, bootstrap, recompute)
- The `saf_vbap` Cargo feature is **preserved**: enabled by default (existing C FFI path), disabled for a zero-dependency Rust-only build (`cargo build --no-default-features`)
- `scripts/build_gsrd.sh` updated with `--no-saf` flag; `run_spatial_stack.sh` updated with `--no-saf` to skip SAF library check

## License compliance

| Source | License | GPLv3 compat |
|--------|---------|-------------|
| `saf_vbap.c` | ISC (Leo McCormack 2017-2018) | ✅ |
| `convhull_3d.c` | MIT (Leo McCormack 2017-2018) | ✅ |
| VBAP algorithm origin | BSD-3 (Archontis Politis 2015) | ✅ |

Copyright notices are preserved in the ported Rust files.

## Test plan

- [x] `cargo check --package renderer` → 0 errors, 0 warnings (with `saf_vbap`)
- [x] `cargo check --package renderer --no-default-features` → 0 errors, 0 warnings (native)
- [x] `cargo build --release --no-default-features` → builds `orender` binary without SAF
- [x] `cargo build --release` (with SAF) → unchanged behaviour
- [x] All 18 renderer unit tests pass in both configurations
- [ ] Numerical regression: native VBAP gains vs SAF within ±1e-4 (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)