### PR TITLE
config: single-source option descriptors (config_fields) + 3 bug fixes

### DIFF
--- a/omniphony-renderer/host_audio/src/lib.rs
+++ b/omniphony-renderer/host_audio/src/lib.rs
@@ -905,7 +905,10 @@ impl HostControlHandler for HostAudio {
         let requested = audio.requested_snapshot();
         render.output_device = requested.output_device;
         render.output_sample_rate = requested.output_sample_rate_hz;
-        render.enable_adaptive_resampling = Some(requested.adaptive_enabled);
+        renderer::config_fields::enable_adaptive_resampling::store(
+            render,
+            requested.adaptive_enabled,
+        );
         render.adaptive_resampling_enable_far_mode = Some(requested.adaptive.enable_far_mode);
         render.adaptive_resampling_force_silence_in_far_mode =
             Some(requested.adaptive.force_silence_in_far_mode);

--- a/omniphony-renderer/orender_engine/src/bridge_loader.rs
+++ b/omniphony-renderer/orender_engine/src/bridge_loader.rs
@@ -300,7 +300,11 @@ mod tests {
     // file next to the test binary and request it by bare relative name.
     #[test]
     fn relative_resolves_next_to_exe() {
-        let dir = std::env::current_exe().unwrap().parent().unwrap().to_path_buf();
+        let dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
         let name = format!("orender_{}_reltest_bridge.so", std::process::id());
         let full = dir.join(&name);
         fs::write(&full, b"x").unwrap();

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -336,6 +336,13 @@ impl OscSender {
         self.clients.is_any_metering_live()
     }
 
+    /// Pre-enable (or disable) metering on the permanent default target so that
+    /// `--osc-metering` / `render.osc_metering` makes meter bundles flow to the
+    /// configured OSC host without requiring a runtime enable message.
+    pub fn set_default_metering(&self, enabled: bool) {
+        self.clients.set_metering_for_permanent(enabled);
+    }
+
     pub fn has_diag_clients(&self) -> bool {
         self.clients.is_any_diag_live()
     }

--- a/omniphony-renderer/orender_engine/src/osc/client_registry.rs
+++ b/omniphony-renderer/orender_engine/src/osc/client_registry.rs
@@ -66,6 +66,19 @@ impl OscClientRegistry {
         }
     }
 
+    /// Enable/disable metering on all *permanent* clients (those registered via
+    /// [`insert_permanent`], i.e. the config-defined default OSC target). Lets
+    /// `--osc-metering` / `render.osc_metering` pre-subscribe the default target
+    /// to meter bundles without it having to send a runtime enable message.
+    pub(crate) fn set_metering_for_permanent(&self, enabled: bool) {
+        let mut clients = self.clients.lock().unwrap();
+        for client in clients.values_mut() {
+            if client.last_seen.is_none() {
+                client.metering_enabled = enabled;
+            }
+        }
+    }
+
     pub(crate) fn set_metering(&self, addr: SocketAddr, enabled: bool) -> bool {
         let mut clients = self.clients.lock().unwrap();
         if let Some(entry) = clients.get_mut(&addr) {
@@ -121,6 +134,15 @@ impl OscClientRegistry {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn metering_for(&self, addr: SocketAddr) -> Option<bool> {
+        self.clients
+            .lock()
+            .unwrap()
+            .get(&addr)
+            .map(|c| c.metering_enabled)
+    }
+
     pub(crate) fn send_filtered<F>(&self, socket: &std::net::UdpSocket, bytes: &[u8], predicate: F)
     where
         F: Fn(&OscClientState) -> bool,
@@ -145,5 +167,29 @@ impl OscClientRegistry {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permanent_metering_toggle_drives_metering_live() {
+        let reg = OscClientRegistry::new(Duration::from_secs(5));
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        reg.insert_permanent(addr);
+
+        // Default target starts opted-out → no metering clients.
+        assert_eq!(reg.metering_for(addr), Some(false));
+        assert!(!reg.is_any_metering_live());
+
+        // `--osc-metering` pre-enables it → metering now flows to the target.
+        reg.set_metering_for_permanent(true);
+        assert_eq!(reg.metering_for(addr), Some(true));
+        assert!(reg.is_any_metering_live());
+
+        reg.set_metering_for_permanent(false);
+        assert!(!reg.is_any_metering_live());
     }
 }

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -149,9 +149,15 @@ impl SpatialRendererParams {
             room_ratio_rear: cfg.and_then(|c| c.room_ratio_rear),
             room_ratio_lower: cfg.and_then(|c| c.room_ratio_lower),
             room_ratio_center_blend: cfg.and_then(|c| c.room_ratio_center_blend),
-            master_gain: cfg.and_then(|c| c.master_gain).unwrap_or(0.0),
-            auto_gain: cfg.and_then(|c| c.auto_gain).unwrap_or(false),
-            use_loudness: cfg.and_then(|c| c.use_loudness).unwrap_or(false),
+            master_gain: cfg
+                .and_then(renderer::config_fields::master_gain::get)
+                .unwrap_or(renderer::config_fields::master_gain::DEFAULT),
+            auto_gain: cfg
+                .and_then(renderer::config_fields::auto_gain::get)
+                .unwrap_or(renderer::config_fields::auto_gain::DEFAULT),
+            use_loudness: cfg
+                .and_then(renderer::config_fields::use_loudness::get)
+                .unwrap_or(renderer::config_fields::use_loudness::DEFAULT),
             distance_diffuse: cfg
                 .and_then(renderer::config_fields::distance_diffuse::get)
                 .unwrap_or(renderer::config_fields::distance_diffuse::DEFAULT),

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -129,7 +129,9 @@ impl SpatialRendererParams {
                 .unwrap_or_else(|| {
                     renderer::config_fields::vbap_distance_model::DEFAULT.to_string()
                 }),
-            spread_from_distance: cfg.and_then(|c| c.spread_from_distance).unwrap_or(false),
+            spread_from_distance: cfg
+                .and_then(renderer::config_fields::spread_from_distance::get)
+                .unwrap_or(renderer::config_fields::spread_from_distance::DEFAULT),
             spread_distance_range: cfg
                 .and_then(renderer::config_fields::spread_distance_range::get)
                 .unwrap_or(renderer::config_fields::spread_distance_range::DEFAULT),

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -97,15 +97,17 @@ impl SpatialRendererParams {
         Self {
             vbap_table: None,
             evaluation_polar_azimuth_resolution: cfg
-                .and_then(|c| c.vbap_azimuth_resolution)
-                .unwrap_or(360),
+                .and_then(renderer::config_fields::vbap_azimuth_resolution::get)
+                .unwrap_or(renderer::config_fields::vbap_azimuth_resolution::DEFAULT),
             evaluation_polar_elevation_resolution: cfg
-                .and_then(|c| c.vbap_elevation_resolution)
-                .unwrap_or(180),
+                .and_then(renderer::config_fields::vbap_elevation_resolution::get)
+                .unwrap_or(renderer::config_fields::vbap_elevation_resolution::DEFAULT),
             evaluation_polar_distance_res: cfg
                 .and_then(renderer::config_fields::vbap_distance_res::get)
                 .unwrap_or(renderer::config_fields::vbap_distance_res::DEFAULT),
-            evaluation_polar_distance_max: cfg.and_then(|c| c.vbap_distance_max).unwrap_or(2.0),
+            evaluation_polar_distance_max: cfg
+                .and_then(renderer::config_fields::vbap_distance_max::get)
+                .unwrap_or(renderer::config_fields::vbap_distance_max::DEFAULT),
             render_evaluation_mode,
             evaluation_mode_explicit: false,
             evaluation_cartesian_x_size: cfg.and_then(|c| c.evaluation_cartesian_x_size),
@@ -118,16 +120,22 @@ impl SpatialRendererParams {
                 Some(false)
             ),
             render_evaluation_position_interpolation: cfg
-                .and_then(|c| c.render_evaluation_position_interpolation)
-                .unwrap_or(true),
+                .and_then(renderer::config_fields::render_evaluation_position_interpolation::get)
+                .unwrap_or(
+                    renderer::config_fields::render_evaluation_position_interpolation::DEFAULT,
+                ),
             vbap_distance_model: cfg
                 .and_then(|c| c.vbap_distance_model.clone())
                 .unwrap_or_else(|| "none".to_string()),
             spread_from_distance: cfg.and_then(|c| c.spread_from_distance).unwrap_or(false),
             spread_distance_range: cfg.and_then(|c| c.spread_distance_range).unwrap_or(1.0),
             spread_distance_curve: cfg.and_then(|c| c.spread_distance_curve).unwrap_or(1.0),
-            vbap_spread_min: cfg.and_then(|c| c.vbap_spread_min).unwrap_or(0.0),
-            vbap_spread_max: cfg.and_then(|c| c.vbap_spread_max).unwrap_or(1.0),
+            vbap_spread_min: cfg
+                .and_then(renderer::config_fields::vbap_spread_min::get)
+                .unwrap_or(renderer::config_fields::vbap_spread_min::DEFAULT),
+            vbap_spread_max: cfg
+                .and_then(renderer::config_fields::vbap_spread_max::get)
+                .unwrap_or(renderer::config_fields::vbap_spread_max::DEFAULT),
             log_object_positions: false,
             room_ratio: cfg
                 .and_then(|c| c.room_ratio.clone())

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -102,7 +102,9 @@ impl SpatialRendererParams {
             evaluation_polar_elevation_resolution: cfg
                 .and_then(|c| c.vbap_elevation_resolution)
                 .unwrap_or(180),
-            evaluation_polar_distance_res: cfg.and_then(|c| c.vbap_distance_res).unwrap_or(8),
+            evaluation_polar_distance_res: cfg
+                .and_then(renderer::config_fields::vbap_distance_res::get)
+                .unwrap_or(renderer::config_fields::vbap_distance_res::DEFAULT),
             evaluation_polar_distance_max: cfg.and_then(|c| c.vbap_distance_max).unwrap_or(2.0),
             render_evaluation_mode,
             evaluation_mode_explicit: false,

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -125,11 +125,17 @@ impl SpatialRendererParams {
                     renderer::config_fields::render_evaluation_position_interpolation::DEFAULT,
                 ),
             vbap_distance_model: cfg
-                .and_then(|c| c.vbap_distance_model.clone())
-                .unwrap_or_else(|| "none".to_string()),
+                .and_then(renderer::config_fields::vbap_distance_model::get)
+                .unwrap_or_else(|| {
+                    renderer::config_fields::vbap_distance_model::DEFAULT.to_string()
+                }),
             spread_from_distance: cfg.and_then(|c| c.spread_from_distance).unwrap_or(false),
-            spread_distance_range: cfg.and_then(|c| c.spread_distance_range).unwrap_or(1.0),
-            spread_distance_curve: cfg.and_then(|c| c.spread_distance_curve).unwrap_or(1.0),
+            spread_distance_range: cfg
+                .and_then(renderer::config_fields::spread_distance_range::get)
+                .unwrap_or(renderer::config_fields::spread_distance_range::DEFAULT),
+            spread_distance_curve: cfg
+                .and_then(renderer::config_fields::spread_distance_curve::get)
+                .unwrap_or(renderer::config_fields::spread_distance_curve::DEFAULT),
             vbap_spread_min: cfg
                 .and_then(renderer::config_fields::vbap_spread_min::get)
                 .unwrap_or(renderer::config_fields::vbap_spread_min::DEFAULT),
@@ -146,11 +152,15 @@ impl SpatialRendererParams {
             master_gain: cfg.and_then(|c| c.master_gain).unwrap_or(0.0),
             auto_gain: cfg.and_then(|c| c.auto_gain).unwrap_or(false),
             use_loudness: cfg.and_then(|c| c.use_loudness).unwrap_or(false),
-            distance_diffuse: cfg.and_then(|c| c.distance_diffuse).unwrap_or(false),
+            distance_diffuse: cfg
+                .and_then(renderer::config_fields::distance_diffuse::get)
+                .unwrap_or(renderer::config_fields::distance_diffuse::DEFAULT),
             distance_diffuse_threshold: cfg
-                .and_then(|c| c.distance_diffuse_threshold)
-                .unwrap_or(1.0),
-            distance_diffuse_curve: cfg.and_then(|c| c.distance_diffuse_curve).unwrap_or(1.0),
+                .and_then(renderer::config_fields::distance_diffuse_threshold::get)
+                .unwrap_or(renderer::config_fields::distance_diffuse_threshold::DEFAULT),
+            distance_diffuse_curve: cfg
+                .and_then(renderer::config_fields::distance_diffuse_curve::get)
+                .unwrap_or(renderer::config_fields::distance_diffuse_curve::DEFAULT),
         }
     }
 }

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -61,6 +61,42 @@ macro_rules! render_field {
     };
 }
 
+/// Declare a `String`-typed config option. Same `{ DEFAULT, get, store }`
+/// shape as [`render_field!`], but `DEFAULT` is a `&'static str` (String is
+/// not const-constructible) and `store` accepts any `AsRef<str>` so call sites
+/// can pass a `&str` or an owned `String`.
+macro_rules! render_field_str {
+    (
+        $(#[$meta:meta])*
+        $vis:vis $name:ident = $default:expr,
+        field = $field:ident
+    ) => {
+        $(#[$meta])*
+        $vis mod $name {
+            use super::RenderConfig;
+
+            /// Canonical default — the single copy of this field's default.
+            pub const DEFAULT: &str = $default;
+
+            /// Read the configured value, if present.
+            pub fn get(cfg: &RenderConfig) -> Option<String> {
+                cfg.$field.clone()
+            }
+
+            /// Store `value`, writing `Some` only when it differs from
+            /// [`DEFAULT`] (skip-if-default), `None` otherwise.
+            pub fn store(cfg: &mut RenderConfig, value: impl AsRef<str>) {
+                let value = value.as_ref();
+                cfg.$field = if value == DEFAULT {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
+        }
+    };
+}
+
 render_field! {
     /// Number of distance cells across the polar VBAP precompute table
     /// (`render.vbap_distance_res`). Pilot field for the descriptor scheme.
@@ -119,6 +155,54 @@ render_field! {
     pub render_evaluation_position_interpolation: bool = true,
     field = render_evaluation_position_interpolation,
     eq = bool::eq
+}
+
+// ── Lot 2: distance / spread ──
+
+render_field! {
+    /// Distance at which distance-based spread reaches 0.0
+    /// (`render.spread_distance_range`). The CLI writer used exact `!= 1.0`,
+    /// the live writer a 1e-4 tolerance; unified on 1e-4.
+    pub spread_distance_range: f32 = 1.0,
+    field = spread_distance_range,
+    eq = |a: &f32, b: &f32| (a - b).abs() < 1e-4
+}
+
+render_field! {
+    /// Curve exponent for distance-based spread (`render.spread_distance_curve`).
+    pub spread_distance_curve: f32 = 1.0,
+    field = spread_distance_curve,
+    eq = |a: &f32, b: &f32| (a - b).abs() < 1e-4
+}
+
+render_field! {
+    /// Enable distance-based antipodal diffuse blending (`render.distance_diffuse`).
+    pub distance_diffuse: bool = false,
+    field = distance_diffuse,
+    eq = bool::eq
+}
+
+render_field! {
+    /// ADM distance at which the distance-diffuse blend reaches 100% direct
+    /// (`render.distance_diffuse_threshold`).
+    pub distance_diffuse_threshold: f32 = 1.0,
+    field = distance_diffuse_threshold,
+    eq = |a: &f32, b: &f32| (a - b).abs() < 1e-4
+}
+
+render_field! {
+    /// Curve exponent for the distance-diffuse blend weight
+    /// (`render.distance_diffuse_curve`).
+    pub distance_diffuse_curve: f32 = 1.0,
+    field = distance_diffuse_curve,
+    eq = |a: &f32, b: &f32| (a - b).abs() < 1e-4
+}
+
+render_field_str! {
+    /// Distance attenuation model id (`render.vbap_distance_model`), e.g.
+    /// "none", "linear", "quadratic", "inverse-square".
+    pub vbap_distance_model = "none",
+    field = vbap_distance_model
 }
 
 #[cfg(test)]
@@ -184,5 +268,18 @@ mod tests {
         // Disabling it IS persisted (the previous CLI writer dropped this).
         super::render_evaluation_position_interpolation::store(&mut cfg, false);
         assert_eq!(cfg.render_evaluation_position_interpolation, Some(false));
+    }
+
+    #[test]
+    fn string_field_skips_default_and_accepts_str_or_string() {
+        let mut cfg = RenderConfig::default();
+        super::vbap_distance_model::store(&mut cfg, "none"); // &str, == default
+        assert_eq!(cfg.vbap_distance_model, None);
+        super::vbap_distance_model::store(&mut cfg, "inverse-square".to_string()); // String
+        assert_eq!(cfg.vbap_distance_model.as_deref(), Some("inverse-square"));
+        assert_eq!(
+            super::vbap_distance_model::get(&cfg).as_deref(),
+            Some("inverse-square")
+        );
     }
 }

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -316,6 +316,42 @@ render_field! {
     eq = bool::eq
 }
 
+// ── Lot 5c: special-cased options (custom descriptors) ──
+
+render_field_str! {
+    /// Object-transition ramp mode (`render.ramp_mode`): "off" | "frame" |
+    /// "sample". Default "frame". Note: this fixes a CLI/live disagreement —
+    /// the old CLI writer treated `Sample` as the default (persisted `Frame`!),
+    /// while the live writer (correctly) treats `Frame` as the default.
+    pub ramp_mode = "frame",
+    field = ramp_mode
+}
+
+/// Presentation / substream selector (`render.presentation`). Special-cased:
+/// the CLI works in strings ("best" or a number) while the config stores a
+/// `u8` (with "best" → absent). Not expressible via the generic macros.
+pub mod presentation {
+    use super::RenderConfig;
+
+    /// Canonical default — the single copy of this field's default.
+    pub const DEFAULT: &str = "best";
+
+    /// Read the configured substream number, if present.
+    pub fn get(cfg: &RenderConfig) -> Option<u8> {
+        cfg.presentation
+    }
+
+    /// Store the CLI string form: `DEFAULT` ("best") or an unparseable value
+    /// clears to `None`; a numeric string is stored as the `u8` substream.
+    pub fn store(cfg: &mut RenderConfig, value: &str) {
+        cfg.presentation = if value == DEFAULT {
+            None
+        } else {
+            value.parse::<u8>().ok()
+        };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -244,6 +244,33 @@ render_field! {
     eq = bool::eq
 }
 
+render_field! {
+    /// Enable OSC metadata output (`render.osc`).
+    pub osc: bool = false,
+    field = osc,
+    eq = bool::eq
+}
+
+render_field_str! {
+    /// OSC target host (`render.osc_host`).
+    pub osc_host = "127.0.0.1",
+    field = osc_host
+}
+
+render_field! {
+    /// OSC target port (`render.osc_port`).
+    pub osc_port: u16 = 9000,
+    field = osc_port,
+    eq = u16::eq
+}
+
+render_field! {
+    /// OSC registration listener port (`render.osc_rx_port`).
+    pub osc_rx_port: u16 = 9000,
+    field = osc_rx_port,
+    eq = u16::eq
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -1,0 +1,111 @@
+//! Single source of truth for `RenderConfig` option fields.
+//!
+//! Historically each option's default lived in 3–4 places (clap
+//! `default_value_t`, the FFI `from_render_config` `unwrap_or(..)`, and the
+//! "skip if == default" thresholds in *both* config writers), which drift
+//! independently. Each option declared here owns its default exactly once and
+//! exposes a symmetric `get` / `store` pair so every read and write site goes
+//! through the same logic:
+//!
+//! - [`DEFAULT`](self) — the canonical default value, referenced by clap and
+//!   by the FFI reader instead of a hard-coded literal.
+//! - `get(&RenderConfig) -> Option<T>` — typed read.
+//! - `store(&mut RenderConfig, T)` — writes `Some(v)` only when `v` differs
+//!   from the default, `None` otherwise. Both the CLI (`effective_to_config`)
+//!   and the live (`save_live_config`) writers call this, so their skip-if-
+//!   default behaviour can no longer diverge.
+//!
+//! The descriptor centralises only the *config* side (key + default + get/
+//! store). Extracting the value from the runtime source (`RenderArgs` for the
+//! CLI, `LiveParams` for the live path) stays a one-liner at the call site,
+//! because those types live in other crates.
+
+use crate::config::RenderConfig;
+
+/// Declare a config option as a `{ DEFAULT, get, store }` descriptor module.
+///
+/// `eq` is the equality used by `store` to decide whether a value equals the
+/// default; pass `i32::eq` / `bool::eq` for exact types or a tolerance closure
+/// (e.g. `|a: &f32, b: &f32| (a - b).abs() < 1e-4`) for floats so the existing
+/// writer thresholds are reproduced exactly.
+macro_rules! render_field {
+    (
+        $(#[$meta:meta])*
+        $vis:vis $name:ident : $ty:ty = $default:expr,
+        field = $field:ident,
+        eq = $eq:expr
+    ) => {
+        $(#[$meta])*
+        $vis mod $name {
+            use super::RenderConfig;
+
+            /// Canonical default — the single copy of this field's default.
+            pub const DEFAULT: $ty = $default;
+
+            /// Read the configured value, if present.
+            pub fn get(cfg: &RenderConfig) -> Option<$ty> {
+                cfg.$field.clone()
+            }
+
+            /// Store `value`, writing `Some` only when it differs from
+            /// [`DEFAULT`] (skip-if-default), `None` otherwise.
+            pub fn store(cfg: &mut RenderConfig, value: $ty) {
+                let eq: fn(&$ty, &$ty) -> bool = $eq;
+                cfg.$field = if eq(&value, &DEFAULT) {
+                    None
+                } else {
+                    Some(value)
+                };
+            }
+        }
+    };
+}
+
+render_field! {
+    /// Number of distance cells across the polar VBAP precompute table
+    /// (`render.vbap_distance_res`). Pilot field for the descriptor scheme.
+    pub vbap_distance_res: i32 = 8,
+    field = vbap_distance_res,
+    eq = i32::eq
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::RenderConfig;
+
+    #[test]
+    fn store_non_default_sets_some() {
+        let mut cfg = RenderConfig::default();
+        super::vbap_distance_res::store(&mut cfg, 12);
+        assert_eq!(cfg.vbap_distance_res, Some(12));
+    }
+
+    #[test]
+    fn store_default_clears_to_none() {
+        let mut cfg = RenderConfig {
+            vbap_distance_res: Some(12),
+            ..Default::default()
+        };
+        super::vbap_distance_res::store(&mut cfg, super::vbap_distance_res::DEFAULT);
+        assert_eq!(cfg.vbap_distance_res, None);
+    }
+
+    #[test]
+    fn get_round_trips_through_store() {
+        let mut cfg = RenderConfig::default();
+        assert_eq!(super::vbap_distance_res::get(&cfg), None);
+        super::vbap_distance_res::store(&mut cfg, 5);
+        assert_eq!(super::vbap_distance_res::get(&cfg), Some(5));
+    }
+
+    /// CLI and live writers now share `store`, so feeding the same value from
+    /// either path must yield an identical config field (parity guard).
+    #[test]
+    fn cli_and_live_writers_agree() {
+        let mut from_cli = RenderConfig::default();
+        let mut from_live = RenderConfig::default();
+        super::vbap_distance_res::store(&mut from_cli, 12); // CLI: args value
+        super::vbap_distance_res::store(&mut from_live, 12); // live: LiveParams value
+        assert_eq!(from_cli.vbap_distance_res, from_live.vbap_distance_res);
+    }
+}

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -232,6 +232,18 @@ render_field! {
     eq = bool::eq
 }
 
+// ── Lot 4: OSC ──
+
+render_field! {
+    /// Pre-enable OSC audio-level metering for the configured default target
+    /// (`render.osc_metering`). Consumed by the CLI at startup
+    /// (`OscSender::set_default_metering`); the live path does not persist it
+    /// (Studio toggles metering per-client at runtime).
+    pub osc_metering: bool = false,
+    field = osc_metering,
+    eq = bool::eq
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -69,6 +69,58 @@ render_field! {
     eq = i32::eq
 }
 
+render_field! {
+    /// Polar VBAP azimuth cell count across [-180°, +180°]
+    /// (`render.vbap_azimuth_resolution`).
+    pub vbap_azimuth_resolution: i32 = 360,
+    field = vbap_azimuth_resolution,
+    eq = i32::eq
+}
+
+render_field! {
+    /// Polar VBAP elevation cell count (`render.vbap_elevation_resolution`).
+    pub vbap_elevation_resolution: i32 = 180,
+    field = vbap_elevation_resolution,
+    eq = i32::eq
+}
+
+render_field! {
+    /// Maximum distance covered by the polar VBAP table
+    /// (`render.vbap_distance_max`). Float field: the live writer used a 1e-4
+    /// tolerance and the CLI writer `f32::EPSILON`; unified here on 1e-4 (the
+    /// more robust threshold — only sub-1e-4 float noise is now treated as the
+    /// default on the CLI side).
+    pub vbap_distance_max: f32 = 2.0,
+    field = vbap_distance_max,
+    eq = |a: &f32, b: &f32| (a - b).abs() < 1e-4
+}
+
+render_field! {
+    /// Minimum VBAP spread floor for point sources (`render.vbap_spread_min`).
+    pub vbap_spread_min: f32 = 0.0,
+    field = vbap_spread_min,
+    eq = |a: &f32, b: &f32| *a == *b
+}
+
+render_field! {
+    /// Maximum VBAP spread cap for fully-diffuse objects
+    /// (`render.vbap_spread_max`).
+    pub vbap_spread_max: f32 = 1.0,
+    field = vbap_spread_max,
+    eq = |a: &f32, b: &f32| *a == *b
+}
+
+render_field! {
+    /// Interpolate between neighbouring VBAP table cells on lookup
+    /// (`render.render_evaluation_position_interpolation`). Default is *on*
+    /// (true), so only an explicit `false` is persisted. This also fixes a CLI
+    /// writer asymmetry where disabling interpolation was previously dropped
+    /// (it wrote `Some(true)` / `None`, never `Some(false)`).
+    pub render_evaluation_position_interpolation: bool = true,
+    field = render_evaluation_position_interpolation,
+    eq = bool::eq
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;
@@ -107,5 +159,30 @@ mod tests {
         super::vbap_distance_res::store(&mut from_cli, 12); // CLI: args value
         super::vbap_distance_res::store(&mut from_live, 12); // live: LiveParams value
         assert_eq!(from_cli.vbap_distance_res, from_live.vbap_distance_res);
+    }
+
+    #[test]
+    fn float_field_uses_tolerance() {
+        let mut cfg = RenderConfig::default();
+        super::vbap_distance_max::store(&mut cfg, 2.0);
+        assert_eq!(cfg.vbap_distance_max, None, "exact default cleared");
+        super::vbap_distance_max::store(&mut cfg, 2.000_05);
+        assert_eq!(
+            cfg.vbap_distance_max, None,
+            "within 1e-4 treated as default"
+        );
+        super::vbap_distance_max::store(&mut cfg, 3.0);
+        assert_eq!(cfg.vbap_distance_max, Some(3.0));
+    }
+
+    #[test]
+    fn interpolation_default_is_on_and_false_persists() {
+        let mut cfg = RenderConfig::default();
+        // Default (on) is not written.
+        super::render_evaluation_position_interpolation::store(&mut cfg, true);
+        assert_eq!(cfg.render_evaluation_position_interpolation, None);
+        // Disabling it IS persisted (the previous CLI writer dropped this).
+        super::render_evaluation_position_interpolation::store(&mut cfg, false);
+        assert_eq!(cfg.render_evaluation_position_interpolation, Some(false));
     }
 }

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -205,6 +205,33 @@ render_field_str! {
     field = vbap_distance_model
 }
 
+// ── Lot 3: gain / loudness ──
+
+render_field! {
+    /// Master output gain in dB (`render.master_gain`). The CLI writer used
+    /// exact `!= 0.0`, the live writer a 0.01 dB tolerance (it derives dB from
+    /// the linear live gain); unified on 0.01 dB (sub-0.01 dB is inaudible).
+    pub master_gain: f32 = 0.0,
+    field = master_gain,
+    eq = |a: &f32, b: &f32| (a - b).abs() <= 0.01
+}
+
+render_field! {
+    /// Automatic gain reduction to avoid clipping (`render.auto_gain`).
+    /// Note: only the CLI writer persists this; the live path leaves it
+    /// untouched (preserved from the existing config).
+    pub auto_gain: bool = false,
+    field = auto_gain,
+    eq = bool::eq
+}
+
+render_field! {
+    /// Loudness metadata correction toward -31 dBFS (`render.use_loudness`).
+    pub use_loudness: bool = false,
+    field = use_loudness,
+    eq = bool::eq
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -271,6 +271,51 @@ render_field! {
     eq = u16::eq
 }
 
+// ── Lot 5a: remaining simple scalar bools/floats ──
+
+render_field! {
+    /// Enable VBAP spatial rendering (`render.enable_vbap`).
+    pub enable_vbap: bool = false,
+    field = enable_vbap,
+    eq = bool::eq
+}
+
+render_field! {
+    /// Deprecated fixed VBAP spread coefficient (`render.vbap_spread`).
+    pub vbap_spread: f32 = 0.0,
+    field = vbap_spread,
+    eq = |a: &f32, b: &f32| *a == *b
+}
+
+render_field! {
+    /// Continuous mode: keep waiting for new data at stream end
+    /// (`render.continuous`).
+    pub continuous: bool = false,
+    field = continuous,
+    eq = bool::eq
+}
+
+render_field! {
+    /// Bed conformance for spatial content (`render.bed_conform`).
+    pub bed_conform: bool = false,
+    field = bed_conform,
+    eq = bool::eq
+}
+
+render_field! {
+    /// Derive spread from object distance (`render.spread_from_distance`).
+    pub spread_from_distance: bool = false,
+    field = spread_from_distance,
+    eq = bool::eq
+}
+
+render_field! {
+    /// Enable adaptive resampling PI controller (`render.enable_adaptive_resampling`).
+    pub enable_adaptive_resampling: bool = false,
+    field = enable_adaptive_resampling,
+    eq = bool::eq
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;

--- a/omniphony-renderer/renderer/src/lib.rs
+++ b/omniphony-renderer/renderer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod backend_registry;
 pub mod config;
+pub mod config_fields;
 pub mod crossover;
 pub mod delay_line;
 pub mod live_params;

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use renderer::live_params::{
-    LiveEvaluationMode, PreferredEvaluationMode, RampMode, RendererControl,
-};
+use renderer::live_params::{LiveEvaluationMode, PreferredEvaluationMode, RendererControl};
 
 use crate::HostControlHandler;
 
@@ -254,10 +252,7 @@ pub fn save_live_config(
     } else {
         None
     };
-    render.ramp_mode = match control.requested_ramp_mode() {
-        RampMode::Frame => None,
-        mode => Some(mode.as_str().to_string()),
-    };
+    renderer::config_fields::ramp_mode::store(render, control.requested_ramp_mode().as_str());
 
     drop(live);
 

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -109,11 +109,7 @@ pub fn save_live_config(
         render.evaluation_cartesian_z_size = None;
         render.evaluation_cartesian_z_neg_size = None;
     }
-    render.spread_from_distance = if live.spread_from_distance {
-        Some(true)
-    } else {
-        None
-    };
+    renderer::config_fields::spread_from_distance::store(render, live.spread_from_distance);
     renderer::config_fields::spread_distance_range::store(render, live.spread_distance_range);
     renderer::config_fields::spread_distance_curve::store(render, live.spread_distance_curve);
     render.size_to_spread_mode =

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -55,11 +55,7 @@ pub fn save_live_config(
     render.speaker_layout = None;
 
     let master_gain_db = 20.0_f32 * live.master_gain.log10();
-    render.master_gain = if master_gain_db.abs() > 0.01 {
-        Some(master_gain_db)
-    } else {
-        None
-    };
+    renderer::config_fields::master_gain::store(render, master_gain_db);
 
     renderer::config_fields::vbap_spread_min::store(render, live.spread_min);
     renderer::config_fields::vbap_spread_max::store(render, live.spread_max);
@@ -126,7 +122,7 @@ pub fn save_live_config(
         } else {
             None
         };
-    render.use_loudness = if live.use_loudness { Some(true) } else { None };
+    renderer::config_fields::use_loudness::store(render, live.use_loudness);
     renderer::config_fields::vbap_distance_model::store(render, live.distance_model.to_string());
     // Room geometry is persisted in metres. Width is the reference and the room
     // scale is Width/2 = the layout radius, so metres = ratio × radius × factor

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -81,11 +81,10 @@ pub fn save_live_config(
     } else {
         None
     };
-    render.vbap_distance_res = if live.evaluation.polar.distance_res != 8 {
-        Some(live.evaluation.polar.distance_res.max(1))
-    } else {
-        None
-    };
+    renderer::config_fields::vbap_distance_res::store(
+        render,
+        live.evaluation.polar.distance_res.max(1),
+    );
     render.vbap_distance_max = if (live.evaluation.polar.distance_max - 2.0).abs() > 1e-4 {
         Some(live.evaluation.polar.distance_max.max(0.01))
     } else {

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -61,36 +61,28 @@ pub fn save_live_config(
         None
     };
 
-    render.vbap_spread_min = if live.spread_min != 0.0 {
-        Some(live.spread_min)
-    } else {
-        None
-    };
-    render.vbap_spread_max = if live.spread_max != 1.0 {
-        Some(live.spread_max)
-    } else {
-        None
-    };
-    render.vbap_azimuth_resolution = if live.evaluation.polar.azimuth_values != 360 {
-        Some(live.evaluation.polar.azimuth_values.max(1))
-    } else {
-        None
-    };
-    render.vbap_elevation_resolution = if live.evaluation.polar.elevation_values != 180 {
-        Some(live.evaluation.polar.elevation_values.max(1))
-    } else {
-        None
-    };
+    renderer::config_fields::vbap_spread_min::store(render, live.spread_min);
+    renderer::config_fields::vbap_spread_max::store(render, live.spread_max);
+    renderer::config_fields::vbap_azimuth_resolution::store(
+        render,
+        live.evaluation.polar.azimuth_values.max(1),
+    );
+    renderer::config_fields::vbap_elevation_resolution::store(
+        render,
+        live.evaluation.polar.elevation_values.max(1),
+    );
     renderer::config_fields::vbap_distance_res::store(
         render,
         live.evaluation.polar.distance_res.max(1),
     );
-    render.vbap_distance_max = if (live.evaluation.polar.distance_max - 2.0).abs() > 1e-4 {
-        Some(live.evaluation.polar.distance_max.max(0.01))
-    } else {
-        None
-    };
-    render.render_evaluation_position_interpolation = Some(live.evaluation.position_interpolation);
+    renderer::config_fields::vbap_distance_max::store(
+        render,
+        live.evaluation.polar.distance_max.max(0.01),
+    );
+    renderer::config_fields::render_evaluation_position_interpolation::store(
+        render,
+        live.evaluation.position_interpolation,
+    );
     render.render_backend = match live.backend_id() {
         "vbap" => None,
         other => Some(other.to_string()),

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -118,16 +118,8 @@ pub fn save_live_config(
     } else {
         None
     };
-    render.spread_distance_range = if (live.spread_distance_range - 1.0).abs() > 1e-4 {
-        Some(live.spread_distance_range)
-    } else {
-        None
-    };
-    render.spread_distance_curve = if (live.spread_distance_curve - 1.0).abs() > 1e-4 {
-        Some(live.spread_distance_curve)
-    } else {
-        None
-    };
+    renderer::config_fields::spread_distance_range::store(render, live.spread_distance_range);
+    renderer::config_fields::spread_distance_curve::store(render, live.spread_distance_curve);
     render.size_to_spread_mode =
         if live.size_to_spread_mode != renderer::render_backend::SizeToSpreadMode::default() {
             Some(live.size_to_spread_mode)
@@ -135,12 +127,7 @@ pub fn save_live_config(
             None
         };
     render.use_loudness = if live.use_loudness { Some(true) } else { None };
-    render.vbap_distance_model =
-        if live.distance_model != renderer::spatial_vbap::DistanceModel::None {
-            Some(live.distance_model.to_string())
-        } else {
-            None
-        };
+    renderer::config_fields::vbap_distance_model::store(render, live.distance_model.to_string());
     // Room geometry is persisted in metres. Width is the reference and the room
     // scale is Width/2 = the layout radius, so metres = ratio × radius × factor
     // (factor 2 for width). The legacy `room_ratio*` are dropped — `Config::load`
@@ -174,21 +161,12 @@ pub fn save_live_config(
     // persist the current values (read lock-free from RendererControl).
     render.meter_rate = Some(round6(control.meter_rate_hz()));
     render.diag_rate = Some(round6(control.diag_rate_hz()));
-    render.distance_diffuse = if live.use_distance_diffuse {
-        Some(true)
-    } else {
-        None
-    };
-    render.distance_diffuse_threshold = if (live.distance_diffuse_threshold - 1.0).abs() > 1e-4 {
-        Some(live.distance_diffuse_threshold)
-    } else {
-        None
-    };
-    render.distance_diffuse_curve = if (live.distance_diffuse_curve - 1.0).abs() > 1e-4 {
-        Some(live.distance_diffuse_curve)
-    } else {
-        None
-    };
+    renderer::config_fields::distance_diffuse::store(render, live.use_distance_diffuse);
+    renderer::config_fields::distance_diffuse_threshold::store(
+        render,
+        live.distance_diffuse_threshold,
+    );
+    renderer::config_fields::distance_diffuse_curve::store(render, live.distance_diffuse_curve);
     let default_metric = renderer::spatial_vbap::DistanceMetric::default();
     render.distance_model_metric = if live.distance_model_metric != default_metric {
         Some(live.distance_model_metric.to_string())

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -244,7 +244,7 @@ pub struct RenderArgs {
 
     /// VBAP spreading coefficient (0.0 = point source, 1.0 = maximum spread)
     /// Deprecated: Use --vbap-distance-res instead for dynamic per-object spread
-    #[arg(long, value_name = "SPREAD", default_value_t = 0.0)]
+    #[arg(long, value_name = "SPREAD", default_value_t = renderer::config_fields::vbap_spread::DEFAULT)]
     pub vbap_spread: f32,
 
     /// Number of distance cells across full range [0, vbap-distance-max]

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -252,7 +252,7 @@ pub struct RenderArgs {
     #[arg(
         long = "evaluation-polar-distance-res",
         value_name = "RESOLUTION",
-        default_value_t = 8
+        default_value_t = renderer::config_fields::vbap_distance_res::DEFAULT
     )]
     pub evaluation_polar_distance_res: i32,
 

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -161,16 +161,16 @@ pub struct RenderArgs {
     pub no_osc_metering: bool,
 
     /// OSC target host
-    #[arg(long, value_name = "HOST", default_value = "127.0.0.1")]
+    #[arg(long, value_name = "HOST", default_value = renderer::config_fields::osc_host::DEFAULT)]
     pub osc_host: String,
 
     /// OSC target port
-    #[arg(long, value_name = "PORT", default_value_t = 9000)]
+    #[arg(long, value_name = "PORT", default_value_t = renderer::config_fields::osc_port::DEFAULT)]
     pub osc_port: u16,
 
     /// OSC registration listener port. Clients register by sending /omniphony/register
     /// to this port and receive the speaker config + all subsequent broadcasts.
-    #[arg(long, value_name = "PORT", default_value_t = 9000)]
+    #[arg(long, value_name = "PORT", default_value_t = renderer::config_fields::osc_rx_port::DEFAULT)]
     pub osc_rx_port: u16,
 
     /// Output device or target name.
@@ -540,15 +540,15 @@ pub struct InputLiveArgs {
     pub no_osc_metering: bool,
 
     /// OSC target host
-    #[arg(long, value_name = "HOST", default_value = "127.0.0.1")]
+    #[arg(long, value_name = "HOST", default_value = renderer::config_fields::osc_host::DEFAULT)]
     pub osc_host: String,
 
     /// OSC target port
-    #[arg(long, value_name = "PORT", default_value_t = 9000)]
+    #[arg(long, value_name = "PORT", default_value_t = renderer::config_fields::osc_port::DEFAULT)]
     pub osc_port: u16,
 
     /// OSC registration listener port.
-    #[arg(long, value_name = "PORT", default_value_t = 9000)]
+    #[arg(long, value_name = "PORT", default_value_t = renderer::config_fields::osc_rx_port::DEFAULT)]
     pub osc_rx_port: u16,
 }
 

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -128,7 +128,7 @@ pub struct RenderArgs {
     /// Presentation or substream selector passed to the bridge plugin.
     /// "best" selects the richest available presentation (default).
     /// Pass a number to request a specific substream (bridge-defined).
-    #[arg(long, value_name = "VALUE", default_value = "best")]
+    #[arg(long, value_name = "VALUE", default_value = renderer::config_fields::presentation::DEFAULT)]
     pub presentation: String,
 
     /// Path to the format bridge plugin library.

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -229,7 +229,7 @@ pub struct RenderArgs {
     #[arg(
         long = "evaluation-polar-azimuth-resolution",
         value_name = "DEG",
-        default_value_t = 360
+        default_value_t = renderer::config_fields::vbap_azimuth_resolution::DEFAULT
     )]
     pub evaluation_polar_azimuth_resolution: i32,
 
@@ -238,7 +238,7 @@ pub struct RenderArgs {
     #[arg(
         long = "evaluation-polar-elevation-resolution",
         value_name = "DEG",
-        default_value_t = 180
+        default_value_t = renderer::config_fields::vbap_elevation_resolution::DEFAULT
     )]
     pub evaluation_polar_elevation_resolution: i32,
 
@@ -260,7 +260,7 @@ pub struct RenderArgs {
     #[arg(
         long = "evaluation-polar-distance-max",
         value_name = "DISTANCE",
-        default_value_t = 2.0
+        default_value_t = renderer::config_fields::vbap_distance_max::DEFAULT
     )]
     pub evaluation_polar_distance_max: f32,
 
@@ -334,12 +334,12 @@ pub struct RenderArgs {
 
     /// Minimum VBAP spread applied when the object spread is 0.0 (point source)
     /// Allows setting a spread floor so objects are never fully localized
-    #[arg(long, value_name = "SPREAD", default_value_t = 0.0)]
+    #[arg(long, value_name = "SPREAD", default_value_t = renderer::config_fields::vbap_spread_min::DEFAULT)]
     pub vbap_spread_min: f32,
 
     /// Maximum VBAP spread applied when the object spread is 1.0 (fully diffuse)
     /// Allows capping spread so objects never fully decorrelate
-    #[arg(long, value_name = "SPREAD", default_value_t = 1.0)]
+    #[arg(long, value_name = "SPREAD", default_value_t = renderer::config_fields::vbap_spread_max::DEFAULT)]
     pub vbap_spread_max: f32,
 
     /// Enable detailed logging of object positions during VBAP spatialization

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -373,7 +373,7 @@ pub struct RenderArgs {
     #[arg(
         long,
         value_name = "DB",
-        default_value_t = 0.0,
+        default_value_t = renderer::config_fields::master_gain::DEFAULT,
         allow_hyphen_values = true
     )]
     pub master_gain: f32,

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -310,7 +310,7 @@ pub struct RenderArgs {
     pub no_vbap_allow_negative_z: bool,
 
     /// Distance attenuation model (none, linear, quadratic, inverse-square)
-    #[arg(long, value_name = "MODEL", default_value = "none")]
+    #[arg(long, value_name = "MODEL", default_value = renderer::config_fields::vbap_distance_model::DEFAULT)]
     pub vbap_distance_model: String,
 
     /// Calculate spread from distance (1.0 at distance=0, 0.0 at distance>=1.0)
@@ -324,12 +324,12 @@ pub struct RenderArgs {
 
     /// Distance at which spread reaches 0.0 (only used with --spread-from-distance)
     /// Lower values = objects become localized sooner, higher values = stay diffuse longer
-    #[arg(long, value_name = "DISTANCE", default_value_t = 1.0)]
+    #[arg(long, value_name = "DISTANCE", default_value_t = renderer::config_fields::spread_distance_range::DEFAULT)]
     pub spread_distance_range: f32,
 
     /// Curve exponent for distance-based spread (only used with --spread-from-distance)
     /// 1.0 = linear, 2.0 = quadratic (slower near, faster far), 0.5 = sqrt (faster near, slower far)
-    #[arg(long, value_name = "EXPONENT", default_value_t = 1.0)]
+    #[arg(long, value_name = "EXPONENT", default_value_t = renderer::config_fields::spread_distance_curve::DEFAULT)]
     pub spread_distance_curve: f32,
 
     /// Minimum VBAP spread applied when the object spread is 0.0 (point source)
@@ -406,12 +406,12 @@ pub struct RenderArgs {
 
     /// ADM distance at which distance-diffuse blend reaches 100% direct.
     /// (pre-room_ratio, 1.0 = surface of the ADM unit sphere)
-    #[arg(long, value_name = "DISTANCE", default_value_t = 1.0)]
+    #[arg(long, value_name = "DISTANCE", default_value_t = renderer::config_fields::distance_diffuse_threshold::DEFAULT)]
     pub distance_diffuse_threshold: f32,
 
     /// Curve exponent for distance-diffuse blend weight.
     /// 1.0 = linear, 2.0 = slow-near (stays diffuse longer), 0.5 = fast-near.
-    #[arg(long, value_name = "EXPONENT", default_value_t = 1.0)]
+    #[arg(long, value_name = "EXPONENT", default_value_t = renderer::config_fields::distance_diffuse_curve::DEFAULT)]
     pub distance_diffuse_curve: f32,
 
     /// Ramp processing mode for object transitions.

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -324,6 +324,18 @@ fn init_osc_runtime(
         match OscSender::new(osc_addr) {
             Ok(sender) => {
                 log::info!("OSC output enabled: {}:{}", args.osc_host, args.osc_port);
+                if args.osc_metering {
+                    // Pre-subscribe the configured default target to meter
+                    // bundles. Without this, metering only flows once a client
+                    // (e.g. Studio) sends a runtime enable, so `--osc-metering`
+                    // had no effect on a headless/config-driven target.
+                    sender.set_default_metering(true);
+                    log::info!(
+                        "OSC metering pre-enabled for default target {}:{} (--osc-metering)",
+                        args.osc_host,
+                        args.osc_port
+                    );
+                }
                 handler.telemetry.osc_sender = Some(sender);
             }
             Err(e) => {

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -78,7 +78,7 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("vbap_spread") {
-        if let Some(v) = cfg.vbap_spread {
+        if let Some(v) = renderer::config_fields::vbap_spread::get(cfg) {
             args.vbap_spread = v;
         }
     }
@@ -195,7 +195,8 @@ pub(super) fn merge_render_config(
     // --- Bool fields: CLI enable/disable flags override config; absent → use config ---
     // enable_vbap
     if !arg_sources.is_explicit("enable_vbap") && !arg_sources.is_explicit("disable_vbap") {
-        args.enable_vbap = cfg.enable_vbap.unwrap_or(false);
+        args.enable_vbap = renderer::config_fields::enable_vbap::get(cfg)
+            .unwrap_or(renderer::config_fields::enable_vbap::DEFAULT);
     } else if args.disable_vbap {
         args.enable_vbap = false;
     }
@@ -221,7 +222,8 @@ pub(super) fn merge_render_config(
     }
     // continuous
     if !arg_sources.is_explicit("continuous") && !arg_sources.is_explicit("no_continuous") {
-        args.continuous = cfg.continuous.unwrap_or(false);
+        args.continuous = renderer::config_fields::continuous::get(cfg)
+            .unwrap_or(renderer::config_fields::continuous::DEFAULT);
     } else if args.no_continuous {
         args.continuous = false;
     }
@@ -241,7 +243,8 @@ pub(super) fn merge_render_config(
     }
     // bed_conform
     if !arg_sources.is_explicit("bed_conform") && !arg_sources.is_explicit("no_bed_conform") {
-        args.bed_conform = cfg.bed_conform.unwrap_or(false);
+        args.bed_conform = renderer::config_fields::bed_conform::get(cfg)
+            .unwrap_or(renderer::config_fields::bed_conform::DEFAULT);
     } else if args.no_bed_conform {
         args.bed_conform = false;
     }
@@ -249,7 +252,9 @@ pub(super) fn merge_render_config(
     if !arg_sources.is_explicit("enable_adaptive_resampling")
         && !arg_sources.is_explicit("disable_adaptive_resampling")
     {
-        args.enable_adaptive_resampling = cfg.enable_adaptive_resampling.unwrap_or(false);
+        args.enable_adaptive_resampling =
+            renderer::config_fields::enable_adaptive_resampling::get(cfg)
+                .unwrap_or(renderer::config_fields::enable_adaptive_resampling::DEFAULT);
     } else if args.disable_adaptive_resampling {
         args.enable_adaptive_resampling = false;
     }
@@ -257,7 +262,8 @@ pub(super) fn merge_render_config(
     if !arg_sources.is_explicit("spread_from_distance")
         && !arg_sources.is_explicit("no_spread_from_distance")
     {
-        args.spread_from_distance = cfg.spread_from_distance.unwrap_or(false);
+        args.spread_from_distance = renderer::config_fields::spread_from_distance::get(cfg)
+            .unwrap_or(renderer::config_fields::spread_from_distance::DEFAULT);
     } else if args.no_spread_from_distance {
         args.spread_from_distance = false;
     }
@@ -330,7 +336,7 @@ pub(super) fn effective_to_config(
         None
     };
     render.bridge_path = args.bridge_path.clone();
-    render.enable_vbap = if args.enable_vbap { Some(true) } else { None };
+    renderer::config_fields::enable_vbap::store(&mut render, args.enable_vbap);
     // Persist the embedded layout instead of a path link. Only override when a
     // layout path is supplied on the CLI; otherwise keep the config's existing
     // embedded `current_layout` (Studio-saved) intact.
@@ -347,11 +353,7 @@ pub(super) fn effective_to_config(
         &mut render,
         args.evaluation_polar_elevation_resolution,
     );
-    render.vbap_spread = if args.vbap_spread != 0.0 {
-        Some(args.vbap_spread)
-    } else {
-        None
-    };
+    renderer::config_fields::vbap_spread::store(&mut render, args.vbap_spread);
     renderer::config_fields::vbap_distance_res::store(
         &mut render,
         args.evaluation_polar_distance_res,
@@ -408,24 +410,19 @@ pub(super) fn effective_to_config(
         render.output_device = args.output_device.clone();
         render.latency_target = args.latency_target_ms;
     }
-    render.continuous = if args.continuous { Some(true) } else { None };
+    renderer::config_fields::continuous::store(&mut render, args.continuous);
     renderer::config_fields::use_loudness::store(&mut render, args.use_loudness);
     renderer::config_fields::auto_gain::store(&mut render, args.auto_gain);
-    render.bed_conform = if args.bed_conform { Some(true) } else { None };
-    render.spread_from_distance = if args.spread_from_distance {
-        Some(true)
-    } else {
-        None
-    };
+    renderer::config_fields::bed_conform::store(&mut render, args.bed_conform);
+    renderer::config_fields::spread_from_distance::store(&mut render, args.spread_from_distance);
     renderer::config_fields::spread_distance_range::store(&mut render, args.spread_distance_range);
     renderer::config_fields::spread_distance_curve::store(&mut render, args.spread_distance_curve);
     renderer::config_fields::vbap_spread_min::store(&mut render, args.vbap_spread_min);
     renderer::config_fields::vbap_spread_max::store(&mut render, args.vbap_spread_max);
-    render.enable_adaptive_resampling = if args.enable_adaptive_resampling {
-        Some(true)
-    } else {
-        None
-    };
+    renderer::config_fields::enable_adaptive_resampling::store(
+        &mut render,
+        args.enable_adaptive_resampling,
+    );
     render.adaptive_resampling_update_interval_callbacks =
         args.adaptive_resampling_update_interval_callbacks;
     render.output_sample_rate = args.output_sample_rate;

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -83,7 +83,7 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("evaluation_polar_distance_res") {
-        if let Some(v) = cfg.vbap_distance_res {
+        if let Some(v) = renderer::config_fields::vbap_distance_res::get(cfg) {
             args.evaluation_polar_distance_res = v;
         }
     }
@@ -273,14 +273,8 @@ pub(super) fn effective_to_config(
     cli: &Cli,
     existing_render_cfg: Option<&renderer::config::RenderConfig>,
 ) -> Result<renderer::config::Config> {
-    use renderer::config::{Config, GlobalConfig, RenderConfig};
+    use renderer::config::{Config, GlobalConfig};
     use renderer::speaker_layout::SpeakerLayout;
-
-    let current_layout = if let Some(ref layout_path) = args.speaker_layout {
-        Some(SpeakerLayout::from_file(layout_path)?)
-    } else {
-        None
-    };
 
     let global = GlobalConfig {
         loglevel: if cli.loglevel != LogLevel::default() {
@@ -297,262 +291,195 @@ pub(super) fn effective_to_config(
         extra: Default::default(),
     };
 
-    let render = RenderConfig {
-        input_mode: None,
-        input_pipe: if args.continuous {
-            args.input.clone()
-        } else {
-            None
-        },
-        live_input: None,
-        output_backend: match args.output_backend {
-            Some(value) if Some(value) != OutputBackend::platform_default() => {
-                Some(format!("{:?}", value).to_lowercase())
-            }
-            _ => None,
-        },
-        presentation: if args.presentation != "best" {
-            args.presentation.parse::<u8>().ok()
-        } else {
-            None
-        },
-        bridge_path: args.bridge_path.clone(),
-        enable_vbap: if args.enable_vbap { Some(true) } else { None },
-        // Persist embedded layout instead of path link.
-        speaker_layout: None,
-        current_layout,
-        vbap_table: args.vbap_table.clone(),
-        vbap_azimuth_resolution: if args.evaluation_polar_azimuth_resolution != 360 {
-            Some(args.evaluation_polar_azimuth_resolution)
-        } else {
-            None
-        },
-        vbap_elevation_resolution: if args.evaluation_polar_elevation_resolution != 180 {
-            Some(args.evaluation_polar_elevation_resolution)
-        } else {
-            None
-        },
-        vbap_spread: if args.vbap_spread != 0.0 {
-            Some(args.vbap_spread)
-        } else {
-            None
-        },
-        vbap_distance_res: if args.evaluation_polar_distance_res != 8 {
-            Some(args.evaluation_polar_distance_res)
-        } else {
-            None
-        },
-        vbap_distance_max: if (args.evaluation_polar_distance_max - 2.0).abs() > f32::EPSILON {
-            Some(args.evaluation_polar_distance_max)
-        } else {
-            None
-        },
-        render_evaluation_position_interpolation: if args.render_evaluation_position_interpolation {
+    // Start from the existing config so every field the CLI cannot express
+    // (live_input, embedded current_layout, render_backend, hybrid_*,
+    // experimental_*, distance metrics, adaptive tuning, DRC, monitoring
+    // cadences, size_to_spread, and any unknown `extra` keys) is preserved
+    // verbatim instead of being erased. `merge_render_config` has already
+    // folded the on-disk config into `args`, so re-storing the args value
+    // re-persists anything the user did not explicitly override on the CLI.
+    let mut render = existing_render_cfg.cloned().unwrap_or_default();
+
+    render.input_pipe = if args.continuous {
+        args.input.clone()
+    } else {
+        None
+    };
+    render.output_backend = match args.output_backend {
+        Some(value) if Some(value) != OutputBackend::platform_default() => {
+            Some(format!("{:?}", value).to_lowercase())
+        }
+        _ => None,
+    };
+    render.presentation = if args.presentation != "best" {
+        args.presentation.parse::<u8>().ok()
+    } else {
+        None
+    };
+    render.bridge_path = args.bridge_path.clone();
+    render.enable_vbap = if args.enable_vbap { Some(true) } else { None };
+    // Persist the embedded layout instead of a path link. Only override when a
+    // layout path is supplied on the CLI; otherwise keep the config's existing
+    // embedded `current_layout` (Studio-saved) intact.
+    if let Some(ref layout_path) = args.speaker_layout {
+        render.current_layout = Some(SpeakerLayout::from_file(layout_path)?);
+        render.speaker_layout = None;
+    }
+    render.vbap_table = args.vbap_table.clone();
+    render.vbap_azimuth_resolution = if args.evaluation_polar_azimuth_resolution != 360 {
+        Some(args.evaluation_polar_azimuth_resolution)
+    } else {
+        None
+    };
+    render.vbap_elevation_resolution = if args.evaluation_polar_elevation_resolution != 180 {
+        Some(args.evaluation_polar_elevation_resolution)
+    } else {
+        None
+    };
+    render.vbap_spread = if args.vbap_spread != 0.0 {
+        Some(args.vbap_spread)
+    } else {
+        None
+    };
+    renderer::config_fields::vbap_distance_res::store(
+        &mut render,
+        args.evaluation_polar_distance_res,
+    );
+    render.vbap_distance_max = if (args.evaluation_polar_distance_max - 2.0).abs() > f32::EPSILON {
+        Some(args.evaluation_polar_distance_max)
+    } else {
+        None
+    };
+    render.render_evaluation_position_interpolation =
+        if args.render_evaluation_position_interpolation {
             Some(true)
         } else {
             None
-        },
-        render_backend: None,
-        render_evaluation_mode: if args.render_evaluation_mode != EvaluationModeArg::Polar {
-            Some(format!("{:?}", args.render_evaluation_mode).to_lowercase())
-        } else {
-            None
-        },
-        evaluation_cartesian_x_size: args.evaluation_cartesian_x_size,
-        evaluation_cartesian_y_size: args.evaluation_cartesian_y_size,
-        evaluation_cartesian_z_size: args.evaluation_cartesian_z_size,
-        evaluation_cartesian_z_neg_size: args.evaluation_cartesian_z_neg_size,
-        vbap_allow_negative_z: if args.vbap_allow_negative_z {
-            Some(true)
-        } else if args.no_vbap_allow_negative_z {
-            Some(false)
-        } else {
-            None
-        },
-        vbap_distance_model: if args.vbap_distance_model != "none" {
-            Some(args.vbap_distance_model.clone())
-        } else {
-            None
-        },
-        master_gain: if args.master_gain != 0.0 {
-            Some(args.master_gain)
-        } else {
-            None
-        },
-        // The CLI works in ratios; metres are a save-time representation only.
-        room_width_m: None,
-        room_front_m: None,
-        room_rear_m: None,
-        room_height_m: None,
-        room_lower_m: None,
-        room_ratio: if args.room_ratio != "1.0,2.0,1.0" {
-            Some(args.room_ratio.clone())
-        } else {
-            None
-        },
-        room_ratio_rear: args.room_ratio_rear,
-        room_ratio_lower: args.room_ratio_lower,
-        room_ratio_center_blend: args.room_ratio_center_blend,
-        osc: if args.osc { Some(true) } else { None },
-        osc_metering: if args.osc_metering { Some(true) } else { None },
-        osc_rx_port: if args.osc_rx_port != 9000 {
-            Some(args.osc_rx_port)
-        } else {
-            None
-        },
-        osc_host: if args.osc_host != "127.0.0.1" {
-            Some(args.osc_host.clone())
-        } else {
-            None
-        },
-        osc_port: if args.osc_port != 9000 {
-            Some(args.osc_port)
-        } else {
-            None
-        },
-        output_device: {
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
-            {
-                args.output_device.clone()
-            }
-            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-            {
-                None
-            }
-        },
-        latency_target: {
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
-            {
-                args.latency_target_ms
-            }
-            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-            {
-                None
-            }
-        },
-        continuous: if args.continuous { Some(true) } else { None },
-        use_loudness: if args.use_loudness { Some(true) } else { None },
-        auto_gain: if args.auto_gain { Some(true) } else { None },
-        bed_conform: if args.bed_conform { Some(true) } else { None },
-        spread_from_distance: if args.spread_from_distance {
-            Some(true)
-        } else {
-            None
-        },
-        spread_distance_range: if args.spread_distance_range != 1.0 {
-            Some(args.spread_distance_range)
-        } else {
-            None
-        },
-        spread_distance_curve: if args.spread_distance_curve != 1.0 {
-            Some(args.spread_distance_curve)
-        } else {
-            None
-        },
-        vbap_spread_min: if args.vbap_spread_min != 0.0 {
-            Some(args.vbap_spread_min)
-        } else {
-            None
-        },
-        vbap_spread_max: if args.vbap_spread_max != 1.0 {
-            Some(args.vbap_spread_max)
-        } else {
-            None
-        },
-        // No CLI surface yet; preserve whatever the active config carries.
-        size_to_spread_mode: existing_render_cfg.and_then(|cfg| cfg.size_to_spread_mode),
-        enable_adaptive_resampling: if args.enable_adaptive_resampling {
-            Some(true)
-        } else {
-            None
-        },
-        // These adaptive tuning fields currently have no CLI surface, so a `save`
-        // round-trip must preserve whatever the active config already carries.
-        adaptive_resampling_enable_far_mode: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_enable_far_mode),
-        adaptive_resampling_force_silence_in_far_mode: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_force_silence_in_far_mode),
-        adaptive_resampling_hard_recover_high_in_far_mode: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_hard_recover_high_in_far_mode),
-        adaptive_resampling_hard_recover_low_in_far_mode: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_hard_recover_low_in_far_mode),
-        adaptive_resampling_far_mode_return_fade_in_ms: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_far_mode_return_fade_in_ms),
-        adaptive_resampling_kp_near: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_kp_near),
-        adaptive_resampling_ki: existing_render_cfg.and_then(|cfg| cfg.adaptive_resampling_ki),
-        adaptive_resampling_integral_discharge_ratio: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_integral_discharge_ratio),
-        adaptive_resampling_max_adjust: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_max_adjust),
-        adaptive_resampling_update_interval_callbacks: args
-            .adaptive_resampling_update_interval_callbacks,
-        adaptive_resampling_high_recover_entry_margin_ms: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_high_recover_entry_margin_ms),
-        adaptive_resampling_low_recover_settle_stable_ms: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_low_recover_settle_stable_ms),
-        adaptive_resampling_low_recover_entry_margin_ms: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_low_recover_entry_margin_ms),
-        adaptive_resampling_low_recover_exit_margin_ms: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_low_recover_exit_margin_ms),
-        adaptive_resampling_low_recover_settle_margin_ms: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_low_recover_settle_margin_ms),
-        adaptive_resampling_low_recover_refill_delta_alpha: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_low_recover_refill_delta_alpha),
-        adaptive_resampling_control_smoothing_cutoff_hz: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_control_smoothing_cutoff_hz),
-        adaptive_resampling_control_smoothing_order: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_control_smoothing_order),
-        adaptive_resampling_use_pre_bridge_clock: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_use_pre_bridge_clock),
-        adaptive_resampling_use_output_pacing: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_use_output_pacing),
-        adaptive_resampling_disable_backpressure: existing_render_cfg
-            .and_then(|cfg| cfg.adaptive_resampling_disable_backpressure),
-        output_sample_rate: args.output_sample_rate,
-        drc_mode: existing_render_cfg.and_then(|cfg| cfg.drc_mode.clone()),
-        drc_weight: existing_render_cfg.and_then(|cfg| cfg.drc_weight),
-        // No CLI surface; persisted/round-tripped via the live save path.
-        meter_rate: existing_render_cfg.and_then(|cfg| cfg.meter_rate),
-        diag_rate: existing_render_cfg.and_then(|cfg| cfg.diag_rate),
-        ramp_mode: if args.ramp_mode != RampModeArg::Sample {
-            Some(match args.ramp_mode {
-                RampModeArg::Off => "off".to_string(),
-                RampModeArg::Frame => "frame".to_string(),
-                RampModeArg::Sample => "sample".to_string(),
-            })
-        } else {
-            None
-        },
-        distance_diffuse: if args.distance_diffuse {
-            Some(true)
-        } else {
-            None
-        },
-        distance_diffuse_threshold: if args.distance_diffuse_threshold != 1.0 {
-            Some(args.distance_diffuse_threshold)
-        } else {
-            None
-        },
-        distance_diffuse_curve: if args.distance_diffuse_curve != 1.0 {
-            Some(args.distance_diffuse_curve)
-        } else {
-            None
-        },
-        experimental_distance_distance_floor: None,
-        experimental_distance_min_active_speakers: None,
-        experimental_distance_max_active_speakers: None,
-        experimental_distance_position_error_floor: None,
-        experimental_distance_position_error_nearest_scale: None,
-        experimental_distance_position_error_span_scale: None,
-        distance_model_metric: None,
-        distance_diffuse_metric: None,
-        hybrid_external_backend: None,
-        hybrid_internal_backend: None,
-        hybrid_curve: None,
-        hybrid_curve_smoothing: None,
-        hybrid_metric: None,
-        extra: Default::default(),
+        };
+    render.render_evaluation_mode = if args.render_evaluation_mode != EvaluationModeArg::Polar {
+        Some(format!("{:?}", args.render_evaluation_mode).to_lowercase())
+    } else {
+        None
+    };
+    render.evaluation_cartesian_x_size = args.evaluation_cartesian_x_size;
+    render.evaluation_cartesian_y_size = args.evaluation_cartesian_y_size;
+    render.evaluation_cartesian_z_size = args.evaluation_cartesian_z_size;
+    render.evaluation_cartesian_z_neg_size = args.evaluation_cartesian_z_neg_size;
+    render.vbap_allow_negative_z = if args.vbap_allow_negative_z {
+        Some(true)
+    } else if args.no_vbap_allow_negative_z {
+        Some(false)
+    } else {
+        None
+    };
+    render.vbap_distance_model = if args.vbap_distance_model != "none" {
+        Some(args.vbap_distance_model.clone())
+    } else {
+        None
+    };
+    render.master_gain = if args.master_gain != 0.0 {
+        Some(args.master_gain)
+    } else {
+        None
+    };
+    // The CLI works in ratios; metres are a save-time representation only, so
+    // clear any metre fields a prior Studio save left behind to keep the ratio
+    // representation authoritative on the next load.
+    render.room_width_m = None;
+    render.room_front_m = None;
+    render.room_rear_m = None;
+    render.room_height_m = None;
+    render.room_lower_m = None;
+    render.room_ratio = if args.room_ratio != "1.0,2.0,1.0" {
+        Some(args.room_ratio.clone())
+    } else {
+        None
+    };
+    render.room_ratio_rear = args.room_ratio_rear;
+    render.room_ratio_lower = args.room_ratio_lower;
+    render.room_ratio_center_blend = args.room_ratio_center_blend;
+    render.osc = if args.osc { Some(true) } else { None };
+    render.osc_metering = if args.osc_metering { Some(true) } else { None };
+    render.osc_rx_port = if args.osc_rx_port != 9000 {
+        Some(args.osc_rx_port)
+    } else {
+        None
+    };
+    render.osc_host = if args.osc_host != "127.0.0.1" {
+        Some(args.osc_host.clone())
+    } else {
+        None
+    };
+    render.osc_port = if args.osc_port != 9000 {
+        Some(args.osc_port)
+    } else {
+        None
+    };
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        render.output_device = args.output_device.clone();
+        render.latency_target = args.latency_target_ms;
+    }
+    render.continuous = if args.continuous { Some(true) } else { None };
+    render.use_loudness = if args.use_loudness { Some(true) } else { None };
+    render.auto_gain = if args.auto_gain { Some(true) } else { None };
+    render.bed_conform = if args.bed_conform { Some(true) } else { None };
+    render.spread_from_distance = if args.spread_from_distance {
+        Some(true)
+    } else {
+        None
+    };
+    render.spread_distance_range = if args.spread_distance_range != 1.0 {
+        Some(args.spread_distance_range)
+    } else {
+        None
+    };
+    render.spread_distance_curve = if args.spread_distance_curve != 1.0 {
+        Some(args.spread_distance_curve)
+    } else {
+        None
+    };
+    render.vbap_spread_min = if args.vbap_spread_min != 0.0 {
+        Some(args.vbap_spread_min)
+    } else {
+        None
+    };
+    render.vbap_spread_max = if args.vbap_spread_max != 1.0 {
+        Some(args.vbap_spread_max)
+    } else {
+        None
+    };
+    render.enable_adaptive_resampling = if args.enable_adaptive_resampling {
+        Some(true)
+    } else {
+        None
+    };
+    render.adaptive_resampling_update_interval_callbacks =
+        args.adaptive_resampling_update_interval_callbacks;
+    render.output_sample_rate = args.output_sample_rate;
+    render.ramp_mode = if args.ramp_mode != RampModeArg::Sample {
+        Some(match args.ramp_mode {
+            RampModeArg::Off => "off".to_string(),
+            RampModeArg::Frame => "frame".to_string(),
+            RampModeArg::Sample => "sample".to_string(),
+        })
+    } else {
+        None
+    };
+    render.distance_diffuse = if args.distance_diffuse {
+        Some(true)
+    } else {
+        None
+    };
+    render.distance_diffuse_threshold = if args.distance_diffuse_threshold != 1.0 {
+        Some(args.distance_diffuse_threshold)
+    } else {
+        None
+    };
+    render.distance_diffuse_curve = if args.distance_diffuse_curve != 1.0 {
+        Some(args.distance_diffuse_curve)
+    } else {
+        None
     };
 
     let global_opt =
@@ -567,4 +494,77 @@ pub(super) fn effective_to_config(
         render: Some(render),
         extra: Default::default(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::effective_to_config;
+    use crate::cli::command::{Commands, ParsedCli};
+
+    /// Build a fully-defaulted `render` arg set + `Cli` straight from clap, so
+    /// the test exercises the real defaults rather than a hand-rolled struct.
+    fn default_render_invocation() -> (crate::cli::command::Cli, crate::cli::command::RenderArgs) {
+        let parsed = ParsedCli::parse_from(["orender", "render"]).expect("parse defaults");
+        let cli = parsed.cli;
+        let args = match cli.command {
+            Commands::Render(ref a) => a.clone(),
+            _ => unreachable!("explicit render subcommand"),
+        };
+        (cli, args)
+    }
+
+    /// Regression guard for the report's §8.2: `--save-config` must NOT erase
+    /// fields the CLI cannot express. Previously `effective_to_config` rebuilt
+    /// the config from scratch and dropped these; now it mutates the existing
+    /// config, so they survive a save with no `--speaker-layout`.
+    #[test]
+    fn save_config_preserves_cli_unexpressible_fields() {
+        let (cli, args) = default_render_invocation();
+
+        let existing = renderer::config::RenderConfig {
+            live_input: Some(renderer::config::LiveInputConfig {
+                node: Some("omniphony_live".to_string()),
+                ..Default::default()
+            }),
+            input_mode: Some(renderer::config::InputModeConfig::Live),
+            current_layout: Some(renderer::speaker_layout::SpeakerLayout {
+                radius_m: 1.5,
+                speakers: vec![],
+            }),
+            hybrid_external_backend: Some("cube".to_string()),
+            experimental_distance_min_active_speakers: Some(3),
+            distance_model_metric: Some("chebyshev".to_string()),
+            render_backend: Some("barycenter".to_string()),
+            ..Default::default()
+        };
+
+        let out = effective_to_config(&args, &cli, Some(&existing)).expect("build config");
+        let render = out.render.expect("render section present");
+
+        assert!(render.live_input.is_some(), "live_input erased");
+        assert_eq!(
+            render.input_mode,
+            Some(renderer::config::InputModeConfig::Live)
+        );
+        assert_eq!(
+            render.current_layout.map(|l| l.radius_m),
+            Some(1.5),
+            "embedded current_layout erased"
+        );
+        assert_eq!(render.hybrid_external_backend.as_deref(), Some("cube"));
+        assert_eq!(render.experimental_distance_min_active_speakers, Some(3));
+        assert_eq!(render.distance_model_metric.as_deref(), Some("chebyshev"));
+        assert_eq!(render.render_backend.as_deref(), Some("barycenter"));
+    }
+
+    /// A CLI value still wins and is persisted (skip-if-default via the
+    /// descriptor) even when starting from an existing config.
+    #[test]
+    fn save_config_persists_pilot_field_from_args() {
+        let (cli, mut args) = default_render_invocation();
+        args.evaluation_polar_distance_res = 12;
+
+        let out = effective_to_config(&args, &cli, None).expect("build config");
+        assert_eq!(out.render.unwrap().vbap_distance_res, Some(12));
+    }
 }

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -58,12 +58,12 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("osc_host") {
-        if let Some(ref h) = cfg.osc_host {
-            args.osc_host = h.clone();
+        if let Some(h) = renderer::config_fields::osc_host::get(cfg) {
+            args.osc_host = h;
         }
     }
     if !arg_sources.is_explicit("osc_port") {
-        if let Some(p) = cfg.osc_port {
+        if let Some(p) = renderer::config_fields::osc_port::get(cfg) {
             args.osc_port = p;
         }
     }
@@ -201,7 +201,8 @@ pub(super) fn merge_render_config(
     }
     // osc
     if !arg_sources.is_explicit("osc") && !arg_sources.is_explicit("no_osc") {
-        args.osc = cfg.osc.unwrap_or(false);
+        args.osc =
+            renderer::config_fields::osc::get(cfg).unwrap_or(renderer::config_fields::osc::DEFAULT);
     } else if args.no_osc {
         args.osc = false;
     }
@@ -214,7 +215,7 @@ pub(super) fn merge_render_config(
     }
     // osc_rx_port (config can override the default 9000)
     if !arg_sources.is_explicit("osc_rx_port") {
-        if let Some(p) = cfg.osc_rx_port {
+        if let Some(p) = renderer::config_fields::osc_rx_port::get(cfg) {
             args.osc_rx_port = p;
         }
     }
@@ -397,23 +398,11 @@ pub(super) fn effective_to_config(
     render.room_ratio_rear = args.room_ratio_rear;
     render.room_ratio_lower = args.room_ratio_lower;
     render.room_ratio_center_blend = args.room_ratio_center_blend;
-    render.osc = if args.osc { Some(true) } else { None };
+    renderer::config_fields::osc::store(&mut render, args.osc);
     renderer::config_fields::osc_metering::store(&mut render, args.osc_metering);
-    render.osc_rx_port = if args.osc_rx_port != 9000 {
-        Some(args.osc_rx_port)
-    } else {
-        None
-    };
-    render.osc_host = if args.osc_host != "127.0.0.1" {
-        Some(args.osc_host.clone())
-    } else {
-        None
-    };
-    render.osc_port = if args.osc_port != 9000 {
-        Some(args.osc_port)
-    } else {
-        None
-    };
+    renderer::config_fields::osc_rx_port::store(&mut render, args.osc_rx_port);
+    renderer::config_fields::osc_host::store(&mut render, &args.osc_host);
+    renderer::config_fields::osc_port::store(&mut render, args.osc_port);
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
         render.output_device = args.output_device.clone();

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -136,8 +136,8 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("vbap_distance_model") {
-        if let Some(ref v) = cfg.vbap_distance_model {
-            args.vbap_distance_model = v.clone();
+        if let Some(v) = renderer::config_fields::vbap_distance_model::get(cfg) {
+            args.vbap_distance_model = v;
         }
     }
     if !arg_sources.is_explicit("master_gain") {
@@ -160,12 +160,12 @@ pub(super) fn merge_render_config(
         args.room_ratio_center_blend = cfg.room_ratio_center_blend;
     }
     if !arg_sources.is_explicit("spread_distance_range") {
-        if let Some(v) = cfg.spread_distance_range {
+        if let Some(v) = renderer::config_fields::spread_distance_range::get(cfg) {
             args.spread_distance_range = v;
         }
     }
     if !arg_sources.is_explicit("spread_distance_curve") {
-        if let Some(v) = cfg.spread_distance_curve {
+        if let Some(v) = renderer::config_fields::spread_distance_curve::get(cfg) {
             args.spread_distance_curve = v;
         }
     }
@@ -253,18 +253,19 @@ pub(super) fn merge_render_config(
     }
     // distance_diffuse (bool flag — no --no- override needed, just the flag)
     if !arg_sources.is_explicit("distance_diffuse") {
-        args.distance_diffuse = cfg.distance_diffuse.unwrap_or(false);
+        args.distance_diffuse = renderer::config_fields::distance_diffuse::get(cfg)
+            .unwrap_or(renderer::config_fields::distance_diffuse::DEFAULT);
     }
     if args.no_vbap_allow_negative_z {
         args.vbap_allow_negative_z = false;
     }
     if !arg_sources.is_explicit("distance_diffuse_threshold") {
-        if let Some(v) = cfg.distance_diffuse_threshold {
+        if let Some(v) = renderer::config_fields::distance_diffuse_threshold::get(cfg) {
             args.distance_diffuse_threshold = v;
         }
     }
     if !arg_sources.is_explicit("distance_diffuse_curve") {
-        if let Some(v) = cfg.distance_diffuse_curve {
+        if let Some(v) = renderer::config_fields::distance_diffuse_curve::get(cfg) {
             args.distance_diffuse_curve = v;
         }
     }
@@ -369,11 +370,7 @@ pub(super) fn effective_to_config(
     } else {
         None
     };
-    render.vbap_distance_model = if args.vbap_distance_model != "none" {
-        Some(args.vbap_distance_model.clone())
-    } else {
-        None
-    };
+    renderer::config_fields::vbap_distance_model::store(&mut render, &args.vbap_distance_model);
     render.master_gain = if args.master_gain != 0.0 {
         Some(args.master_gain)
     } else {
@@ -426,16 +423,8 @@ pub(super) fn effective_to_config(
     } else {
         None
     };
-    render.spread_distance_range = if args.spread_distance_range != 1.0 {
-        Some(args.spread_distance_range)
-    } else {
-        None
-    };
-    render.spread_distance_curve = if args.spread_distance_curve != 1.0 {
-        Some(args.spread_distance_curve)
-    } else {
-        None
-    };
+    renderer::config_fields::spread_distance_range::store(&mut render, args.spread_distance_range);
+    renderer::config_fields::spread_distance_curve::store(&mut render, args.spread_distance_curve);
     renderer::config_fields::vbap_spread_min::store(&mut render, args.vbap_spread_min);
     renderer::config_fields::vbap_spread_max::store(&mut render, args.vbap_spread_max);
     render.enable_adaptive_resampling = if args.enable_adaptive_resampling {
@@ -455,21 +444,15 @@ pub(super) fn effective_to_config(
     } else {
         None
     };
-    render.distance_diffuse = if args.distance_diffuse {
-        Some(true)
-    } else {
-        None
-    };
-    render.distance_diffuse_threshold = if args.distance_diffuse_threshold != 1.0 {
-        Some(args.distance_diffuse_threshold)
-    } else {
-        None
-    };
-    render.distance_diffuse_curve = if args.distance_diffuse_curve != 1.0 {
-        Some(args.distance_diffuse_curve)
-    } else {
-        None
-    };
+    renderer::config_fields::distance_diffuse::store(&mut render, args.distance_diffuse);
+    renderer::config_fields::distance_diffuse_threshold::store(
+        &mut render,
+        args.distance_diffuse_threshold,
+    );
+    renderer::config_fields::distance_diffuse_curve::store(
+        &mut render,
+        args.distance_diffuse_curve,
+    );
 
     let global_opt =
         if global.loglevel.is_none() && global.log_format.is_none() && global.strict.is_none() {

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -68,12 +68,12 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("evaluation_polar_azimuth_resolution") {
-        if let Some(v) = cfg.vbap_azimuth_resolution {
+        if let Some(v) = renderer::config_fields::vbap_azimuth_resolution::get(cfg) {
             args.evaluation_polar_azimuth_resolution = v;
         }
     }
     if !arg_sources.is_explicit("evaluation_polar_elevation_resolution") {
-        if let Some(v) = cfg.vbap_elevation_resolution {
+        if let Some(v) = renderer::config_fields::vbap_elevation_resolution::get(cfg) {
             args.evaluation_polar_elevation_resolution = v;
         }
     }
@@ -88,7 +88,7 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("evaluation_polar_distance_max") {
-        if let Some(v) = cfg.vbap_distance_max {
+        if let Some(v) = renderer::config_fields::vbap_distance_max::get(cfg) {
             args.evaluation_polar_distance_max = v;
         }
     }
@@ -96,7 +96,9 @@ pub(super) fn merge_render_config(
         && !arg_sources.is_explicit("no_render_evaluation_position_interpolation")
     {
         args.render_evaluation_position_interpolation =
-            cfg.render_evaluation_position_interpolation.unwrap_or(true);
+            renderer::config_fields::render_evaluation_position_interpolation::get(cfg).unwrap_or(
+                renderer::config_fields::render_evaluation_position_interpolation::DEFAULT,
+            );
     } else if args.no_render_evaluation_position_interpolation {
         args.render_evaluation_position_interpolation = false;
     }
@@ -168,12 +170,12 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("vbap_spread_min") {
-        if let Some(v) = cfg.vbap_spread_min {
+        if let Some(v) = renderer::config_fields::vbap_spread_min::get(cfg) {
             args.vbap_spread_min = v;
         }
     }
     if !arg_sources.is_explicit("vbap_spread_max") {
-        if let Some(v) = cfg.vbap_spread_max {
+        if let Some(v) = renderer::config_fields::vbap_spread_max::get(cfg) {
             args.vbap_spread_max = v;
         }
     }
@@ -326,16 +328,14 @@ pub(super) fn effective_to_config(
         render.speaker_layout = None;
     }
     render.vbap_table = args.vbap_table.clone();
-    render.vbap_azimuth_resolution = if args.evaluation_polar_azimuth_resolution != 360 {
-        Some(args.evaluation_polar_azimuth_resolution)
-    } else {
-        None
-    };
-    render.vbap_elevation_resolution = if args.evaluation_polar_elevation_resolution != 180 {
-        Some(args.evaluation_polar_elevation_resolution)
-    } else {
-        None
-    };
+    renderer::config_fields::vbap_azimuth_resolution::store(
+        &mut render,
+        args.evaluation_polar_azimuth_resolution,
+    );
+    renderer::config_fields::vbap_elevation_resolution::store(
+        &mut render,
+        args.evaluation_polar_elevation_resolution,
+    );
     render.vbap_spread = if args.vbap_spread != 0.0 {
         Some(args.vbap_spread)
     } else {
@@ -345,17 +345,14 @@ pub(super) fn effective_to_config(
         &mut render,
         args.evaluation_polar_distance_res,
     );
-    render.vbap_distance_max = if (args.evaluation_polar_distance_max - 2.0).abs() > f32::EPSILON {
-        Some(args.evaluation_polar_distance_max)
-    } else {
-        None
-    };
-    render.render_evaluation_position_interpolation =
-        if args.render_evaluation_position_interpolation {
-            Some(true)
-        } else {
-            None
-        };
+    renderer::config_fields::vbap_distance_max::store(
+        &mut render,
+        args.evaluation_polar_distance_max,
+    );
+    renderer::config_fields::render_evaluation_position_interpolation::store(
+        &mut render,
+        args.render_evaluation_position_interpolation,
+    );
     render.render_evaluation_mode = if args.render_evaluation_mode != EvaluationModeArg::Polar {
         Some(format!("{:?}", args.render_evaluation_mode).to_lowercase())
     } else {
@@ -439,16 +436,8 @@ pub(super) fn effective_to_config(
     } else {
         None
     };
-    render.vbap_spread_min = if args.vbap_spread_min != 0.0 {
-        Some(args.vbap_spread_min)
-    } else {
-        None
-    };
-    render.vbap_spread_max = if args.vbap_spread_max != 1.0 {
-        Some(args.vbap_spread_max)
-    } else {
-        None
-    };
+    renderer::config_fields::vbap_spread_min::store(&mut render, args.vbap_spread_min);
+    renderer::config_fields::vbap_spread_max::store(&mut render, args.vbap_spread_max);
     render.enable_adaptive_resampling = if args.enable_adaptive_resampling {
         Some(true)
     } else {

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -205,6 +205,13 @@ pub(super) fn merge_render_config(
     } else if args.no_osc {
         args.osc = false;
     }
+    // osc_metering (was never read from config → the flag had no effect)
+    if !arg_sources.is_explicit("osc_metering") && !arg_sources.is_explicit("no_osc_metering") {
+        args.osc_metering = renderer::config_fields::osc_metering::get(cfg)
+            .unwrap_or(renderer::config_fields::osc_metering::DEFAULT);
+    } else if args.no_osc_metering {
+        args.osc_metering = false;
+    }
     // osc_rx_port (config can override the default 9000)
     if !arg_sources.is_explicit("osc_rx_port") {
         if let Some(p) = cfg.osc_rx_port {
@@ -391,7 +398,7 @@ pub(super) fn effective_to_config(
     render.room_ratio_lower = args.room_ratio_lower;
     render.room_ratio_center_blend = args.room_ratio_center_blend;
     render.osc = if args.osc { Some(true) } else { None };
-    render.osc_metering = if args.osc_metering { Some(true) } else { None };
+    renderer::config_fields::osc_metering::store(&mut render, args.osc_metering);
     render.osc_rx_port = if args.osc_rx_port != 9000 {
         Some(args.osc_rx_port)
     } else {

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -22,8 +22,8 @@ pub(super) fn merge_render_config(
         args.output_sample_rate = cfg.output_sample_rate;
     }
     if !arg_sources.is_explicit("ramp_mode") {
-        if let Some(ref v) = cfg.ramp_mode {
-            if let Some(mode) = renderer::live_params::RampMode::from_str(v) {
+        if let Some(v) = renderer::config_fields::ramp_mode::get(cfg) {
+            if let Some(mode) = renderer::live_params::RampMode::from_str(&v) {
                 args.ramp_mode = match mode {
                     renderer::live_params::RampMode::Off => RampModeArg::Off,
                     renderer::live_params::RampMode::Frame => RampModeArg::Frame,
@@ -53,7 +53,7 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("presentation") {
-        if let Some(p) = cfg.presentation {
+        if let Some(p) = renderer::config_fields::presentation::get(cfg) {
             args.presentation = p.to_string();
         }
     }
@@ -330,11 +330,7 @@ pub(super) fn effective_to_config(
         }
         _ => None,
     };
-    render.presentation = if args.presentation != "best" {
-        args.presentation.parse::<u8>().ok()
-    } else {
-        None
-    };
+    renderer::config_fields::presentation::store(&mut render, &args.presentation);
     render.bridge_path = args.bridge_path.clone();
     renderer::config_fields::enable_vbap::store(&mut render, args.enable_vbap);
     // Persist the embedded layout instead of a path link. Only override when a
@@ -426,15 +422,14 @@ pub(super) fn effective_to_config(
     render.adaptive_resampling_update_interval_callbacks =
         args.adaptive_resampling_update_interval_callbacks;
     render.output_sample_rate = args.output_sample_rate;
-    render.ramp_mode = if args.ramp_mode != RampModeArg::Sample {
-        Some(match args.ramp_mode {
-            RampModeArg::Off => "off".to_string(),
-            RampModeArg::Frame => "frame".to_string(),
-            RampModeArg::Sample => "sample".to_string(),
-        })
-    } else {
-        None
-    };
+    renderer::config_fields::ramp_mode::store(
+        &mut render,
+        match args.ramp_mode {
+            RampModeArg::Off => "off",
+            RampModeArg::Frame => "frame",
+            RampModeArg::Sample => "sample",
+        },
+    );
     renderer::config_fields::distance_diffuse::store(&mut render, args.distance_diffuse);
     renderer::config_fields::distance_diffuse_threshold::store(
         &mut render,

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -141,7 +141,7 @@ pub(super) fn merge_render_config(
         }
     }
     if !arg_sources.is_explicit("master_gain") {
-        if let Some(v) = cfg.master_gain {
+        if let Some(v) = renderer::config_fields::master_gain::get(cfg) {
             args.master_gain = v;
         }
     }
@@ -219,13 +219,15 @@ pub(super) fn merge_render_config(
     }
     // use_loudness
     if !arg_sources.is_explicit("use_loudness") && !arg_sources.is_explicit("no_loudness") {
-        args.use_loudness = cfg.use_loudness.unwrap_or(false);
+        args.use_loudness = renderer::config_fields::use_loudness::get(cfg)
+            .unwrap_or(renderer::config_fields::use_loudness::DEFAULT);
     } else if args.no_loudness {
         args.use_loudness = false;
     }
     // auto_gain
     if !arg_sources.is_explicit("auto_gain") && !arg_sources.is_explicit("no_auto_gain") {
-        args.auto_gain = cfg.auto_gain.unwrap_or(false);
+        args.auto_gain = renderer::config_fields::auto_gain::get(cfg)
+            .unwrap_or(renderer::config_fields::auto_gain::DEFAULT);
     } else if args.no_auto_gain {
         args.auto_gain = false;
     }
@@ -371,11 +373,7 @@ pub(super) fn effective_to_config(
         None
     };
     renderer::config_fields::vbap_distance_model::store(&mut render, &args.vbap_distance_model);
-    render.master_gain = if args.master_gain != 0.0 {
-        Some(args.master_gain)
-    } else {
-        None
-    };
+    renderer::config_fields::master_gain::store(&mut render, args.master_gain);
     // The CLI works in ratios; metres are a save-time representation only, so
     // clear any metre fields a prior Studio save left behind to keep the ratio
     // representation authoritative on the next load.
@@ -415,8 +413,8 @@ pub(super) fn effective_to_config(
         render.latency_target = args.latency_target_ms;
     }
     render.continuous = if args.continuous { Some(true) } else { None };
-    render.use_loudness = if args.use_loudness { Some(true) } else { None };
-    render.auto_gain = if args.auto_gain { Some(true) } else { None };
+    renderer::config_fields::use_loudness::store(&mut render, args.use_loudness);
+    renderer::config_fields::auto_gain::store(&mut render, args.auto_gain);
     render.bed_conform = if args.bed_conform { Some(true) } else { None };
     render.spread_from_distance = if args.spread_from_distance {
         Some(true)

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -151,7 +151,11 @@ fn is_bridge_unavailable_error(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         let text = cause.to_string();
         text.contains("No bridge plugin found")
-            || text.contains("Bridge path '")
+            // Matches both `resolve_bridge_path` messages: "bridge path '…'" (CLI)
+            // and "render.bridge_path '…' (from config)". The previous
+            // "Bridge path '" (capital B) matched neither, so a bad/missing
+            // bridge path hard-exited instead of entering the idle OSC runtime.
+            || text.contains("does not exist or is not a file")
             || text.contains("Failed to load bridge plugin from")
             || text.contains("Bridge plugin is missing the `new_bridge` export")
     })


### PR DESCRIPTION
## Why

Every renderer option was hand-wired across ~6 independent sites, and each
option's default lived in 3–4 copies (clap `default_value_t`, the FFI
`from_render_config` `unwrap_or(..)`, and the "skip if == default" thresholds in
*both* config writers). These drift independently — the root cause of the
inconsistencies catalogued in `docs/orender-options-report.md` §8.

## What

Introduce `renderer/src/config_fields.rs`: one descriptor per option exposing a
single canonical `DEFAULT` plus a symmetric `get`/`store` (skip-if-default
centralised). Macros `render_field!` / `render_field_str!` (+ a few custom
descriptors) cover scalar bool/int/float/String options. Every read/write site
(clap default, config→args merge, FFI `from_render_config`, CLI writer
`effective_to_config`, live writer `save_live_config`/`amend_saved_config`) now
goes through the descriptor, so the default and skip-if-default can no longer
diverge.

**29 options migrated** (pilot + lots 1–5): the Polar/VBAP, distance/spread,
gain/loudness and OSC groups, plus the remaining simple scalars and two
special-cased options (`ramp_mode`, `presentation`).

**Deliberately not migrated** (a descriptor would add divergence or can't model
the field; see §10): `output_backend` (default already single-sourced via
`platform_default()`), `render_evaluation_mode` (CLI vs live value-space
mismatch), `vbap_allow_negative_z` (semantic tri-state), `room_*` (metres↔ratios
conversion), layout/live-input structs, and `Option<T>` pass-throughs.

## Bug fixes (found along the way)

1. **`--save-config` no longer erases CLI-unexpressible fields.**
   `effective_to_config` now starts from the existing config and overwrites only
   what the CLI controls, so `live_input`, embedded `current_layout`,
   `hybrid_*`, `experimental_*`, distance metrics, etc. survive a save (report
   §8.2).
2. **`osc_metering` is now functional.** It was write-only (persisted, never
   read/consumed). It now pre-enables metering on the configured default OSC
   target via `OscSender::set_default_metering` (report §8.1).
3. **Bad/missing bridge path now enters the idle OSC runtime.**
   `is_bridge_unavailable_error` matched `"Bridge path '"` but
   `resolve_bridge_path` emits lowercase `"bridge path '..."`; matched on the
   common substring instead.

Plus two default-asymmetry fixes that fall out of the shared `store`:
`render_evaluation_position_interpolation` and `ramp_mode` (the CLI writer
treated the wrong value as the default and dropped explicit non-defaults).

## Testing

- `cargo build`, full `cargo test` (0 failures incl. new `config_fields`
  round-trip/parity tests, a `config_resolution` §8.2 regression test, and an
  OSC registry test), `cargo fmt --check` clean.
- Manual `--save-config` round-trips for every migrated group (non-defaults
  persisted, defaults absent; flagless re-save preserves config values).
- Idle OSC runtime + `osc_metering` pre-enable verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)