### PR TITLE
Remove strict mode (live rendering never wants a premature stop)

### DIFF
--- a/omniphony-renderer/audio_input/src/bridge.rs
+++ b/omniphony-renderer/audio_input/src/bridge.rs
@@ -57,20 +57,15 @@ pub struct BridgeDecodeDiag {
     pub push_packet_dt_us: Arc<AtomicU64>,
 }
 
-pub fn spawn_bridge_decode_worker<OnFrame, OnFlush, OnFatal>(
+pub fn spawn_bridge_decode_worker<OnFrame>(
     bridge: FormatBridgeBox,
     raw_rx: mpsc::Receiver<(u8, Vec<u8>)>,
     requested_drc_mode: Option<Arc<RwLock<String>>>,
-    strict_mode: bool,
     diag: Option<BridgeDecodeDiag>,
     mut on_frame: OnFrame,
-    mut on_flush: OnFlush,
-    mut on_fatal: OnFatal,
 ) -> Result<thread::JoinHandle<()>>
 where
     OnFrame: FnMut(RDecodedFrame, f32) + Send + 'static,
-    OnFlush: FnMut() + Send + 'static,
-    OnFatal: FnMut(anyhow::Error) + Send + 'static,
 {
     thread::Builder::new()
         .name("bridge-decode".to_string())
@@ -120,15 +115,8 @@ where
                         result.error_message
                     );
                 }
-                if result.did_reset {
-                    if strict_mode && !result.error_message.is_empty() {
-                        on_fatal(anyhow!("{}", result.error_message));
-                        return;
-                    }
-                    if strict_mode {
-                        on_flush();
-                    }
-                }
+                // Bridge reset: keep audio running, never abort or flush. In live
+                // rendering we never want a premature stop (strict mode removed).
                 let frame_count = result.frames.len().max(1) as f32;
                 let per_frame_decode_time_ms = decode_time_ms / frame_count;
                 for frame in result.frames {

--- a/omniphony-renderer/orender_engine/src/bridge_loader.rs
+++ b/omniphony-renderer/orender_engine/src/bridge_loader.rs
@@ -19,16 +19,18 @@ pub struct LoadedBridge {
 }
 
 impl LoadedBridge {
-    /// Load a bridge plugin from `path` and create one instance with the given strict-mode flag.
+    /// Load a bridge plugin from `path` and create one instance.
     ///
     /// Format-specific options (e.g. presentation index) are applied afterwards via
     /// [`FormatBridgeBox::configure`] before the first [`FormatBridgeBox::push_packet`].
-    pub fn load_with_params(path: &Path, strict: bool) -> Result<Self> {
+    pub fn load_with_params(path: &Path) -> Result<Self> {
         let lib = BridgeLibRef::load_from_file(path)
             .with_context(|| format!("Failed to load bridge plugin from {}", path.display()))?;
         install_bridge_host_log_sink(&lib);
         let new_bridge = lib.new_bridge();
-        let bridge = new_bridge(strict);
+        // strict mode removed from the host; bridges ignore the flag. The ABI
+        // parameter is kept for compatibility and always passed as `false`.
+        let bridge = new_bridge(false);
         Ok(Self { lib, bridge })
     }
 
@@ -300,7 +302,11 @@ mod tests {
     // file next to the test binary and request it by bare relative name.
     #[test]
     fn relative_resolves_next_to_exe() {
-        let dir = std::env::current_exe().unwrap().parent().unwrap().to_path_buf();
+        let dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
         let name = format!("orender_{}_reltest_bridge.so", std::process::id());
         let full = dir.join(&name);
         fs::write(&full, b"x").unwrap();

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -179,7 +179,7 @@ impl Engine {
         // The renderer's table mode/defaults come from the bridge, so load and
         // configure it before building the renderer.
         let t_bridge = std::time::Instant::now();
-        let mut bridge = LoadedBridge::load_with_params(&resolved_bridge, false)?;
+        let mut bridge = LoadedBridge::load_with_params(&resolved_bridge)?;
         bridge.configure("presentation", "best");
         if let Some(codec) = input_codec {
             // Disambiguates the bridge's `Raw` transport (no data_type byte).

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -24,8 +24,6 @@ pub struct GlobalConfig {
     pub loglevel: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub log_format: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub strict: Option<bool>,
     /// See `Config::extra` — preserve unknown keys through round-trips.
     #[serde(flatten, default, skip_serializing_if = "Mapping::is_empty")]
     pub extra: Mapping,

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -31,14 +31,6 @@ pub struct Cli {
     #[arg(long, global = true, value_enum, default_value_t = LogLevel::Info)]
     pub loglevel: LogLevel,
 
-    /// Treat warnings as fatal errors (fail on first warning).
-    #[arg(long, global = true, conflicts_with = "no_strict")]
-    pub strict: bool,
-
-    /// Override config file 'strict' setting to false.
-    #[arg(long, global = true, conflicts_with = "strict")]
-    pub no_strict: bool,
-
     /// Log output format.
     #[arg(long, global = true, value_enum, default_value_t = LogFormat::Plain)]
     pub log_format: LogFormat,

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -293,7 +293,6 @@ pub(super) fn effective_to_config(
         } else {
             None
         },
-        strict: if cli.strict { Some(true) } else { None },
         extra: Default::default(),
     };
 
@@ -555,12 +554,11 @@ pub(super) fn effective_to_config(
         extra: Default::default(),
     };
 
-    let global_opt =
-        if global.loglevel.is_none() && global.log_format.is_none() && global.strict.is_none() {
-            None
-        } else {
-            Some(global)
-        };
+    let global_opt = if global.loglevel.is_none() && global.log_format.is_none() {
+        None
+    } else {
+        Some(global)
+    };
 
     Ok(Config {
         global: global_opt,

--- a/omniphony-renderer/src/cli/decode/decoder_thread.rs
+++ b/omniphony-renderer/src/cli/decode/decoder_thread.rs
@@ -64,7 +64,6 @@ pub struct PipeInputDiag {
 
 pub struct DecoderThreadConfig {
     pub input_path: std::path::PathBuf,
-    pub strict_mode: bool,
     pub continuous: bool,
     pub drain_pipe: bool,
     pub tx: mpsc::SyncSender<Result<DecoderMessage>>,
@@ -91,7 +90,6 @@ pub fn spawn_decoder_thread(config: DecoderThreadConfig) -> thread::JoinHandle<R
     thread::spawn(move || -> Result<()> {
         let DecoderThreadConfig {
             input_path,
-            strict_mode,
             continuous,
             drain_pipe,
             tx,
@@ -323,22 +321,11 @@ pub fn spawn_decoder_thread(config: DecoderThreadConfig) -> thread::JoinHandle<R
                     }
 
                     if result.did_reset {
-                        if strict_mode && !result.error_message.is_empty() {
-                            // Strict mode: propagate parse/decode error to handler.
-                            let _ = tx.send(Err(anyhow::anyhow!("{}", result.error_message)));
-                            return Ok(false);
-                        }
-                        // Non-strict: keep audio running through transient decoder resets.
-                        // Flushing here turns a recoverable bridge reset into an audible
-                        // dropout that can last much longer than the actual decode hiccup.
-                        if strict_mode {
-                            let _ =
-                                tx.send(Ok(DecoderMessage::FlushRequest(DecodedSource::Bridge)));
-                        } else {
-                            log::debug!(
-                                "Bridge reset in non-strict mode; keeping audio buffers intact"
-                            );
-                        }
+                        // Keep audio running through transient decoder resets — never
+                        // abort or flush. Flushing would turn a recoverable bridge reset
+                        // into an audible dropout much longer than the actual decode
+                        // hiccup; in live rendering we never want a premature stop.
+                        log::debug!("Bridge reset; keeping audio buffers intact");
                     }
 
                     let frame_count_in_packet = result.frames.len().max(1) as f32;

--- a/omniphony-renderer/src/cli/decode/live_input.rs
+++ b/omniphony-renderer/src/cli/decode/live_input.rs
@@ -86,7 +86,6 @@ struct PipewirePcmInputConfig {
 #[derive(Clone)]
 pub struct LiveBridgeRuntimeConfig {
     pub lib: bridge_api::BridgeLibRef,
-    pub strict_mode: bool,
     pub presentation: String,
     pub clock_mode: InputClockMode,
     pub requested_drc_mode: Arc<std::sync::RwLock<String>>,
@@ -127,7 +126,6 @@ impl ActiveCaptureConfig {
                     && lhs.sample_rate_hz == rhs.sample_rate_hz
                     && lhs.target_latency_ms == rhs.target_latency_ms
                     && lhs.clock_mode == rhs.clock_mode
-                    && lhs.runtime.strict_mode == rhs.runtime.strict_mode
                     && lhs.runtime.presentation == rhs.runtime.presentation
             }
             _ => false,
@@ -731,7 +729,6 @@ fn run_pipewire_bridge_capture_loop(
     let (raw_tx, raw_rx) = mpsc::sync_channel::<(u8, Vec<u8>)>(256);
     let bridge = instantiate_live_bridge(&config.runtime)?;
     let tx_for_frame = tx.clone();
-    let tx_for_flush = tx.clone();
     // DIAG iec958-chain: capture bridge plugin output cadence. Registry-handed
     // diag metrics — updated each time the harletty plugin emits a decoded
     // PCM frame, so the Studio plot can see whether the plugin batches
@@ -760,7 +757,6 @@ fn run_pipewire_bridge_capture_loop(
         bridge,
         raw_rx,
         Some(config.runtime.requested_drc_mode.clone()),
-        config.runtime.strict_mode,
         Some(BridgeDecodeDiag {
             frames_per_push_packet: bridge_frames_per_push_packet_out,
             push_packet_dt_us: bridge_push_packet_dt_us_out,
@@ -797,12 +793,6 @@ fn run_pipewire_bridge_capture_loop(
                 decode_time_ms,
                 sent_at: Instant::now(),
             })));
-        },
-        move || {
-            let _ = tx_for_flush.try_send(Ok(DecoderMessage::FlushRequest(DecodedSource::Bridge)));
-        },
-        move |err| {
-            let _ = tx.try_send(Err(err));
         },
     )?;
     let ingest = LiveBridgeIngestRuntime::new(raw_tx);
@@ -1746,7 +1736,8 @@ fn run_pipewire_bridge_capture_stream(
 fn instantiate_live_bridge(runtime: &LiveBridgeRuntimeConfig) -> Result<FormatBridgeBox> {
     install_bridge_host_log_sink(&runtime.lib);
     let new_bridge = runtime.lib.new_bridge();
-    let mut bridge = new_bridge(runtime.strict_mode);
+    // strict mode removed: bridges ignore it; the host always requests non-strict.
+    let mut bridge = new_bridge(false);
     if !bridge.configure("presentation".into(), runtime.presentation.as_str().into()) {
         anyhow::bail!(
             "Bridge rejected presentation value '{}'",

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -6,10 +6,9 @@ use super::decoder_thread::{
 };
 use super::handler::DecodeHandler;
 use super::live_input::{LiveBridgeRuntimeConfig, spawn_live_input_manager};
-use super::state::{FrameHandlerContext, WriterState};
+use super::state::FrameHandlerContext;
 use crate::cli::command::{Cli, EvaluationModeArg, OutputBackend, RenderArgSources, RenderArgs};
 use anyhow::Result;
-use log::Level;
 use orender_engine::bridge_loader::{LoadedBridge, resolve_bridge_path};
 use std::sync::mpsc;
 use std::sync::{Arc, atomic::AtomicU64};
@@ -34,7 +33,6 @@ const IDLE_BRIDGE_PREFERRED_EVALUATION_MODE: bridge_api::RVbapTableMode =
     bridge_api::RVbapTableMode::Cartesian;
 
 struct PreparedDecodeRun {
-    state: WriterState,
     tx: mpsc::SyncSender<Result<DecoderMessage>>,
     rx: mpsc::Receiver<Result<DecoderMessage>>,
     cmd_tx: mpsc::Sender<DecoderCommand>,
@@ -47,7 +45,6 @@ struct PreparedDecodeRun {
     _shutdown: sys::ShutdownHandle,
     bridge_lib: bridge_api::BridgeLibRef,
     input_path: std::path::PathBuf,
-    strict_mode: bool,
     presentation: String,
     is_spatial_presentation: bool,
     coordinate_format: bridge_api::RCoordinateFormat,
@@ -177,7 +174,7 @@ fn maybe_save_effective_config(
     Ok(true)
 }
 
-fn prepare_render_run(args: &RenderArgs, cli: &Cli) -> Result<PreparedDecodeRun> {
+fn prepare_render_run(args: &RenderArgs) -> Result<PreparedDecodeRun> {
     let input = args
         .input
         .as_ref()
@@ -185,9 +182,8 @@ fn prepare_render_run(args: &RenderArgs, cli: &Cli) -> Result<PreparedDecodeRun>
         .clone();
 
     log::info!(
-        "Decoding stream from file: {} (strict mode: {}, presentation: {})",
+        "Decoding stream from file: {} (presentation: {})",
         input.display(),
-        cli.strict,
         args.presentation
     );
 
@@ -201,18 +197,9 @@ fn prepare_render_run(args: &RenderArgs, cli: &Cli) -> Result<PreparedDecodeRun>
         ));
     }
 
-    let strict_mode = cli.strict;
-    let fail_level = if strict_mode {
-        Level::Warn
-    } else {
-        Level::Error
-    };
-    let state = WriterState { fail_level };
-
     let bridge_path = resolve_bridge_path(args.bridge_path.as_deref())?;
     log::info!("Loading format bridge: {}", bridge_path.display());
-    let LoadedBridge { lib, mut bridge } =
-        LoadedBridge::load_with_params(&bridge_path, strict_mode)?;
+    let LoadedBridge { lib, mut bridge } = LoadedBridge::load_with_params(&bridge_path)?;
     if !bridge.configure("presentation".into(), args.presentation.as_str().into()) {
         return Err(anyhow::anyhow!(
             "Bridge rejected presentation value '{}'",
@@ -270,7 +257,6 @@ fn prepare_render_run(args: &RenderArgs, cli: &Cli) -> Result<PreparedDecodeRun>
 
     let decode_thread = spawn_decoder_thread(DecoderThreadConfig {
         input_path: input.clone(),
-        strict_mode,
         continuous: args.continuous,
         drain_pipe: !args.no_drain_pipe,
         tx: tx.clone(),
@@ -282,7 +268,6 @@ fn prepare_render_run(args: &RenderArgs, cli: &Cli) -> Result<PreparedDecodeRun>
     });
 
     Ok(PreparedDecodeRun {
-        state,
         tx,
         rx,
         cmd_tx,
@@ -293,7 +278,6 @@ fn prepare_render_run(args: &RenderArgs, cli: &Cli) -> Result<PreparedDecodeRun>
         _shutdown: shutdown,
         bridge_lib: lib,
         input_path: input,
-        strict_mode,
         presentation: args.presentation.clone(),
         is_spatial_presentation,
         coordinate_format,
@@ -433,7 +417,6 @@ fn handle_stream_end(handler: &mut DecodeHandler, args: &RenderArgs) -> Result<(
 struct DecodeRunContext<'a> {
     args: &'a RenderArgs,
     effective_output_backend: OutputBackend,
-    state: &'a WriterState,
 }
 
 fn handle_audio_message(
@@ -458,7 +441,6 @@ fn handle_audio_message(
 
     let ctx = FrameHandlerContext {
         output_backend: ctx.effective_output_backend,
-        state: ctx.state,
         bed_conform: ctx.args.bed_conform,
         use_loudness: ctx.args.use_loudness,
         decode_time_ms: decoded.decode_time_ms,
@@ -562,7 +544,6 @@ fn run_render_message_phase(
     let run_ctx = DecodeRunContext {
         args,
         effective_output_backend,
-        state: &prepared.state,
     };
 
     sys::notify_ready();
@@ -766,7 +747,6 @@ fn run_prepared_render(
                 audio_control.clone(),
                 LiveBridgeRuntimeConfig {
                     lib: prepared.bridge_lib.clone(),
-                    strict_mode: prepared.strict_mode,
                     presentation: prepared.presentation.clone(),
                     clock_mode: input_control.requested_snapshot().clock_mode,
                     requested_drc_mode: live_drc_mode.clone(),
@@ -818,7 +798,7 @@ pub fn cmd_render(args: &RenderArgs, cli: &Cli, arg_sources: &RenderArgSources<'
             return Ok(());
         }
 
-        let bridge_path_after_run = match prepare_render_run(args, cli) {
+        let bridge_path_after_run = match prepare_render_run(args) {
             Ok(prepared) => run_prepared_render(
                 prepared,
                 args,

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -4,7 +4,6 @@ use audio_output::AdaptiveResamplingConfig;
 #[cfg(target_os = "linux")]
 use audio_output::pipewire::PipewireBufferConfig;
 use bridge_api::RCoordinateFormat;
-use log::Level;
 use orender_engine::osc::OscSender;
 use renderer::metering::AudioMeter;
 use std::sync::Arc;
@@ -51,10 +50,6 @@ impl DiagPublishCadence {
     pub fn mark_sent(&mut self, now: Instant) {
         self.last_send_at = Some(now);
     }
-}
-
-pub struct WriterState {
-    pub fail_level: Level,
 }
 
 #[derive(Clone)]
@@ -230,9 +225,8 @@ impl Default for DecodeSessionState {
     }
 }
 
-pub struct FrameHandlerContext<'a> {
+pub struct FrameHandlerContext {
     pub output_backend: OutputBackend,
-    pub state: &'a WriterState,
     pub bed_conform: bool,
     pub use_loudness: bool,
     pub decode_time_ms: f32,

--- a/omniphony-renderer/src/main.rs
+++ b/omniphony-renderer/src/main.rs
@@ -130,19 +130,9 @@ fn main() -> Result<()> {
             .unwrap_or(cli.log_format)
     };
 
-    // Resolve effective strict: --strict → true, --no-strict → false, else config.
-    let effective_strict = if parsed.is_explicit("strict") {
-        true
-    } else if parsed.is_explicit("no_strict") {
-        false
-    } else {
-        global_cfg.strict.unwrap_or(false)
-    };
-
     // Apply effective values back to cli so downstream code (cmd_render etc.) sees them.
     cli.loglevel = effective_loglevel;
     cli.log_format = effective_log_format;
-    cli.strict = effective_strict;
 
     let base_level = cli.loglevel.to_level_filter();
 


### PR DESCRIPTION
## Why

`--strict` only made sense for bit-perfect **file** output. In live rendering we
never want a premature stop at any cost. Tracing showed strict's only real
effect was aborting/flushing the decode on a transient bridge reset
(`decoder_thread` / live PipeWire bridge worker), plus a dead `WriterState.fail_level`
that was computed but never read.

## What

Remove strict mode from the renderer:

- **CLI**: drop the global `--strict` / `--no-strict` flags and their resolution
  in `main.rs`.
- **Config**: drop `GlobalConfig.strict`. A legacy `global.strict` in an existing
  config is now ignored on load (captured by `#[serde(flatten)] extra`) and
  dropped on the next `--save-config` — harmless cleanup, no parse error.
- **Decode**: a bridge reset now always keeps audio buffers intact — never abort,
  never flush — in both the pipe-bridge decoder thread and the live PipeWire
  bridge worker.
- Remove the now-dead `WriterState` / `fail_level` plumbing and the
  `on_flush` / `on_fatal` callbacks of `spawn_bridge_decode_worker` (they existed
  only for strict).

The bridge ABI `new_bridge(strict: bool)` is **kept** (no ABI break, no bridge /
cross-project changes); the host always passes `false`, and harletty-bridge
already ignored the flag.

## Testing

- `cargo build`, full `cargo test` (0 failures), `cargo fmt --check` clean.
- `--strict` is now rejected (`unexpected argument`); `--save-config` no longer
  writes `strict`; a legacy config with `global.strict: true` loads fine and the
  key is cleaned out on re-save.

Note: also rustfmt's a pre-existing whitespace drift in `bridge_loader.rs` (test)
so this branch's fmt gate is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)