### PR TITLE
fix(meters): truthful peak cursor on audio level meters (objects, speakers, master)

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc/state_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/state_emit.rs
@@ -260,6 +260,13 @@ impl OscSender {
                 args: vec![OscType::Float(peak), OscType::Float(rms)],
             }));
         }
+        messages.push(OscPacket::Message(OscMessage {
+            addr: "/omniphony/meter/master".to_string(),
+            args: vec![
+                OscType::Float(snapshot.master_peak),
+                OscType::Float(snapshot.master_rms),
+            ],
+        }));
 
         let bundle = OscPacket::Bundle(OscBundle {
             timetag: OscTime {

--- a/omniphony-renderer/renderer/src/metering.rs
+++ b/omniphony-renderer/renderer/src/metering.rs
@@ -17,6 +17,11 @@ pub struct MeterSnapshot {
     pub object_levels: Vec<(u32, f32, f32)>,
     /// (peak_dbfs, rms_dbfs) — one per output speaker
     pub speaker_levels: Vec<(f32, f32)>,
+    /// Master output level (peak_dbfs, rms_dbfs), aggregated from the
+    /// post-master-gain speaker accumulators: peak = max over speakers, rms =
+    /// combined RMS across all speakers over the send interval.
+    pub master_peak: f32,
+    pub master_rms: f32,
 }
 
 pub struct AudioMeter {
@@ -150,6 +155,23 @@ impl AudioMeter {
             })
             .collect();
 
+        // Master = aggregate of the post-master-gain speaker accumulators.
+        // Peak is the loudest speaker sample; RMS is the combined energy across
+        // all speakers over the interval. Free: no extra per-sample work.
+        let master_peak = linear_to_dbfs(
+            self.spk_peak[..self.num_speakers]
+                .iter()
+                .copied()
+                .fold(0.0f32, f32::max),
+        );
+        let master_rms = if self.num_speakers == 0 {
+            DBFS_FLOOR
+        } else {
+            let energy: f64 = self.spk_rms_sq[..self.num_speakers].iter().sum();
+            let total = (self.num_speakers as f64) * (spk_count as f64);
+            linear_to_dbfs((energy / total).sqrt() as f32)
+        };
+
         // Reset accumulators
         for v in &mut self.obj_peak {
             *v = 0.0;
@@ -170,6 +192,42 @@ impl AudioMeter {
         Some(MeterSnapshot {
             object_levels,
             speaker_levels,
+            master_peak,
+            master_rms,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn master_peak_is_loudest_speaker_and_survives_over_0_dbfs() {
+        // 1 kHz send rate → ~1 ms interval, so a short sleep lets poll() fire.
+        let mut m = AudioMeter::new(2, 1000.0);
+        // 2 speakers, 2 frames. spk0 hits 1.3 linear (> 1.0 → over 0 dBFS).
+        let interleaved = [1.3f32, 0.5, 0.2, 0.5];
+        m.process_speakers(&interleaved, 2);
+
+        std::thread::sleep(Duration::from_millis(3));
+        let snap = m.poll().expect("send interval should have elapsed");
+
+        // Master peak == loudest speaker peak, and the over-0 dBFS value is kept.
+        let expected = 20.0 * 1.3f32.log10();
+        assert!(
+            (snap.master_peak - expected).abs() < 1e-3,
+            "master_peak = {} (expected ≈ {})",
+            snap.master_peak,
+            expected
+        );
+        assert!(snap.master_peak > 0.0, "over-0 dBFS peak flattened");
+
+        let spk_max = snap
+            .speaker_levels
+            .iter()
+            .map(|&(p, _)| p)
+            .fold(f32::MIN, f32::max);
+        assert!((snap.master_peak - spk_max).abs() < 1e-6);
     }
 }

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -308,6 +308,8 @@ pub struct AppState {
     pub source_levels: HashMap<String, Meter>,
     #[serde(rename = "speakerLevels")]
     pub speaker_levels: HashMap<String, Meter>,
+    #[serde(rename = "masterLevel")]
+    pub master_level: Option<Meter>,
     #[serde(rename = "objectSpeakerGains")]
     pub object_speaker_gains: HashMap<String, Vec<f64>>,
     #[serde(rename = "objectGains")]
@@ -628,6 +630,7 @@ impl Default for AppState {
             sources: HashMap::new(),
             source_levels: HashMap::new(),
             speaker_levels: HashMap::new(),
+            master_level: None,
             object_speaker_gains: HashMap::new(),
             object_gains: HashMap::new(),
             speaker_gains: HashMap::new(),

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -1598,6 +1598,25 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                 )
             }
 
+            OscEvent::MeterMaster {
+                peak_dbfs,
+                rms_dbfs,
+            } => {
+                s.master_level = Some(Meter {
+                    peak_dbfs,
+                    rms_dbfs,
+                });
+                (
+                    Some((
+                        "master:meter",
+                        serde_json::json!({
+                            "meter": { "peakDbfs": peak_dbfs, "rmsDbfs": rms_dbfs }
+                        }),
+                    )),
+                    removed_ids,
+                )
+            }
+
             OscEvent::MeterDrcGain { value } => (
                 Some(("meter:drc_gain", serde_json::json!({ "value": value }))),
                 removed_ids,

--- a/omniphony-studio/src-tauri/src/osc_parser.rs
+++ b/omniphony-studio/src-tauri/src/osc_parser.rs
@@ -175,6 +175,14 @@ pub enum OscEvent {
         rms_dbfs: f64,
     },
 
+    #[serde(rename = "meter:master")]
+    MeterMaster {
+        #[serde(rename = "peakDbfs")]
+        peak_dbfs: f64,
+        #[serde(rename = "rmsDbfs")]
+        rms_dbfs: f64,
+    },
+
     #[serde(rename = "meter:drc_gain")]
     MeterDrcGain { value: f64 },
 
@@ -882,7 +890,10 @@ fn parse_meter(parts: &[&str], args: &[f64]) -> Option<OscEvent> {
     if after.len() >= 3 {
         let kind = after[1];
         let id = after[2].to_string();
-        let peak = clamp(to_number(args[0]).unwrap_or(-100.0), -100.0, 0.0);
+        // Peak ceiling is left high (+24 dBFS) so true over-0 dBFS peaks
+        // (clipping) reach the UI instead of being flattened to 0; the RMS that
+        // drives the bar stays bounded for a clean fill.
+        let peak = clamp(to_number(args[0]).unwrap_or(-100.0), -100.0, 24.0);
         let rms = clamp(to_number(args[1]).unwrap_or(-100.0), -100.0, 0.0);
         match kind {
             "object" => {
@@ -901,6 +912,23 @@ fn parse_meter(parts: &[&str], args: &[f64]) -> Option<OscEvent> {
             }
             _ => {}
         }
+    }
+
+    if after.len() == 2 && after[1] == "master" {
+        let peak = clamp(
+            args.get(0).copied().and_then(to_number).unwrap_or(-100.0),
+            -100.0,
+            24.0,
+        );
+        let rms = clamp(
+            args.get(1).copied().and_then(to_number).unwrap_or(-100.0),
+            -100.0,
+            0.0,
+        );
+        return Some(OscEvent::MeterMaster {
+            peak_dbfs: peak,
+            rms_dbfs: rms,
+        });
     }
 
     if after.len() == 2 && after[1] == "drc_gain" {

--- a/omniphony-studio/src/controls/master.js
+++ b/omniphony-studio/src/controls/master.js
@@ -9,11 +9,12 @@ import {
   dirty,
   speakerLevels,
   supportsRealtimeKey,
-  masterPeak
+  masterPeak,
+  masterLevel
 } from '../state.js';
 import { t, tf } from '../i18n.js';
 import { formatNumber } from '../coordinates.js';
-import { linearToDb, dbToLinear } from '../mute-solo.js';
+import { linearToDb, dbToMeterPercent, METER_DB_MIN } from '../mute-solo.js';
 import { scheduleUIFlush } from '../flush.js';
 import { inAudioPanel, inRendererPanel, inDrcPanel } from '../ui/panel-roots.js';
 
@@ -101,17 +102,35 @@ export function flashClipIndicator() {
   }, 1000);
 }
 
-export function getAverageSpeakerRmsDb() {
-  const valid = Array.from(speakerLevels.values()).filter(
-    (meter) => meter && typeof meter.rmsDbfs === 'number'
+// Master output meter. Preferred source: the engine's post-master-gain
+// /omniphony/meter/master (state.masterLevel). Fallback when that message is
+// absent (older engine / un-rebuilt backend): derive it from the speaker
+// meters — master peak = loudest speaker peak (identical to the engine's
+// max(spk_peak), speakers are already metered post-master-gain), master RMS ≈
+// combined speaker energy. Returns { peakDb, rmsDb } or null when no data.
+function getMasterMeter() {
+  if (masterLevel && typeof masterLevel.rmsDbfs === 'number') {
+    const rmsDb = masterLevel.rmsDbfs;
+    return {
+      rmsDb,
+      peakDb: typeof masterLevel.peakDbfs === 'number' ? masterLevel.peakDbfs : rmsDb
+    };
+  }
+  const speakers = Array.from(speakerLevels.values()).filter(
+    (m) => m && typeof m.peakDbfs === 'number'
   );
-  if (valid.length === 0) {
+  if (speakers.length === 0) {
     return null;
   }
-  const sumLinear = valid.reduce((acc, meter) => acc + dbToLinear(meter.rmsDbfs), 0);
-  const avgLinear = sumLinear / valid.length;
-  const avgDb = 20 * Math.log10(Math.max(avgLinear, 1e-6));
-  return Math.max(-100, Math.min(0, avgDb));
+  let peakDb = METER_DB_MIN;
+  let sumSquares = 0;
+  for (const m of speakers) {
+    if (m.peakDbfs > peakDb) peakDb = m.peakDbfs;
+    const rmsLin = Math.pow(10, (typeof m.rmsDbfs === 'number' ? m.rmsDbfs : -100) / 20);
+    sumSquares += rmsLin * rmsLin;
+  }
+  const rmsLin = Math.sqrt(sumSquares / speakers.length);
+  return { peakDb, rmsDb: rmsLin > 0 ? 20 * Math.log10(rmsLin) : METER_DB_MIN };
 }
 
 export function updateMasterMeterUI() {
@@ -120,34 +139,42 @@ export function updateMasterMeterUI() {
   const masterMeterPeakEl = inAudioPanel('masterMeterPeak');
 
   if (!masterMeterTextEl || !masterMeterFillEl) return;
-  const avgDb = getAverageSpeakerRmsDb();
-  if (avgDb === null) {
+
+  const level = getMasterMeter();
+  if (!level) {
     masterMeterTextEl.textContent = t('status.masterMeter');
     masterMeterFillEl.style.setProperty('--level', '0%');
-    if (masterMeterPeakEl) masterMeterPeakEl.style.opacity = '0';
+    if (masterMeterPeakEl) {
+      masterMeterPeakEl.style.opacity = '0';
+      masterMeterPeakEl.classList.remove('over');
+    }
     return;
   }
-  const levelPercent = ((avgDb + 100) / 100) * 100;
+
+  const rmsDb = level.rmsDb;
+  const peakDb = level.peakDb;
+  // Bar follows the peak (same quantity as the hold cursor) so they meet on
+  // transients; RMS stays as the numeric readout.
+  const levelPercent = dbToMeterPercent(peakDb);
   masterMeterFillEl.style.setProperty('--level', `${levelPercent.toFixed(1)}%`);
 
   const now = Date.now();
-  if (avgDb >= (masterPeak.db ?? -100) || now > masterPeak.expires) {
-    if (avgDb >= (masterPeak.db ?? -100)) {
-      masterPeak.db = avgDb;
-      masterPeak.value = levelPercent;
-      masterPeak.expires = now + 1000;
-    } else {
-      masterPeak.db = Math.max(avgDb, masterPeak.db - 2.0);
-      masterPeak.value = ((Math.max(-100, masterPeak.db) + 100) / 100) * 100;
-      if (masterPeak.value <= levelPercent + 0.1) masterPeak.expires = now + 1000;
-    }
+  if (peakDb >= (masterPeak.db ?? METER_DB_MIN)) {
+    masterPeak.db = peakDb;
+    masterPeak.value = dbToMeterPercent(peakDb);
+    masterPeak.expires = now + 1000;
+  } else if (now > masterPeak.expires) {
+    masterPeak.db = Math.max(peakDb, masterPeak.db - 2.0);
+    masterPeak.value = dbToMeterPercent(masterPeak.db);
+    if (masterPeak.value <= levelPercent + 0.1) masterPeak.expires = now + 1000;
   }
 
-  masterMeterTextEl.textContent = `${formatNumber(masterPeak.db ?? avgDb, 1)} dB`;
+  masterMeterTextEl.textContent = `${formatNumber(rmsDb, 1)} dB`;
 
   if (masterMeterPeakEl) {
     masterMeterPeakEl.style.setProperty('--level', `${masterPeak.value.toFixed(1)}%`);
     masterMeterPeakEl.style.opacity = masterPeak.value > 0.1 ? '1' : '0';
+    masterMeterPeakEl.classList.toggle('over', (masterPeak.db ?? METER_DB_MIN) >= 0);
   }
 }
 

--- a/omniphony-studio/src/mute-solo.js
+++ b/omniphony-studio/src/mute-solo.js
@@ -45,10 +45,21 @@ export function formatLevel(meter) {
   return `${formatNumber(meter.rmsDbfs, 1)} dB`;
 }
 
+// Meter scale: -60 dBFS at the bottom, +6 dBFS at the top. 0 dBFS sits at
+// dbToMeterPercent(0) ≈ 90.9%, leaving a headroom (over-0) zone above it so
+// true clipping peaks are visible instead of being flattened at the top.
+export const METER_DB_MIN = -60;
+export const METER_DB_MAX = 6;
+
+export function dbToMeterPercent(db) {
+  const v = Number.isFinite(db) ? db : METER_DB_MIN;
+  const pct = ((v - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN)) * 100;
+  return Math.min(100, Math.max(0, pct));
+}
+
 export function meterToPercent(meter) {
-  const db = typeof meter?.rmsDbfs === 'number' ? meter.rmsDbfs : -100;
-  const clamped = Math.min(0, Math.max(-100, db));
-  return ((clamped + 100) / 100) * 100;
+  const db = typeof meter?.rmsDbfs === 'number' ? meter.rmsDbfs : METER_DB_MIN;
+  return dbToMeterPercent(db);
 }
 
 export function linearToDb(value) {
@@ -71,29 +82,42 @@ export function dbToLinear(db) {
 // Meter UI
 // ---------------------------------------------------------------------------
 
+// Shared peak-hold for the level meters: the bar (meterFill) follows the RMS,
+// while the cursor holds the engine-reported true sample peak (peakDbfs) with a
+// 1 s hold then decay. The cursor turns red (`.over`) once the held peak crosses
+// 0 dBFS, into the headroom zone.
+export function updatePeakHold(peaksMap, id, peakDb, levelPercent, now) {
+  let peak = id !== null ? peaksMap.get(id) : null;
+  if (!peak || peakDb >= (peak.db ?? METER_DB_MIN)) {
+    peak = { value: dbToMeterPercent(peakDb), db: peakDb, expires: now + 1000 };
+    if (id !== null) peaksMap.set(id, peak);
+  } else if (now > peak.expires) {
+    peak.db = Math.max(peakDb, peak.db - 2.0); // Decay DB value
+    peak.value = dbToMeterPercent(peak.db);
+    if (peak.value <= levelPercent + 0.1) peak.expires = now + 1000;
+  }
+  return peak;
+}
+
 export function updateMeterUI(entry, meter, type = null, id = null) {
   if (!entry) return;
-  const levelPercent = meterToPercent(meter);
-  const currentDb = typeof meter?.rmsDbfs === 'number' ? meter.rmsDbfs : -100;
+  const rmsDb = typeof meter?.rmsDbfs === 'number' ? meter.rmsDbfs : METER_DB_MIN;
+  const peakDb = typeof meter?.peakDbfs === 'number' ? meter.peakDbfs : rmsDb;
+  // Bar and cursor are the same quantity (peak) so the fill rises to the hold
+  // marker on transients instead of leaving a permanent crest-factor gap; the
+  // RMS stays as the numeric readout.
+  const levelPercent = dbToMeterPercent(peakDb);
 
   if (entry.peakCursor) {
     const now = Date.now();
     const peaksMap = type === 'speaker' ? speakerPeaks : sourcePeaks;
-    let peak = id !== null ? peaksMap.get(id) : null;
+    const peak = updatePeakHold(peaksMap, id, peakDb, levelPercent, now);
 
-    if (!peak || currentDb >= (peak.db ?? -100)) {
-      peak = { value: levelPercent, db: currentDb, expires: now + 1000 };
-      if (id !== null) peaksMap.set(id, peak);
-    } else if (now > peak.expires) {
-      peak.db = Math.max(currentDb, peak.db - 2.0); // Decay DB value
-      peak.value = ((Math.max(-100, peak.db) + 100) / 100) * 100;
-      if (peak.value <= levelPercent + 0.1) peak.expires = now + 1000;
-    }
-
-    entry.levelText.textContent = `${formatNumber(peak.db ?? currentDb, 1)} dB`;
+    entry.levelText.textContent = `${formatNumber(rmsDb, 1)} dB`;
     entry.meterFill.style.setProperty('--level', `${levelPercent.toFixed(1)}%`);
     entry.peakCursor.style.setProperty('--level', `${peak.value.toFixed(1)}%`);
     entry.peakCursor.style.opacity = peak.value > 0.1 ? '1' : '0';
+    entry.peakCursor.classList.toggle('over', (peak.db ?? METER_DB_MIN) >= 0);
   } else {
     entry.levelText.textContent = formatLevel(meter);
     entry.meterFill.style.setProperty('--level', `${levelPercent.toFixed(1)}%`);

--- a/omniphony-studio/src/oscParser.js
+++ b/omniphony-studio/src/oscParser.js
@@ -459,7 +459,9 @@ function parseMeterMessage(parts, args) {
     return null;
   }
 
-  const peakDbfs = clamp(toNumber(args[0]) ?? -100, -100, 0);
+  // Peak ceiling left high (+24 dBFS) so over-0 dBFS clipping peaks survive to
+  // the UI; the RMS that drives the bar stays bounded at 0.
+  const peakDbfs = clamp(toNumber(args[0]) ?? -100, -100, 24);
   const rmsDbfs = clamp(toNumber(args[1]) ?? -100, -100, 0);
 
   return {

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -37,6 +37,7 @@ import {
   dirty,
   dirtySpeakerMeters,
   dirtyObjectMeters,
+  setMasterLevel,
   METER_DECAY_START_MS,
   METER_DECAY_DB_PER_SEC,
   DEFAULT_SAMPLE_RATE_HZ
@@ -584,7 +585,7 @@ export function createSpeakerItem(id, speaker) {
   level.appendChild(levelText);
 
   const meterBar = document.createElement('div');
-  meterBar.className = 'meter-bar';
+  meterBar.className = 'meter-bar level-meter';
   const meterFill = document.createElement('div');
   meterFill.className = 'meter-fill';
   const peakCursor = document.createElement('div');
@@ -635,6 +636,7 @@ export function createSpeakerItem(id, speaker) {
 
   return {
     root,
+    idStrip,
     label: idText,
     levelText,
     meterFill,
@@ -652,9 +654,10 @@ export function createSpeakerItem(id, speaker) {
 const speakerClipTimers = new Map();
 
 /**
- * Flash the background of a speaker row red for 1 s when that speaker clips.
- * Driven by the renderer's `/omniphony/state/clip <idx>` event; works regardless
- * of the auto-gain toggle. Mirrors the master clip indicator's remanence.
+ * Flash the speaker's name chip (`.id-strip`) red for 1 s when that speaker
+ * clips. Driven by the renderer's `/omniphony/state/clip <idx>` event; works
+ * regardless of the auto-gain toggle. Mirrors the master clip indicator's
+ * remanence.
  */
 export function flashSpeakerClip(index) {
   if (!Number.isInteger(index) || index < 0) {
@@ -662,13 +665,14 @@ export function flashSpeakerClip(index) {
   }
   const id = String(index);
   const entry = speakerItems.get(id);
-  if (!entry?.root) {
+  const target = entry?.idStrip;
+  if (!target) {
     return;
   }
   // Restart the fade animation even if a previous flash is still running.
-  entry.root.classList.remove('clip-flash');
-  void entry.root.offsetWidth; // force reflow so the animation replays
-  entry.root.classList.add('clip-flash');
+  target.classList.remove('clip-flash');
+  void target.offsetWidth; // force reflow so the animation replays
+  target.classList.add('clip-flash');
   const existing = speakerClipTimers.get(id);
   if (existing) {
     clearTimeout(existing);
@@ -676,7 +680,7 @@ export function flashSpeakerClip(index) {
   speakerClipTimers.set(
     id,
     setTimeout(() => {
-      entry.root.classList.remove('clip-flash');
+      target.classList.remove('clip-flash');
       speakerClipTimers.delete(id);
     }, 1000)
   );
@@ -1069,7 +1073,7 @@ export function createObjectItem(id) {
   level.appendChild(levelText);
 
   const meterBar = document.createElement('div');
-  meterBar.className = 'meter-bar';
+  meterBar.className = 'meter-bar level-meter';
   const meterFill = document.createElement('div');
   meterFill.className = 'meter-fill';
   const peakCursor = document.createElement('div');
@@ -1923,6 +1927,17 @@ export function updateSpeakerLevel(index, meter) {
     applySpeakerLevel(mesh, speakerLevels.get(key));
   }
   updateSpeakerMeterUI(key);
+  dirty.masterMeter = true;
+  scheduleUIFlush();
+}
+
+// Engine-metered master output level (post-master-gain), from
+// /omniphony/meter/master. Drives the master bar (RMS) + peak cursor.
+export function updateMasterLevel(meter) {
+  setMasterLevel({
+    peakDbfs: Number(meter?.peakDbfs ?? -100),
+    rmsDbfs: Number(meter?.rmsDbfs ?? -100)
+  });
   dirty.masterMeter = true;
   scheduleUIFlush();
 }

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -20,6 +20,12 @@ export const speakerLevels = new Map();
 export const sourcePeaks = new Map(); // { value: number, expires: number }
 export const speakerPeaks = new Map(); // { value: number, expires: number }
 export let masterPeak = { value: 0, expires: 0 };
+// Engine-reported master output meter { peakDbfs, rmsDbfs }, or null until the
+// first /omniphony/meter/master is received. Live ESM binding read by master.js.
+export let masterLevel = null;
+export function setMasterLevel(meter) {
+  masterLevel = meter;
+}
 export const sourceLevelLastSeen = new Map();
 export const speakerLevelLastSeen = new Map();
 export const sourceGains = new Map();

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -1473,6 +1473,36 @@
         transition: clip-path 0.1s linear, opacity 0.2s ease;
       }
 
+      /* Audio level meters run on a -60..+6 dBFS scale (mute-solo.js
+         dbToMeterPercent): 0 dBFS sits at 90.9%, leaving an over-0 "headroom"
+         zone above it. The peak cursor turns solid red once the held peak
+         crosses 0 dBFS (clipping). */
+      .meter-bar.level-meter .meter-fill {
+        z-index: 1;
+      }
+
+      .meter-bar.level-meter .meter-peak {
+        z-index: 3;
+      }
+
+      .meter-bar.level-meter::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 90.9%;
+        right: 0;
+        background: rgba(255, 80, 80, 0.32);
+        border-left: 1px solid rgba(255, 230, 230, 0.75);
+        pointer-events: none;
+        z-index: 2;
+      }
+
+      .meter-peak.over {
+        background: #ff3b3b;
+        box-shadow: 0 0 6px rgba(255, 59, 59, 0.9);
+      }
+
       .control-row {
         display: grid;
         grid-template-columns: 1fr auto auto auto;
@@ -1792,17 +1822,18 @@
         position: relative;
       }
 
-      .speaker-item.clip-flash {
+      /* Clip indicator: flash just the speaker's name chip, not the whole row. */
+      .speaker-item .id-strip.clip-flash {
         animation: speaker-clip-flash 1s ease-out;
       }
 
       @keyframes speaker-clip-flash {
         0% {
-          background-color: rgba(255, 59, 48, 0.55);
-          box-shadow: inset 0 0 0 1px rgba(255, 59, 48, 0.85);
+          background-color: rgba(255, 59, 48, 0.85);
+          box-shadow: inset 0 0 0 1px rgba(255, 59, 48, 0.9);
         }
         100% {
-          background-color: rgba(255, 59, 48, 0);
+          background-color: rgba(0, 0, 0, 0.55);
           box-shadow: inset 0 0 0 1px rgba(255, 59, 48, 0);
         }
       }

--- a/omniphony-studio/src/tauri-bridge.js
+++ b/omniphony-studio/src/tauri-bridge.js
@@ -25,6 +25,7 @@ import {
 import { updateSource, updateSourceLevel, updateSourceGains, updateSourceBandGains, updateSourceSize, updateSourceTag, removeSource } from './sources.js';
 import {
   updateSpeakerLevel,
+  updateMasterLevel,
   renderLayout,
   renderSpeakerEditor,
   hydrateLayoutSelect,
@@ -194,6 +195,10 @@ export function setupTauriBridge() {
 
   listen('speaker:meter', ({ payload }) => {
     updateSpeakerLevel(Number(payload.id), payload.meter);
+  });
+
+  listen('master:meter', ({ payload }) => {
+    updateMasterLevel(payload.meter);
   });
 
   listen('speaker:gain', ({ payload }) => {

--- a/omniphony-studio/src/ui/audio-panel.js
+++ b/omniphony-studio/src/ui/audio-panel.js
@@ -258,7 +258,7 @@ export function audioPanelMarkup() {
         <div class="info-title" data-i18n="master.title">Master</div>
         <div class="meter-row">
           <div id="masterMeterText" class="fixed-metric">— dB</div>
-          <div class="meter-bar">
+          <div class="meter-bar level-meter">
             <div id="masterMeterFill" class="meter-fill"></div>
             <div id="masterMeterPeak" class="meter-peak"></div>
           </div>


### PR DESCRIPTION
## Problem

The small peak cursor on the audio level meters (objects, speakers, master) was misleading:

- The engine already sends a **true per-sample peak** for objects and speakers (`AudioMeter` accumulates `max(|sample|)` at the full frame rate, 50 Hz send), but the client **ignored `peakDbfs`** and derived the cursor from the **RMS** instead.
- The **master** meter didn't exist engine-side at all — it was a client-side *average of the speaker RMS*, doubly wrong.
- Both OSC parsers **clamped the peak to 0 dBFS**, flattening real clipping (the internal float pipeline is not bounded to 1.0; clipping happens at the DAC), hiding the magnitude of overs.

## Changes

**Engine**
- `metering.rs`: `MeterSnapshot` exposes `master_peak`/`master_rms`, derived in `poll()` from the post-master-gain speaker accumulators — **no per-sample cost**. Unit test added.
- `state_emit.rs`: emit `/omniphony/meter/master [peak, rms]` (covers both mpv and CLI paths).

**Tauri serde layer**
- `osc_parser.rs`: lift the peak ceiling (`[-100, +24]`) so over-0 dBFS peaks reach the UI; new `MeterMaster` variant + routing.
- `app_state.rs` / `osc_listener.rs`: `masterLevel` field + `master:meter` event.

**Studio UI**
- Peak cursor now follows `peakDbfs` (true sample peak); **the bar follows the peak too** (same quantity as the cursor) so the fill rises to the hold marker on transients instead of leaving a permanent crest-factor gap. RMS stays as the numeric readout.
- New **-60..+6 dBFS** scale (`dbToMeterPercent`) with a red **headroom zone** above 0 dBFS and a red cursor when clipping.
- Master consumes the engine meter, with a **client fallback** (max of speaker peaks — numerically identical to the engine's `max(spk_peak)`) so it works even against an engine/backend not yet rebuilt from this branch.
- Clip indicator scoped to the speaker's **name chip** (`.id-strip`) instead of flashing the whole row.

## Validation
- `cargo fmt --check` ✅ · renderer metering test ✅ (master peak = +2.28 dBFS on a 1.3 linear sample, over-0 preserved, == max of speaker peaks) · 66 pre-existing tests intact ✅
- `cargo check` on `orender_engine` and the Tauri backend ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)