### PR TITLE
feat(overlay): expose per-control toggles over the FFI for mpv keybinds

### DIFF
--- a/omniphony-renderer/orender_engine/src/overlay.rs
+++ b/omniphony-renderer/orender_engine/src/overlay.rs
@@ -346,6 +346,96 @@ pub fn set_trail_config(enabled: bool, ttl_ms: u32, diffuse: bool, teleport_thre
     save_prefs();
 }
 
+// ── toggles (host keybinds: flip current state, return the new one) ──────────
+//
+// These exist so the mpv shim can bind a key to "flip" a control and show the
+// resulting state in the OSD, without keeping its own mirror that could drift
+// from Studio's OSC pushes. Each flips the *current* value atomically and
+// returns the new one; persistence mirrors the matching `set_*` (enable / labels
+// / trails persist; objects / heatmap / bands / colormap are transient, owned by
+// Studio and re-pushed on connect).
+
+/// Flip the master enable and return the new state. Persisted.
+pub fn toggle_enabled() -> bool {
+    let o = overlay();
+    let new = !o.enabled.load(Ordering::Relaxed);
+    o.enabled.store(new, Ordering::Relaxed);
+    save_prefs();
+    new
+}
+
+/// Flip object-label visibility and return the new state. Persisted.
+pub fn toggle_labels() -> bool {
+    let new = {
+        let Ok(mut s) = overlay().state.lock() else {
+            return false;
+        };
+        s.labels_enabled = !s.labels_enabled;
+        s.labels_enabled
+    };
+    save_prefs();
+    new
+}
+
+/// Flip object visibility (markers + labels + trails + depth lines) and return
+/// the new state. Transient (display-only), like [`set_objects_visible`].
+pub fn toggle_objects() -> bool {
+    let Ok(mut s) = overlay().state.lock() else {
+        return false;
+    };
+    s.objects_visible = !s.objects_visible;
+    s.objects_visible
+}
+
+/// Flip whether the trails are drawn and return the new state. Clears the trail
+/// buffers when disabling (so they don't reappear on re-enable). Persisted, like
+/// [`set_trail_config`].
+pub fn toggle_trails() -> bool {
+    let new = {
+        let Ok(mut s) = overlay().state.lock() else {
+            return false;
+        };
+        s.cfg.enabled = !s.cfg.enabled;
+        if !s.cfg.enabled {
+            s.trails.clear();
+        }
+        s.cfg.enabled
+    };
+    save_prefs();
+    new
+}
+
+/// Flip the energy heatmap and return the new state. Transient, like
+/// [`set_heatmap_enabled`].
+pub fn toggle_heatmap() -> bool {
+    let Ok(mut s) = overlay().state.lock() else {
+        return false;
+    };
+    s.heatmap_enabled = !s.heatmap_enabled;
+    s.heatmap_enabled
+}
+
+/// Advance the heatmap colour gradient to the next index (wraps 0..=4, mirroring
+/// `OBJECT_ENERGY_COLORMAPS`) and return the new index. Transient.
+pub fn cycle_heatmap_colormap() -> usize {
+    let Ok(mut s) = overlay().state.lock() else {
+        return 0;
+    };
+    s.heatmap_colormap = (s.heatmap_colormap + 1) % 5;
+    s.heatmap_colormap as usize
+}
+
+/// Step the heatmap depth-plane count by `delta` (clamped to 1..=12) and return
+/// the new count. Transient, like [`set_heatmap_bands`].
+pub fn adjust_heatmap_bands(delta: i32) -> usize {
+    let Ok(mut s) = overlay().state.lock() else {
+        return FIELD_BANDS;
+    };
+    let next = (s.heatmap_bands as i32 + delta).clamp(1, 12) as usize;
+    s.heatmap_bands = next;
+    next
+}
+
 // ── persistence (orender-owned, real-time, separate from the savable config) ─
 
 /// Point the overlay at its prefs file and load it. Called once by the host at
@@ -1257,6 +1347,47 @@ mod tests {
     fn zero_resolution_returns_empty() {
         let _g = guard();
         assert!(build_ass(0, 0).is_empty());
+    }
+
+    #[test]
+    fn toggles_flip_and_return_new_state() {
+        let _g = guard();
+        // guard() leaves enable/labels/objects/heatmap on; each toggle flips and
+        // reports the resulting value.
+        assert!(!toggle_enabled());
+        assert!(toggle_enabled());
+        assert!(!toggle_labels());
+        assert!(toggle_labels());
+        assert!(!toggle_objects());
+        assert!(toggle_objects());
+        assert!(!toggle_heatmap());
+        assert!(toggle_heatmap());
+    }
+
+    #[test]
+    fn toggle_trails_clears_buffers_when_disabling() {
+        let _g = guard();
+        // Build up a trail, then disable: the buffer must be dropped so it can't
+        // reappear on re-enable.
+        update_positions(vec![(0, 0.0, 0.0, 0.5, String::new())]);
+        let now = now_secs();
+        trail_append(&mut overlay().state.lock().unwrap(), 0, 0.0, 0.0, 0.5, now);
+        assert!(!overlay().state.lock().unwrap().trails.is_empty());
+        assert!(!toggle_trails(), "trails start enabled (default) → off");
+        assert!(overlay().state.lock().unwrap().trails.is_empty());
+        assert!(toggle_trails(), "back on");
+    }
+
+    #[test]
+    fn heatmap_bands_clamp_and_colormap_wraps() {
+        let _g = guard();
+        set_heatmap_bands(3);
+        assert_eq!(adjust_heatmap_bands(2), 5);
+        assert_eq!(adjust_heatmap_bands(-10), 1, "clamps at 1");
+        assert_eq!(adjust_heatmap_bands(100), 12, "clamps at 12");
+        set_heatmap_colormap(3);
+        assert_eq!(cycle_heatmap_colormap(), 4);
+        assert_eq!(cycle_heatmap_colormap(), 0, "wraps 4 → 0");
     }
 
     // The energy heatmap is now a separate BGRA bitmap (drawn under the ASS via

--- a/omniphony-renderer/orender_ffi/include/orender.h
+++ b/omniphony-renderer/orender_ffi/include/orender.h
@@ -160,6 +160,45 @@ uintptr_t orender_overlay_ass(uint32_t res_x, uint32_t res_y, uint8_t *out, uint
 void orender_overlay_set_enabled(int enabled);
 
 /**
+ * Flip the master enable and return the new state (1 = on, 0 = off).
+ */
+int orender_overlay_toggle(void);
+
+/**
+ * Flip object-label visibility and return the new state (1 = on, 0 = off).
+ */
+int orender_overlay_toggle_labels(void);
+
+/**
+ * Flip object visibility (markers + labels + trails + depth lines) and return
+ * the new state (1 = on, 0 = off).
+ */
+int orender_overlay_toggle_objects(void);
+
+/**
+ * Flip whether motion trails are drawn and return the new state (1 = on,
+ * 0 = off). Clears the trail buffers when disabling.
+ */
+int orender_overlay_toggle_trails(void);
+
+/**
+ * Flip the object energy heatmap and return the new state (1 = on, 0 = off).
+ */
+int orender_overlay_toggle_heatmap(void);
+
+/**
+ * Advance the heatmap colour gradient to the next index (wraps 0..=4) and return
+ * the new index.
+ */
+uint32_t orender_overlay_cycle_heatmap_colormap(void);
+
+/**
+ * Step the heatmap depth-plane count by `delta` (clamped to 1..=12) and return
+ * the new count.
+ */
+uint32_t orender_overlay_adjust_heatmap_bands(int32_t delta);
+
+/**
  * Render the object energy heatmap as a single flattened BGRA bitmap
  * (premultiplied alpha) for mpv's `overlay-add`, drawn *under* the ASS overlay.
  *

--- a/omniphony-renderer/orender_ffi/src/lib.rs
+++ b/omniphony-renderer/orender_ffi/src/lib.rs
@@ -145,7 +145,8 @@ pub struct OrenderConfig {
 const VERSION_MAJOR: u32 = 0;
 // 2: added orender_overlay_ass / orender_overlay_set_enabled (in-process overlay).
 // 3: added orender_overlay_heatmap_bgra (BGRA energy-field bitmap for overlay-add).
-const VERSION_MINOR: u32 = 3;
+// 4: added overlay toggles (labels/objects/trails/heatmap) + heatmap band/colormap cycling.
+const VERSION_MINOR: u32 = 4;
 
 unsafe fn opt_str<'a>(p: *const c_char) -> Option<&'a str> {
     if p.is_null() {
@@ -482,6 +483,81 @@ pub extern "C" fn orender_overlay_set_enabled(enabled: c_int) {
     let _ = catch_unwind(AssertUnwindSafe(|| {
         orender_engine::overlay::set_enabled(enabled != 0);
     }));
+}
+
+// ── overlay toggles (host keybinds) ──────────────────────────────────────────
+//
+// Each flips the matching control inside the renderer and returns the *new*
+// state (1 = on, 0 = off; the heatmap band/colormap variants return the new
+// numeric value). Returning the result lets the mpv shim show it in the OSD
+// without keeping a mirror that could drift from Studio's OSC pushes. On a panic
+// the catch returns a safe default (0).
+
+/// Flip the master enable and return the new state (1 = on, 0 = off).
+#[no_mangle]
+pub extern "C" fn orender_overlay_toggle() -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::toggle_enabled() as c_int
+    }))
+    .unwrap_or(0)
+}
+
+/// Flip object-label visibility and return the new state (1 = on, 0 = off).
+#[no_mangle]
+pub extern "C" fn orender_overlay_toggle_labels() -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::toggle_labels() as c_int
+    }))
+    .unwrap_or(0)
+}
+
+/// Flip object visibility (markers + labels + trails + depth lines) and return
+/// the new state (1 = on, 0 = off).
+#[no_mangle]
+pub extern "C" fn orender_overlay_toggle_objects() -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::toggle_objects() as c_int
+    }))
+    .unwrap_or(0)
+}
+
+/// Flip whether motion trails are drawn and return the new state (1 = on,
+/// 0 = off). Clears the trail buffers when disabling.
+#[no_mangle]
+pub extern "C" fn orender_overlay_toggle_trails() -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::toggle_trails() as c_int
+    }))
+    .unwrap_or(0)
+}
+
+/// Flip the object energy heatmap and return the new state (1 = on, 0 = off).
+#[no_mangle]
+pub extern "C" fn orender_overlay_toggle_heatmap() -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::toggle_heatmap() as c_int
+    }))
+    .unwrap_or(0)
+}
+
+/// Advance the heatmap colour gradient to the next index (wraps 0..=4) and return
+/// the new index.
+#[no_mangle]
+pub extern "C" fn orender_overlay_cycle_heatmap_colormap() -> u32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::cycle_heatmap_colormap() as u32
+    }))
+    .unwrap_or(0)
+}
+
+/// Step the heatmap depth-plane count by `delta` (clamped to 1..=12) and return
+/// the new count.
+#[no_mangle]
+pub extern "C" fn orender_overlay_adjust_heatmap_bands(delta: i32) -> u32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        orender_engine::overlay::adjust_heatmap_bands(delta) as u32
+    }))
+    .unwrap_or(0)
 }
 
 /// Render the object energy heatmap as a single flattened BGRA bitmap


### PR DESCRIPTION
## Why

The mpv overlay shim could only flip the whole overlay on/off; everything else — object labels, objects, motion trails, the energy heatmap and its planes/colormap — was reachable only from Studio over OSC. This adds host-facing toggles so mpv keybinds (companion PR in `mgth/mpv-omniphony`) can drive them too.

## Changes

**`orender_engine` (`overlay.rs`)** — new host-facing helpers that flip the current state and return the **new** value, so the host can show it in the OSD without keeping a mirror that drifts from Studio's OSC pushes:

- `toggle_enabled` / `toggle_labels` / `toggle_objects` / `toggle_trails` / `toggle_heatmap`
- `cycle_heatmap_colormap` (wraps 0..=4), `adjust_heatmap_bands` (clamps 1..=12)

Persistence mirrors the matching `set_*`: enable/labels/trails persist; objects/heatmap/bands/colormap stay transient (Studio owns them and re-pushes on connect). `toggle_trails` clears the trail buffers when disabling.

**`orender_ffi`** — **ABI minor 3 → 4**. New symbols returning the new state: `orender_overlay_toggle{,_labels,_objects,_trails,_heatmap}`, `orender_overlay_cycle_heatmap_colormap`, `orender_overlay_adjust_heatmap_bands`. `include/orender.h` regenerated by cbindgen; symbols confirmed exported in `liborender.so`. `orender_overlay_set_enabled` kept for compatibility.

## Tests

`cargo test -p orender_engine` — flip round-trips for every toggle, band clamp (1..=12), colormap wrap (4 → 0), trails cleared on disable. 22/22 green; `fmt --check` clean.

## Notes

Independent of the overlay bugfix PR (`fix/mpv-overlay-requires-orender-session`). The mpv-omniphony companion PR degrades gracefully on an older liborender (ABI < 4), so merge order is not critical, but the keybinds only become fully functional once this ships in a redistributed `liborender`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)