### PR TITLE
refactor(audio): migrate realtime hot-path locks to parking_lot

### DIFF
--- a/omniphony-renderer/audio_output/Cargo.toml
+++ b/omniphony-renderer/audio_output/Cargo.toml
@@ -12,6 +12,7 @@ name = "audio_output"
 anyhow = "1"
 log = "0.4"
 crossbeam = "0.8"
+parking_lot = "0.12"
 rubato = "0.14"
 serde = { version = "1", features = ["derive"] }
 sys = { path = "../sys" }

--- a/omniphony-renderer/audio_output/src/asio.rs
+++ b/omniphony-renderer/audio_output/src/asio.rs
@@ -3,11 +3,12 @@
 use anyhow::{Result, anyhow};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crossbeam::queue::ArrayQueue;
+use parking_lot::Mutex;
 use rubato::{
     Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
 };
 use std::sync::{
-    Arc, Mutex,
+    Arc,
     atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering},
 };
 use std::time::Duration;
@@ -295,7 +296,7 @@ impl AsioWriter {
 
         let live_config = Arc::new(Mutex::new(adaptive_config));
         let live_config_for_callback = Arc::clone(&live_config);
-        let initial_cfg = live_config.lock().unwrap().clone();
+        let initial_cfg = live_config.lock().clone();
 
         // Calculate max ratio for adaptive adjustments
         // Allow small adjustments around the base resample ratio
@@ -395,7 +396,7 @@ impl AsioWriter {
                 };
                 pipeline_latency_ms_bits_clone
                     .store(callback_midpoint_ms.to_bits(), Ordering::Relaxed);
-                let current_asio_cfg = live_config_for_callback.lock().unwrap().clone();
+                let current_asio_cfg = live_config_for_callback.lock().clone();
                 // ASIO callback dt comes from the nominal frame size of
                 // the active buffer. We don't have an atomic-published dt
                 // here as on the PipeWire path; the configured value is
@@ -529,7 +530,7 @@ impl AsioWriter {
                 // output_fifo contains frames * channel_count
                 let output_frames_needed = data.len() / device_channel_count_for_callback as usize;
                 let audio_samples_needed = output_frames_needed * channel_count as usize;
-                let far_mode_cfg = live_config_for_callback.lock().unwrap().clone();
+                let far_mode_cfg = live_config_for_callback.lock().clone();
                 let startup_low_recover_was_active = runtime_state.startup_low_recover_active;
                 let low_recover_was_active =
                     runtime_state.low_recover_phase != LowRecoverPhase::Inactive;
@@ -855,8 +856,6 @@ impl AsioWriter {
 
     /// Update adaptive resampling tuning parameters without restarting the audio stream.
     pub fn update_adaptive_config(&self, config: AdaptiveResamplingConfig) {
-        if let Ok(mut c) = self.live_adaptive_config.lock() {
-            *c = config;
-        }
+        *self.live_adaptive_config.lock() = config;
     }
 }

--- a/omniphony-renderer/audio_output/src/control.rs
+++ b/omniphony-renderer/audio_output/src/control.rs
@@ -1,8 +1,6 @@
 use crate::AdaptiveResamplingConfig;
-use std::sync::{
-    Mutex,
-    atomic::{AtomicBool, Ordering},
-};
+use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct OutputDeviceOption {
@@ -65,20 +63,20 @@ impl AudioControl {
     }
 
     pub fn requested_snapshot(&self) -> RequestedAudioOutputConfig {
-        self.requested.lock().unwrap().clone()
+        self.requested.lock().clone()
     }
 
     pub fn update_requested(&self, f: impl FnOnce(&mut RequestedAudioOutputConfig)) {
-        let mut requested = self.requested.lock().unwrap();
+        let mut requested = self.requested.lock();
         f(&mut requested);
     }
 
     pub fn applied_snapshot(&self) -> AppliedAudioOutputState {
-        self.applied.lock().unwrap().clone()
+        self.applied.lock().clone()
     }
 
     pub fn update_applied(&self, f: impl FnOnce(&mut AppliedAudioOutputState)) {
-        let mut applied = self.applied.lock().unwrap();
+        let mut applied = self.applied.lock();
         f(&mut applied);
     }
 
@@ -343,25 +341,25 @@ impl AudioControl {
     }
 
     pub fn set_available_output_devices(&self, devices: Vec<OutputDeviceOption>) {
-        *self.available_output_devices.lock().unwrap() = devices;
+        *self.available_output_devices.lock() = devices;
     }
 
     pub fn available_output_devices(&self) -> Vec<OutputDeviceOption> {
-        self.available_output_devices.lock().unwrap().clone()
+        self.available_output_devices.lock().clone()
     }
 
     pub fn set_device_list_fetcher(
         &self,
         fetcher: impl Fn() -> Vec<OutputDeviceOption> + Send + Sync + 'static,
     ) {
-        *self.device_list_fetcher.lock().unwrap() = Some(Box::new(fetcher));
+        *self.device_list_fetcher.lock() = Some(Box::new(fetcher));
     }
 
     pub fn refresh_available_output_devices(&self) -> Option<Vec<OutputDeviceOption>> {
-        let fetcher = self.device_list_fetcher.lock().unwrap();
+        let fetcher = self.device_list_fetcher.lock();
         fetcher.as_ref().map(|f| {
             let devices = f();
-            *self.available_output_devices.lock().unwrap() = devices.clone();
+            *self.available_output_devices.lock() = devices.clone();
             devices
         })
     }

--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Result, anyhow};
 use crossbeam::queue::ArrayQueue;
+use parking_lot::Mutex;
 use pipewire as pw;
 use rubato::{
     Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
@@ -9,7 +10,7 @@ use rubato::{
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::{
-    Arc, Mutex,
+    Arc,
     atomic::{AtomicBool, AtomicI64, AtomicU8, AtomicU32, AtomicU64, Ordering},
 };
 use std::thread;
@@ -952,9 +953,7 @@ impl PipewireWriter {
         // so toggling `use_output_pacing` over OSC starts a clean pre-roll.
         self.set_output_pacing_enabled(config.use_output_pacing);
         self.set_backpressure_disabled(config.disable_backpressure);
-        if let Ok(mut c) = self.live_adaptive_config.lock() {
-            *c = config;
-        }
+        *self.live_adaptive_config.lock() = config;
     }
 
     /// Diagnostic metric handles published by the PipeWire output backend.
@@ -1261,7 +1260,7 @@ fn run_pipewire_loop(
 
     // Snapshot the current config for initialisation (resampler max ratio, thresholds).
     // The live Arc is polled in the callback for any subsequent updates.
-    let adaptive_config_snapshot = adaptive_config.lock().unwrap().clone();
+    let adaptive_config_snapshot = adaptive_config.lock().clone();
 
     // Initialize resampler for true rate conversion and for adaptive 1:1 operation.
     let mut resampler_opt = if use_local_resampler {
@@ -1554,7 +1553,7 @@ fn run_pipewire_loop(
                         (control_available_override as f64).to_bits(),
                         Ordering::Relaxed,
                     );
-                    let current_adaptive_cfg = live_adaptive_config_for_callback.lock().unwrap().clone();
+                    let current_adaptive_cfg = live_adaptive_config_for_callback.lock().clone();
                     // Classical control_available calculation (ring + FIFO +
                     // pending - callback/2). The cumulative-flow override was
                     // tried during the 0.4 Hz investigation but caused
@@ -1758,7 +1757,7 @@ fn run_pipewire_loop(
                             && runtime_state.low_recover_phase == LowRecoverPhase::Inactive
                         {
                             // Refresh config from the live Arc (non-blocking; keep stale on contention).
-                            if let Ok(cfg) = live_adaptive_config_for_callback.try_lock() {
+                            if let Some(cfg) = live_adaptive_config_for_callback.try_lock() {
                                 adaptive_update_interval = cfg.update_interval_callbacks.max(1) as u64;
                             }
                             if should_run_adaptive_servo(
@@ -1836,7 +1835,7 @@ fn run_pipewire_loop(
                         }
 
                         let audio_samples_needed = max_samples;
-                        let far_mode_cfg = live_adaptive_config_for_callback.lock().unwrap().clone();
+                        let far_mode_cfg = live_adaptive_config_for_callback.lock().clone();
                         let low_recover_was_active =
                             runtime_state.low_recover_phase != LowRecoverPhase::Inactive;
                         // State machine on raw: its entry/exit/settle bands are
@@ -2087,7 +2086,7 @@ fn run_pipewire_loop(
                             && runtime_state.low_recover_phase == LowRecoverPhase::Inactive
                         {
                             // Refresh config from live Arc (non-blocking; keep stale on contention).
-                            let native_servo_cfg = live_adaptive_config_for_callback.lock().unwrap().clone();
+                            let native_servo_cfg = live_adaptive_config_for_callback.lock().clone();
                             if adaptive_resampling_enabled {
                                 adaptive_update_interval = native_servo_cfg.update_interval_callbacks.max(1) as u64;
                             }
@@ -2181,7 +2180,7 @@ fn run_pipewire_loop(
                         let frames_to_read = available_frames.min(max_frames);
                         let samples_to_read = frames_to_read * ch;
 
-                        let far_mode_cfg2 = live_adaptive_config_for_callback.lock().unwrap().clone();
+                        let far_mode_cfg2 = live_adaptive_config_for_callback.lock().clone();
                         // State machine on raw — see resampler path.
                         let far_decision: FarModeDecision = update_far_mode_state(
                             &mut runtime_state,

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -378,7 +378,7 @@ impl Engine {
             .and_then(renderer::live_params::RampMode::from_str)
             .unwrap_or(renderer::live_params::RampMode::Frame);
         control.set_requested_ramp_mode(ramp_mode);
-        control.live.write().unwrap().ramp_mode = ramp_mode;
+        control.live.write().ramp_mode = ramp_mode;
 
         // DRC: seed the live params from config and publish the bridge's
         // supported modes (so studio shows the DRC control). The decode-side
@@ -392,7 +392,7 @@ impl Engine {
             .collect();
         control.set_bridge_supported_drc_modes(supported_drc);
         {
-            let mut live = control.live.write().unwrap();
+            let mut live = control.live.write();
             live.drc_mode = render_cfg
                 .as_ref()
                 .and_then(|c| c.drc_mode.clone())
@@ -473,7 +473,7 @@ impl Engine {
     fn sync_drc_mode(&mut self) {
         let live_mode = {
             let control = self.renderer.renderer_control();
-            let live = control.live.read().unwrap();
+            let live = control.live.read();
             if live.drc_mode == self.applied_drc_mode {
                 return;
             }
@@ -635,7 +635,7 @@ impl Engine {
             let labels: Vec<RChannelLabel> = frame.channel_labels.iter().copied().collect();
             let (room_ratio, room_ratio_rear, room_ratio_lower, room_ratio_center_blend) = {
                 let control = self.renderer.renderer_control();
-                let live = control.live.read().unwrap();
+                let live = control.live.read();
                 (
                     live.room_ratio,
                     live.room_ratio_rear,
@@ -696,7 +696,6 @@ impl Engine {
             .renderer_control()
             .live
             .read()
-            .unwrap()
             .drc_weight
             .clamp(0.0, 1.0);
         self.drc_target_gain = if drc_weight >= 1.0 {

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -302,7 +302,7 @@ pub(crate) fn handle_control_message(
             return;
         }
         realtime_seq.master_gain = Some(seq);
-        control.live.write().unwrap().master_gain = value;
+        control.live.write().master_gain = value;
         control.mark_dirty();
         broadcast_int(socket, clients, "/omniphony/state/config/saved", 0);
         if let Ok(bytes) = rosc::encoder::encode(&rosc::OscPacket::Message(rosc::OscMessage {
@@ -344,14 +344,7 @@ pub(crate) fn handle_control_message(
             return;
         }
         realtime_seq.speaker_gain.insert(idx, seq);
-        control
-            .live
-            .write()
-            .unwrap()
-            .speakers
-            .entry(idx)
-            .or_default()
-            .gain = value;
+        control.live.write().speakers.entry(idx).or_default().gain = value;
         control.mark_speaker_params_dirty();
         control.mark_dirty();
         broadcast_int(socket, clients, "/omniphony/state/config/saved", 0);
@@ -410,14 +403,7 @@ pub(crate) fn handle_control_message(
         };
         let clamped = value.clamp(0.0, 2.0);
         realtime_seq.object_gain.insert(id.clone(), seq);
-        control
-            .live
-            .write()
-            .unwrap()
-            .objects
-            .entry(idx)
-            .or_default()
-            .gain = clamped;
+        control.live.write().objects.entry(idx).or_default().gain = clamped;
         control.mark_object_params_dirty();
         control.mark_dirty();
         broadcast_int(socket, clients, "/omniphony/state/config/saved", 0);

--- a/omniphony-renderer/orender_engine/src/osc/export.rs
+++ b/omniphony-renderer/orender_engine/src/osc/export.rs
@@ -114,7 +114,7 @@ fn sanitize_layout_name(name: &str) -> String {
 
 pub(crate) fn export_current_layout(control: &Arc<RendererControl>, requested_name: Option<&str>) {
     let config_path = {
-        let guard = control.config_path.lock().unwrap();
+        let guard = control.config_path.lock();
         guard.clone()
     };
     let base_dir = config_path

--- a/omniphony-renderer/orender_engine/src/osc/recompute.rs
+++ b/omniphony-renderer/orender_engine/src/osc/recompute.rs
@@ -92,7 +92,7 @@ pub(crate) fn trigger_layout_recompute(
                         rebuild_plan_for_thread.backend_id()
                     );
                     let renderer_state_json = {
-                        let live = control_clone.live.read().unwrap();
+                        let live = control_clone.live.read();
                         let topology = control_clone.active_topology();
                         let scale_m = control_clone.editable_layout().radius_m;
                         build_renderer_state_json(&live, &topology, scale_m)
@@ -102,7 +102,7 @@ pub(crate) fn trigger_layout_recompute(
                         serde_json::to_string(&layout).unwrap_or_else(|_| "{}".to_string())
                     };
                     let speakers_state_json = {
-                        let live = control_clone.live.read().unwrap();
+                        let live = control_clone.live.read();
                         let layout = control_clone.editable_layout();
                         build_speakers_state_json(&live, &layout)
                     };

--- a/omniphony-renderer/orender_engine/src/osc/state_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/state_emit.rs
@@ -20,7 +20,7 @@ impl OscSender {
             Some(ref c) => c,
             None => return,
         };
-        let live = control.live.read().unwrap();
+        let live = control.live.read();
         let socket = &self.socket;
         let clients = &self.clients;
 

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -439,7 +439,7 @@ pub fn build_spatial_renderer(
         let control = renderer.renderer_control();
         let mut requires_rebuild = false;
         {
-            let mut live = control.live.write().unwrap();
+            let mut live = control.live.write();
             if let Some(configured_backend) = configured_backend {
                 if live.backend_id() != configured_backend.as_str() {
                     live.backend_id = configured_backend.as_str().to_string();

--- a/omniphony-renderer/renderer/examples/gain_modes.rs
+++ b/omniphony-renderer/renderer/examples/gain_modes.rs
@@ -61,7 +61,7 @@ fn make_cartesian_renderer() -> SpatialRenderer {
     {
         let ctrl = r.renderer_control();
         ctrl.set_requested_ramp_mode(RampMode::Off);
-        ctrl.live.write().unwrap().ramp_mode = RampMode::Off;
+        ctrl.live.write().ramp_mode = RampMode::Off;
     }
     r
 }

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -14,10 +14,11 @@
 
 use anyhow::Result;
 use arc_swap::ArcSwap;
+use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
 
 use crate::backend_registry::{TopologyBuildPlan, prepare_topology_build_plan};
 use crate::render_backend::backend_descriptor_by_id;
@@ -722,7 +723,7 @@ impl RendererControl {
 
     /// Store the active config file path so the save-config OSC handler can use it.
     pub fn set_config_path(&self, path: PathBuf) {
-        *self.config_path.lock().unwrap() = Some(path);
+        *self.config_path.lock() = Some(path);
     }
 
     /// The active config file path, if one was resolved at construction. `None`
@@ -730,25 +731,25 @@ impl RendererControl {
     /// the very condition Studio surfaces in About to diagnose CLI-vs-host
     /// config mismatches.
     pub fn config_path(&self) -> Option<PathBuf> {
-        self.config_path.lock().unwrap().clone()
+        self.config_path.lock().clone()
     }
 
     /// Record whether the active config path actually loaded (see field docs).
     pub fn set_config_status(&self, status: Option<String>) {
-        *self.config_status.lock().unwrap() = status;
+        *self.config_status.lock() = status;
     }
 
     pub fn config_status(&self) -> Option<String> {
-        self.config_status.lock().unwrap().clone()
+        self.config_status.lock().clone()
     }
 
     /// Record the degraded "no decoder" bridge error (see field docs).
     pub fn set_bridge_error(&self, message: Option<String>) {
-        *self.bridge_error.lock().unwrap() = message;
+        *self.bridge_error.lock() = message;
     }
 
     pub fn bridge_error(&self) -> Option<String> {
-        self.bridge_error.lock().unwrap().clone()
+        self.bridge_error.lock().clone()
     }
 
     pub fn active_topology(&self) -> Arc<RenderTopology> {
@@ -760,11 +761,11 @@ impl RendererControl {
     }
 
     pub fn editable_layout(&self) -> SpeakerLayout {
-        self.editable_layout.lock().unwrap().clone()
+        self.editable_layout.lock().clone()
     }
 
     pub fn with_editable_layout<R>(&self, f: impl FnOnce(&mut SpeakerLayout) -> R) -> R {
-        let mut layout = self.editable_layout.lock().unwrap();
+        let mut layout = self.editable_layout.lock();
         f(&mut layout)
     }
 
@@ -773,11 +774,11 @@ impl RendererControl {
     }
 
     pub fn backend_rebuild_params(&self) -> Option<BackendRebuildParams> {
-        *self.backend_rebuild_params.read().unwrap()
+        *self.backend_rebuild_params.read()
     }
 
     pub fn set_backend_rebuild_params(&self, params: Option<BackendRebuildParams>) {
-        *self.backend_rebuild_params.write().unwrap() = params;
+        *self.backend_rebuild_params.write() = params;
     }
 
     pub fn mark_object_params_dirty(&self) {
@@ -832,7 +833,7 @@ impl RendererControl {
         &self,
         layout: SpeakerLayout,
     ) -> Option<TopologyBuildPlan> {
-        let live = self.live.read().unwrap();
+        let live = self.live.read();
         let backend_rebuild_params = self.backend_rebuild_params();
         let evaluation_build_config = evaluation_build_config_from_live(
             &live,
@@ -869,7 +870,7 @@ impl RendererControl {
 
         // Same cartesian grid the full gain table uses.
         let (x_positions, y_positions, z_positions, template) = {
-            let live = self.live.read().unwrap();
+            let live = self.live.read();
             let rebuild_params = self.backend_rebuild_params();
             let config = evaluation_build_config_from_live(
                 &live,
@@ -982,34 +983,34 @@ impl RendererControl {
     }
 
     pub fn set_input_path(&self, input_path: Option<String>) {
-        *self.input_path.lock().unwrap() = input_path;
+        *self.input_path.lock() = input_path;
     }
 
     pub fn input_path(&self) -> Option<String> {
-        self.input_path.lock().unwrap().clone()
+        self.input_path.lock().clone()
     }
 
     pub fn set_bridge_path(&self, bridge_path: Option<PathBuf>) {
-        *self.bridge_path.lock().unwrap() = bridge_path;
+        *self.bridge_path.lock() = bridge_path;
     }
 
     pub fn bridge_path(&self) -> Option<PathBuf> {
-        self.bridge_path.lock().unwrap().clone()
+        self.bridge_path.lock().clone()
     }
 
     pub fn set_bridge_supported_drc_modes(&self, modes: Vec<String>) {
-        *self.bridge_supported_drc_modes.lock().unwrap() = modes;
+        *self.bridge_supported_drc_modes.lock() = modes;
     }
 
     pub fn bridge_supported_drc_modes(&self) -> Vec<String> {
-        self.bridge_supported_drc_modes.lock().unwrap().clone()
+        self.bridge_supported_drc_modes.lock().clone()
     }
 
     pub fn set_requested_ramp_mode(&self, mode: RampMode) {
-        *self.requested_ramp_mode.lock().unwrap() = mode;
+        *self.requested_ramp_mode.lock() = mode;
     }
 
     pub fn requested_ramp_mode(&self) -> RampMode {
-        *self.requested_ramp_mode.lock().unwrap()
+        *self.requested_ramp_mode.lock()
     }
 }

--- a/omniphony-renderer/renderer/src/spatial_renderer.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer.rs
@@ -408,7 +408,7 @@ pub struct SpatialRenderer {
     frame_counter: std::sync::atomic::AtomicU64,
 
     /// Per-channel state (movement detection + gain ramping)
-    channel_states: std::sync::Mutex<std::collections::HashMap<usize, ChannelState>>,
+    channel_states: parking_lot::Mutex<std::collections::HashMap<usize, ChannelState>>,
 
     /// Sample rate for ramp time calculations
     sample_rate: u32,
@@ -1028,7 +1028,7 @@ impl SpatialRenderer {
             bed_indices: arc_swap::ArcSwap::new(std::sync::Arc::new(Vec::new())),
             first_render: std::sync::atomic::AtomicBool::new(true),
             frame_counter: std::sync::atomic::AtomicU64::new(0),
-            channel_states: std::sync::Mutex::new(std::collections::HashMap::new()),
+            channel_states: parking_lot::Mutex::new(std::collections::HashMap::new()),
             sample_rate,
             distance_model,
             log_object_positions,
@@ -1111,7 +1111,7 @@ impl SpatialRenderer {
         let gain_linear = 10.0_f32.powf(gain_db as f32 / 20.0);
         self.loudness_gain
             .store(gain_linear.to_bits(), std::sync::atomic::Ordering::Relaxed);
-        self.control.live.write().unwrap().dialogue_level = Some(dialogue_level);
+        self.control.live.write().dialogue_level = Some(dialogue_level);
         log::info!(
             "Dialog normalization: dialogue_level={} dBFS → gain={} dB (linear: {:.4})",
             dialogue_level,
@@ -1185,7 +1185,7 @@ impl SpatialRenderer {
     /// stream restart so stale object positions cannot leak into subsequent
     /// rendering.
     pub fn reset_runtime_state(&self) {
-        self.channel_states.lock().unwrap().clear();
+        self.channel_states.lock().clear();
         self.first_render
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
@@ -1201,7 +1201,7 @@ impl SpatialRenderer {
         strategy: &dyn RampStrategy,
         ctx: &RampContext,
     ) -> Result<()> {
-        let mut channel_states = self.channel_states.lock().unwrap();
+        let mut channel_states = self.channel_states.lock();
 
         for event in events {
             let state = channel_states
@@ -1318,7 +1318,7 @@ impl SpatialRenderer {
         // ── 1. Snapshot live params so we hold the read lock for as short a time as possible ──
         let live_position_interpolation;
         let live = {
-            let g = self.control.live.read().unwrap();
+            let g = self.control.live.read();
             live_position_interpolation = g.evaluation.position_interpolation;
             let object_params_generation = self
                 .control
@@ -1487,7 +1487,7 @@ impl SpatialRenderer {
 
         // Hold channel metadata state lock once for the whole render pass.
         // This avoids lock/unlock churn in the channel loop.
-        let mut channel_states = self.channel_states.lock().unwrap();
+        let mut channel_states = self.channel_states.lock();
 
         // Process each channel
         for input_channel_idx in 0..input_channel_count {
@@ -2067,7 +2067,7 @@ impl SpatialRenderer {
                 // Apply it to the shared master gain. Re-reading under the write
                 // lock preserves any concurrent OSC master change.
                 let new_master_gain = {
-                    let mut params = self.control.live.write().unwrap();
+                    let mut params = self.control.live.write();
                     params.master_gain *= required_gain;
                     params.master_gain
                 };
@@ -2465,7 +2465,6 @@ mod tests {
         control
             .live
             .write()
-            .unwrap()
             .set_evaluation_mode(LiveEvaluationMode::Realtime);
         let plan = control.prepare_topology_rebuild().expect("rebuild plan");
         let reused = plan
@@ -2605,7 +2604,7 @@ mod tests {
 
         let render = |mode: RampMode| -> Vec<f32> {
             let mut r = build();
-            r.control.live.write().unwrap().ramp_mode = mode;
+            r.control.live.write().ramp_mode = mode;
             // First block establishes a position (and seeds Interp's start gains).
             r.render_frame(&pcm, 1, &block_a, Vec::new(), false)
                 .unwrap();

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -533,7 +533,6 @@ pub fn apply_simple_osc_control(
                     ctx.renderer
                         .live
                         .write()
-                        .unwrap()
                         .speakers
                         .entry(idx)
                         .or_default()
@@ -554,7 +553,7 @@ pub fn apply_simple_osc_control(
                 });
                 if removed {
                     {
-                        let mut live = ctx.renderer.live.write().unwrap();
+                        let mut live = ctx.renderer.live.write();
                         remap_live_speakers_remove(&mut live.speakers, remove_idx);
                     }
                     ctx.renderer.mark_speaker_params_dirty();
@@ -578,7 +577,7 @@ pub fn apply_simple_osc_control(
                 });
                 if moved {
                     {
-                        let mut live = ctx.renderer.live.write().unwrap();
+                        let mut live = ctx.renderer.live.write();
                         remap_live_speakers_move(
                             &mut live.speakers,
                             move_speaker.from,
@@ -630,7 +629,6 @@ pub fn apply_simple_osc_control(
                         ctx.renderer
                             .live
                             .write()
-                            .unwrap()
                             .speakers
                             .entry(speaker_patch.id)
                             .or_default()
@@ -647,7 +645,6 @@ pub fn apply_simple_osc_control(
                         ctx.renderer
                             .live
                             .write()
-                            .unwrap()
                             .speakers
                             .entry(speaker_patch.id)
                             .or_default()
@@ -672,7 +669,7 @@ pub fn apply_simple_osc_control(
         let requested = parse_string_arg(msg.args.first())
             .and_then(|value| RenderBackendKind::from_str(&value));
         if let Some(requested) = requested {
-            let mut live = ctx.renderer.live.write().unwrap();
+            let mut live = ctx.renderer.live.write();
             if live.backend_id() != requested.as_str() {
                 live.backend_id = requested.as_str().to_string();
                 effects.mark_dirty = true;
@@ -696,7 +693,7 @@ pub fn apply_simple_osc_control(
         let requested = parse_string_arg(msg.args.first())
             .and_then(|value| LiveEvaluationMode::from_str(&value));
         if let Some(requested) = requested {
-            let mut live = ctx.renderer.live.write().unwrap();
+            let mut live = ctx.renderer.live.write();
             if live.evaluation.mode != requested {
                 live.set_evaluation_mode(requested);
                 effects.mark_dirty = true;
@@ -728,7 +725,7 @@ pub fn apply_simple_osc_control(
     if addr == "/omniphony/control/input/drc_mode" {
         let requested = parse_string_arg(msg.args.first());
         if let Some(requested) = requested {
-            let mut live = ctx.renderer.live.write().unwrap();
+            let mut live = ctx.renderer.live.write();
             if live.drc_mode != requested {
                 live.drc_mode = requested.clone();
                 effects.mark_dirty = true;
@@ -741,7 +738,7 @@ pub fn apply_simple_osc_control(
     if addr == "/omniphony/control/input/drc_weight" {
         if let Some(value) = parse_f32_arg(msg.args.first()) {
             let clamped = value.clamp(0.0, 1.0);
-            let mut live = ctx.renderer.live.write().unwrap();
+            let mut live = ctx.renderer.live.write();
             if (live.drc_weight - clamped).abs() > f32::EPSILON {
                 live.drc_weight = clamped;
                 effects.mark_dirty = true;
@@ -759,7 +756,7 @@ pub fn apply_simple_osc_control(
             return Some(effects);
         };
         ctx.renderer.set_requested_ramp_mode(mode);
-        ctx.renderer.live.write().unwrap().ramp_mode = mode;
+        ctx.renderer.live.write().ramp_mode = mode;
         effects.mark_dirty = true;
         effects.log_message = Some(format!("OSC: ramp_mode → {}", mode.as_str()));
         return Some(effects);
@@ -777,7 +774,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/gain" {
         if let Some(gain) = parse_f32_arg(msg.args.first()) {
-            ctx.renderer.live.write().unwrap().master_gain = gain;
+            ctx.renderer.live.write().master_gain = gain;
             effects.mark_dirty = true;
         }
         return Some(effects);
@@ -787,7 +784,7 @@ pub fn apply_simple_osc_control(
         ($path:literal, $field:ident) => {
             if addr == $path {
                 if let Some(value) = parse_f32_arg(msg.args.first()) {
-                    ctx.renderer.live.write().unwrap().$field = value;
+                    ctx.renderer.live.write().$field = value;
                     effects.mark_dirty = true;
                     effects.trigger_layout_recompute = true;
                 }
@@ -809,7 +806,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/spread/from_distance" {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
-            ctx.renderer.live.write().unwrap().spread_from_distance = v;
+            ctx.renderer.live.write().spread_from_distance = v;
             effects.mark_dirty = true;
             effects.trigger_layout_recompute = true;
         }
@@ -821,7 +818,7 @@ pub fn apply_simple_osc_control(
             if let Some(mode) = renderer::render_backend::SizeToSpreadMode::from_str(
                 s.trim().to_ascii_lowercase().as_str(),
             ) {
-                ctx.renderer.live.write().unwrap().size_to_spread_mode = mode;
+                ctx.renderer.live.write().size_to_spread_mode = mode;
                 effects.mark_dirty = true;
                 // No layout recompute: only the GainCache is affected via its
                 // size_to_spread_mode key.
@@ -832,7 +829,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/auto_gain" {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
-            ctx.renderer.live.write().unwrap().auto_gain = v;
+            ctx.renderer.live.write().auto_gain = v;
             effects.mark_dirty = true;
             // Per-frame gain-stage flag: no topology recompute.
         }
@@ -842,7 +839,7 @@ pub fn apply_simple_osc_control(
     if addr == "/omniphony/control/auto_gain_ceiling" {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             // dBFS target; clamp to a sane range (ceiling at or below 0 dBFS).
-            ctx.renderer.live.write().unwrap().auto_gain_ceiling_db = v.clamp(-12.0, 0.0);
+            ctx.renderer.live.write().auto_gain_ceiling_db = v.clamp(-12.0, 0.0);
             effects.mark_dirty = true;
             // Per-frame gain-stage value: no topology recompute.
         }
@@ -858,43 +855,19 @@ pub fn apply_simple_osc_control(
         if let Some(size) = size {
             let state_addr = match rest {
                 "x_size" => {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .evaluation
-                        .cartesian
-                        .x_size = size;
+                    ctx.renderer.live.write().evaluation.cartesian.x_size = size;
                     Some("/omniphony/state/render_evaluation/cartesian/x_size")
                 }
                 "y_size" => {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .evaluation
-                        .cartesian
-                        .y_size = size;
+                    ctx.renderer.live.write().evaluation.cartesian.y_size = size;
                     Some("/omniphony/state/render_evaluation/cartesian/y_size")
                 }
                 "z_size" => {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .evaluation
-                        .cartesian
-                        .z_size = size;
+                    ctx.renderer.live.write().evaluation.cartesian.z_size = size;
                     Some("/omniphony/state/render_evaluation/cartesian/z_size")
                 }
                 "z_neg_size" => {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .evaluation
-                        .cartesian
-                        .z_neg_size = size;
+                    ctx.renderer.live.write().evaluation.cartesian.z_neg_size = size;
                     Some("/omniphony/state/render_evaluation/cartesian/z_neg_size")
                 }
                 _ => None,
@@ -916,12 +889,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/render_evaluation/position_interpolation" {
         if let Some(enabled) = parse_bool_arg(msg.args.first()) {
-            ctx.renderer
-                .live
-                .write()
-                .unwrap()
-                .evaluation
-                .position_interpolation = enabled;
+            ctx.renderer.live.write().evaluation.position_interpolation = enabled;
             // No layout recompute: this flag only selects nearest-cell vs
             // trilinear at table-read time. The precomputed table content is
             // independent of it, and the renderer syncs the live value into the
@@ -947,23 +915,11 @@ pub fn apply_simple_osc_control(
                 if let Some(res) = res {
                     let state_addr = match rest {
                         "azimuth_resolution" => {
-                            ctx.renderer
-                                .live
-                                .write()
-                                .unwrap()
-                                .evaluation
-                                .polar
-                                .azimuth_values = res;
+                            ctx.renderer.live.write().evaluation.polar.azimuth_values = res;
                             Some("/omniphony/state/render_evaluation/polar/azimuth_resolution")
                         }
                         "elevation_resolution" => {
-                            ctx.renderer
-                                .live
-                                .write()
-                                .unwrap()
-                                .evaluation
-                                .polar
-                                .elevation_values = res;
+                            ctx.renderer.live.write().evaluation.polar.elevation_values = res;
                             Some("/omniphony/state/render_evaluation/polar/elevation_resolution")
                         }
                         _ => None,
@@ -987,13 +943,7 @@ pub fn apply_simple_osc_control(
                     _ => None,
                 };
                 if let Some(res) = res {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .evaluation
-                        .polar
-                        .distance_res = res;
+                    ctx.renderer.live.write().evaluation.polar.distance_res = res;
                     effects.mark_dirty = true;
                     effects.trigger_layout_recompute = true;
                     effects.evaluation_only = true;
@@ -1010,13 +960,7 @@ pub fn apply_simple_osc_control(
                     _ => None,
                 };
                 if let Some(max_v) = max_v {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .evaluation
-                        .polar
-                        .distance_max = max_v;
+                    ctx.renderer.live.write().evaluation.polar.distance_max = max_v;
                     effects.mark_dirty = true;
                     effects.trigger_layout_recompute = true;
                     effects.evaluation_only = true;
@@ -1033,7 +977,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/loudness" {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
-            ctx.renderer.live.write().unwrap().use_loudness = v;
+            ctx.renderer.live.write().use_loudness = v;
             effects.mark_dirty = true;
         }
         return Some(effects);
@@ -1042,7 +986,7 @@ pub fn apply_simple_osc_control(
     if addr == "/omniphony/control/distance_model" {
         if let Some(OscType::String(model)) = msg.args.first() {
             if let Ok(model) = model.parse::<renderer::spatial_vbap::DistanceModel>() {
-                ctx.renderer.live.write().unwrap().distance_model = model;
+                ctx.renderer.live.write().distance_model = model;
                 effects.mark_dirty = true;
                 effects.trigger_layout_recompute = true;
             }
@@ -1053,7 +997,7 @@ pub fn apply_simple_osc_control(
     if addr == "/omniphony/control/distance_model_metric" {
         if let Some(OscType::String(metric)) = msg.args.first() {
             if let Ok(metric) = metric.parse::<renderer::spatial_vbap::DistanceMetric>() {
-                ctx.renderer.live.write().unwrap().distance_model_metric = metric;
+                ctx.renderer.live.write().distance_model_metric = metric;
                 effects.mark_dirty = true;
                 effects.trigger_layout_recompute = true;
             }
@@ -1062,7 +1006,7 @@ pub fn apply_simple_osc_control(
     }
 
     if let Some(rest) = addr.strip_prefix("/omniphony/control/experimental_distance/") {
-        let mut live = ctx.renderer.live.write().unwrap();
+        let mut live = ctx.renderer.live.write();
         let mut changed = false;
         match rest {
             "distance_floor" => {
@@ -1137,7 +1081,7 @@ pub fn apply_simple_osc_control(
     }
 
     if let Some(rest) = addr.strip_prefix("/omniphony/control/barycenter/") {
-        let mut live = ctx.renderer.live.write().unwrap();
+        let mut live = ctx.renderer.live.write();
         let mut changed = false;
         match rest {
             "localize" => {
@@ -1158,7 +1102,7 @@ pub fn apply_simple_osc_control(
     }
 
     if let Some(rest) = addr.strip_prefix("/omniphony/control/hybrid/") {
-        let mut live = ctx.renderer.live.write().unwrap();
+        let mut live = ctx.renderer.live.write();
         let mut changed = false;
         match rest {
             "external_backend" | "internal_backend" => {
@@ -1243,7 +1187,7 @@ pub fn apply_simple_osc_control(
             let l = parse_f32_arg(msg.args.get(1));
             let h = parse_f32_arg(msg.args.get(2));
             if let (Some(w), Some(l), Some(h)) = (w, l, h) {
-                ctx.renderer.live.write().unwrap().room_ratio = [w, l, h];
+                ctx.renderer.live.write().room_ratio = [w, l, h];
                 effects.mark_dirty = true;
                 effects.trigger_layout_recompute = true;
                 effects.log_message = Some(format!("OSC: room_ratio → [{}, {}, {}]", w, l, h));
@@ -1254,7 +1198,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/room_ratio_rear" {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.01)) {
-            ctx.renderer.live.write().unwrap().room_ratio_rear = v;
+            ctx.renderer.live.write().room_ratio_rear = v;
             effects.mark_dirty = true;
             effects.trigger_layout_recompute = true;
             effects.log_message = Some(format!("OSC: room_ratio_rear → {}", v));
@@ -1264,7 +1208,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/room_ratio_lower" {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.01)) {
-            ctx.renderer.live.write().unwrap().room_ratio_lower = v;
+            ctx.renderer.live.write().room_ratio_lower = v;
             effects.mark_dirty = true;
             effects.trigger_layout_recompute = true;
             effects.log_message = Some(format!("OSC: room_ratio_lower → {}", v));
@@ -1274,7 +1218,7 @@ pub fn apply_simple_osc_control(
 
     if addr == "/omniphony/control/room_ratio_center_blend" {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.clamp(0.0, 1.0)) {
-            ctx.renderer.live.write().unwrap().room_ratio_center_blend = v;
+            ctx.renderer.live.write().room_ratio_center_blend = v;
             effects.mark_dirty = true;
             effects.trigger_layout_recompute = true;
             effects.log_message = Some(format!("OSC: room_ratio_center_blend → {}", v));
@@ -1286,7 +1230,7 @@ pub fn apply_simple_osc_control(
         match rest {
             "enabled" => {
                 if let Some(v) = parse_bool_arg(msg.args.first()) {
-                    ctx.renderer.live.write().unwrap().use_distance_diffuse = v;
+                    ctx.renderer.live.write().use_distance_diffuse = v;
                     effects.mark_dirty = true;
                     effects.trigger_layout_recompute = true;
                 }
@@ -1295,7 +1239,7 @@ pub fn apply_simple_osc_control(
             "metric" => {
                 if let Some(OscType::String(metric)) = msg.args.first() {
                     if let Ok(metric) = metric.parse::<renderer::spatial_vbap::DistanceMetric>() {
-                        ctx.renderer.live.write().unwrap().distance_diffuse_metric = metric;
+                        ctx.renderer.live.write().distance_diffuse_metric = metric;
                         effects.mark_dirty = true;
                         effects.trigger_layout_recompute = true;
                     }
@@ -1304,11 +1248,7 @@ pub fn apply_simple_osc_control(
             }
             "threshold" => {
                 if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(1e-6)) {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .unwrap()
-                        .distance_diffuse_threshold = v;
+                    ctx.renderer.live.write().distance_diffuse_threshold = v;
                     effects.mark_dirty = true;
                     effects.trigger_layout_recompute = true;
                 }
@@ -1316,7 +1256,7 @@ pub fn apply_simple_osc_control(
             }
             "curve" => {
                 if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.0)) {
-                    ctx.renderer.live.write().unwrap().distance_diffuse_curve = v;
+                    ctx.renderer.live.write().distance_diffuse_curve = v;
                     effects.mark_dirty = true;
                     effects.trigger_layout_recompute = true;
                 }
@@ -1335,7 +1275,6 @@ pub fn apply_simple_osc_control(
                     ctx.renderer
                         .live
                         .write()
-                        .unwrap()
                         .objects
                         .entry(idx)
                         .or_default()
@@ -1357,7 +1296,6 @@ pub fn apply_simple_osc_control(
                     ctx.renderer
                         .live
                         .write()
-                        .unwrap()
                         .objects
                         .entry(idx)
                         .or_default()

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -25,14 +25,14 @@ pub fn save_live_config(
     host: Option<&dyn HostControlHandler>,
 ) -> Result<SaveLiveConfigResult> {
     let path = {
-        let guard = control.config_path.lock().unwrap();
+        let guard = control.config_path.lock();
         guard
             .as_ref()
             .cloned()
             .ok_or_else(|| anyhow!("no config path available"))?
     };
 
-    let live = control.live.read().unwrap();
+    let live = control.live.read();
     let mut config = renderer::config::Config::load_or_default(&path);
     let render = config.render.get_or_insert_with(Default::default);
     let requested_bridge_path = control.bridge_path();

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -291,7 +291,7 @@ pub fn build_live_state_bundle(
     has_audio: bool,
     has_input: bool,
 ) -> Vec<OscPacket> {
-    let live = control.live.read().unwrap();
+    let live = control.live.read();
     let active_topology = control.active_topology();
     let editable_layout = control.editable_layout();
     let layout_json = serde_json::to_string(&editable_layout).unwrap_or_else(|_| "{}".to_string());

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -375,14 +375,14 @@ fn init_osc_runtime(
             .as_ref()
             .and_then(|cfg| cfg.drc_mode.clone())
             .unwrap_or_else(|| "Off".to_string());
-        ctrl.live.write().unwrap().drc_mode = drc_mode;
+        ctrl.live.write().drc_mode = drc_mode;
 
         let drc_weight = render_cfg
             .as_ref()
             .and_then(|cfg| cfg.drc_weight)
             .unwrap_or(1.0)
             .clamp(0.0, 1.0);
-        ctrl.live.write().unwrap().drc_weight = drc_weight;
+        ctrl.live.write().drc_weight = drc_weight;
 
         // Monitoring cadences: seed RendererControl from config (CLI default
         // 50 Hz). Renderer is the source of truth — OSC-adjustable + persisted.
@@ -400,7 +400,7 @@ fn init_osc_runtime(
         );
 
         ctrl.set_requested_ramp_mode(args.ramp_mode.into());
-        ctrl.live.write().unwrap().ramp_mode = args.ramp_mode.into();
+        ctrl.live.write().ramp_mode = args.ramp_mode.into();
 
         let requested_latency_target_ms = {
             #[cfg(target_os = "linux")]

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -238,7 +238,7 @@ impl DecodeHandler {
     pub fn poll_runtime_state(&mut self) -> Result<()> {
         if let Some(renderer) = self.spatial_renderer.as_ref() {
             let control = renderer.renderer_control();
-            let drc_mode = control.live.read().unwrap().drc_mode.clone();
+            let drc_mode = control.live.read().drc_mode.clone();
 
             if Some(&drc_mode) != self.last_seen_drc_mode.as_ref() {
                 if let Some(ref tx) = self.drc_mode_cmd_tx {

--- a/omniphony-renderer/src/cli/decode/sample_write.rs
+++ b/omniphony-renderer/src/cli/decode/sample_write.rs
@@ -230,7 +230,6 @@ impl<'a> SampleWriteCoordinator<'a> {
                     .renderer_control()
                     .live
                     .read()
-                    .unwrap()
                     .drc_weight
                     .clamp(0.0, 1.0);
                 self.output.drc_target_gain = if drc_weight >= 1.0 {
@@ -366,7 +365,7 @@ impl<'a> SampleWriteCoordinator<'a> {
                     let labels: Vec<RChannelLabel> = frame.channel_labels.iter().copied().collect();
                     let (room_ratio, room_ratio_rear, room_ratio_lower, room_ratio_center_blend) = {
                         let control = renderer.renderer_control();
-                        let live = control.live.read().unwrap();
+                        let live = control.live.read();
                         (
                             live.room_ratio,
                             live.room_ratio_rear,

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -372,7 +372,7 @@ fn effective_output_backend(
 fn log_auto_gain_summary(handler: &DecodeHandler) {
     if let Some(ref renderer) = handler.spatial_renderer {
         if renderer.auto_gain_triggered() {
-            let master_gain = renderer.renderer_control().live.read().unwrap().master_gain;
+            let master_gain = renderer.renderer_control().live.read().master_gain;
             log::warn!(
                 "Auto-gain: master gain was lowered to {:.4} ({:.1} dB) to avoid clipping; \
                  save the config to keep it for future playback.",
@@ -682,7 +682,7 @@ fn run_prepared_render(
         let ctrl = renderer.renderer_control();
         ctrl.set_bridge_supported_drc_modes(prepared.supported_drc_modes.clone());
 
-        let initial_mode = ctrl.live.read().unwrap().drc_mode.clone();
+        let initial_mode = ctrl.live.read().drc_mode.clone();
         *live_drc_mode.write().unwrap() = initial_mode.clone();
         prepared
             .cmd_tx


### PR DESCRIPTION
## Why

The audio render thread acquires the shared `RendererControl` locks (and
`SpatialRenderer::channel_states`) with `std::sync` `RwLock`/`Mutex` and
`.read()/.write()/.lock().unwrap()`. If *any* thread panics while holding one
of those locks, std poisons it, so the next acquisition in the audio callback
re-panics and tears down the stream. `parking_lot` locks cannot be poisoned,
which removes this entire crash class from the realtime path.

This is the safety prerequisite (Phase 0) for opening the renderer to external
contributors: a bug elsewhere must never be able to kill the audio thread
through lock poisoning.

## What

- **renderer**: `RendererControl` (`live`, editable layout, config/bridge
  fields, ramp, backend rebuild params) and `SpatialRenderer::channel_states`
  now use `parking_lot`; dropped 27 guard `.unwrap()`s.
- **audio_output**: pipewire / asio / control locks moved to `parking_lot`
  (dependency added). Edge cases handled explicitly:
  - `try_lock()` return type `Result` → `Option` (the `.map(...).unwrap_or(..)`
    sites keep working; one `if let Ok(_)` → `if let Some(_)`);
  - two `if let Ok(_) = .lock()` rewritten to direct guard access;
  - the PipeWire `main_loop.lock()` (foreign pipewire-rs API, **not** a std
    lock) is left untouched.
- Propagated the guard-type change through `runtime_control`,
  `orender_engine` and the `orender` binary call sites that touch
  `control.live`.

## Out of scope (intentionally still on std locks)

`orender_engine`'s own OSC client-registry / gaintable / overlay mutexes and
the CLI `live_drc_mode` lock — none of these are on the audio hot path. They
can be revisited separately if desired.

## Validation

- No behavioural change (mechanical refactor).
- `cargo fmt --all -- --check` clean.
- `cargo build --workspace` green.
- `cargo test --workspace` green (incl. doctests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)