### PR TITLE
feat: open the render-backend frontier via a registration registry

### DIFF
--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -22,20 +22,25 @@
 //! Do expensive setup (here: normalising the speaker directions) when the model
 //! is built, never in `compute_gains`. See the `GainModel` trait docs.
 //!
-//! ## Known limitation (lifted by the backend-frontier refactor)
+//! ## Selecting it at runtime
 //!
-//! A backend can be *implemented* from outside today, but it cannot yet be
-//! *selected* at runtime without editing the renderer's central
-//! [`GainModelKind`] enum and the backend registry. That is why [`kind`] below
-//! has to borrow an existing variant. Opening that frontier (registration
-//! without touching core enums) is the next step.
+//! Implement [`BackendFactory`] (see [`ExampleFactory`]) and a host registers it
+//! with `RendererControl::register_backend`; selecting `backend_id = "example"`
+//! then routes a topology rebuild through it — no central enum or `match` to edit.
+//!
+//! One rough edge remains: [`GainModelKind`] is still a closed enum in `renderer`,
+//! so [`kind`] below has to borrow an existing variant. Moving identity onto the
+//! factory (to retire that enum) is the next step.
 //!
 //! [`kind`]: GainModel::kind
 
+use renderer::backend_registry::{
+    BackendBuildCtx, BackendBuildPlan, BackendFactory, DynamicBackendPlan,
+};
 use renderer::render_backend::{
     BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse,
 };
-use renderer::spatial_vbap::Gains;
+use renderer::spatial_vbap::{Gains, spherical_to_adm};
 use renderer::speaker_layout::SpeakerLayout;
 
 /// Sharpness of the cosine lobe: higher = tighter localisation on the nearest
@@ -142,6 +147,40 @@ impl GainModel for ExampleBackend {
         // `supports_table_export` is false, so the host never calls this for a
         // real export; be explicit rather than silently succeeding.
         anyhow::bail!("example backend does not support table export")
+    }
+}
+
+/// Registers [`ExampleBackend`] under the id `"example"`.
+///
+/// This is the other half of the skeleton: implement [`BackendFactory`] and a
+/// host can `register` it (`RendererControl::register_backend`) at startup, after
+/// which selecting `backend_id = "example"` routes a topology rebuild through it.
+/// Note there is no central enum or `match` to edit — the factory returns a
+/// [`BackendBuildPlan::Dynamic`] whose closure builds the model from the layout.
+pub struct ExampleFactory;
+
+impl BackendFactory for ExampleFactory {
+    fn id(&self) -> &'static str {
+        "example"
+    }
+
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+        // Capture the spatializable speaker directions now (build thread), so the
+        // model builder closure owns everything it needs and the hot path does no
+        // layout lookups. Azimuth/elevation pairs are converted to unit vectors.
+        let (azimuth_elevation, _spatializable_indices) = ctx.layout.spatializable_positions();
+        let speaker_positions: Vec<[f32; 3]> = azimuth_elevation
+            .iter()
+            .map(|[az, el]| {
+                let (x, y, z) = spherical_to_adm(*az, *el, 1.0);
+                [x, y, z]
+            })
+            .collect();
+
+        Some(BackendBuildPlan::Dynamic(DynamicBackendPlan::new(
+            "example",
+            move || Ok(Box::new(ExampleBackend::new(&speaker_positions))),
+        )))
     }
 }
 

--- a/omniphony-renderer/orender_engine/Cargo.toml
+++ b/omniphony-renderer/orender_engine/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/mgth/Omniphony"
 
 [dependencies]
 renderer = { version = "0.2.4", path = "../renderer" }
+# Demonstration render backend, registered at startup to prove the open backend
+# frontier end-to-end. A real deployment would register/discover backends here.
+example_backend = { path = "../example_backend" }
 bridge_api = { version = "0.2.0", path = "../bridge_api" }
 runtime_control = { version = "0.2.4", path = "../runtime_control" }
 sys = { version = "0.1.0", path = "../sys" }

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -370,9 +370,9 @@ pub fn build_spatial_renderer(
     };
 
     log::info!("VBAP spatial rendering enabled");
-    let configured_backend = render_cfg
-        .and_then(|cfg| cfg.render_backend.as_deref())
-        .and_then(RenderBackendKind::from_str);
+    // Raw configured backend id; resolved against the enum aliases *and* the
+    // registry below (so a registered out-of-tree backend id is selectable too).
+    let configured_backend_cfg = render_cfg.and_then(|cfg| cfg.render_backend.as_deref());
     let configured_evaluation = render_cfg
         .and_then(|cfg| cfg.render_evaluation_mode.as_deref())
         .and_then(LiveEvaluationMode::from_str);
@@ -437,12 +437,21 @@ pub fn build_spatial_renderer(
     });
     {
         let control = renderer.renderer_control();
+        // Register the demonstration backend so `backend_id = "example"` resolves.
+        control.register_backend(Box::new(example_backend::ExampleFactory));
+        // Resolve the configured backend id: enum names/aliases first (e.g.
+        // "distance" -> experimental_distance), then any registered backend id.
+        let configured_backend = configured_backend_cfg.and_then(|raw| {
+            RenderBackendKind::from_str(raw)
+                .map(|kind| kind.as_str().to_string())
+                .or_else(|| control.has_backend(raw).then(|| raw.to_string()))
+        });
         let mut requires_rebuild = false;
         {
             let mut live = control.live.write();
-            if let Some(configured_backend) = configured_backend {
-                if live.backend_id() != configured_backend.as_str() {
-                    live.backend_id = configured_backend.as_str().to_string();
+            if let Some(configured_backend) = &configured_backend {
+                if live.backend_id() != configured_backend {
+                    live.backend_id = configured_backend.clone();
                     requires_rebuild = true;
                 }
             }

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -648,6 +648,7 @@ impl BackendFactory for HybridFactory {
 }
 
 pub fn prepare_topology_build_plan(
+    registry: &BackendRegistry,
     layout: SpeakerLayout,
     live: &LiveParams,
     backend_rebuild_params: Option<BackendRebuildParams>,
@@ -655,7 +656,6 @@ pub fn prepare_topology_build_plan(
 ) -> Option<TopologyBuildPlan> {
     // Dispatch through the registry instead of a hard-coded `match` on the id, so
     // a backend's construction lives with the backend rather than here.
-    let registry = BackendRegistry::builtin();
     let factory = registry.get(live.backend_id())?;
     let ctx = BackendBuildCtx {
         layout: &layout,

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -504,73 +504,175 @@ fn preferred_evaluation_mode(
         .unwrap_or(PreferredEvaluationMode::PrecomputedCartesian)
 }
 
+/// Inputs available to a [`BackendFactory`] when it builds its plan: the resolved
+/// speaker layout, the live parameters, and the optional geometry rebuild params
+/// (present for backends that need triangulation, e.g. VBAP).
+pub struct BackendBuildCtx<'a> {
+    pub layout: &'a SpeakerLayout,
+    pub live: &'a LiveParams,
+    pub backend_rebuild_params: Option<BackendRebuildParams>,
+}
+
+/// A render backend's registration entry: a stable id plus how to build its gain
+/// model plan for a given context.
+///
+/// Implement this and `register` it into a [`BackendRegistry`] to add a backend
+/// without editing the central dispatch. Identity is data (a string id), not an
+/// enum variant, so a backend can live in its own crate.
+pub trait BackendFactory: Send + Sync {
+    /// Stable identifier matched against `LiveParams::backend_id()` (e.g. `"vbap"`).
+    fn id(&self) -> &'static str;
+    /// Build this backend's plan, or `None` if it cannot be prepared for the
+    /// given context (e.g. VBAP without geometry rebuild params).
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan>;
+}
+
+/// Ordered set of backend factories keyed by id. Use [`BackendRegistry::builtin`]
+/// for the shipped backends; a host can `register` additional ones at startup.
+pub struct BackendRegistry {
+    factories: Vec<Box<dyn BackendFactory>>,
+}
+
+impl BackendRegistry {
+    pub fn new() -> Self {
+        Self {
+            factories: Vec::new(),
+        }
+    }
+
+    /// Registry preloaded with the built-in backends.
+    pub fn builtin() -> Self {
+        let mut registry = Self::new();
+        registry.register(Box::new(VbapFactory));
+        registry.register(Box::new(BarycenterFactory));
+        registry.register(Box::new(ExperimentalDistanceFactory));
+        registry.register(Box::new(HybridFactory));
+        registry
+    }
+
+    /// Register a backend. A later registration with the same id replaces the
+    /// earlier one, so a host can override a built-in.
+    pub fn register(&mut self, factory: Box<dyn BackendFactory>) {
+        let id = factory.id();
+        match self.factories.iter_mut().find(|f| f.id() == id) {
+            Some(slot) => *slot = factory,
+            None => self.factories.push(factory),
+        }
+    }
+
+    /// Look up a factory by id.
+    pub fn get(&self, id: &str) -> Option<&dyn BackendFactory> {
+        self.factories
+            .iter()
+            .find(|f| f.id() == id)
+            .map(|f| f.as_ref())
+    }
+
+    /// Ids of all registered backends, in registration order.
+    pub fn ids(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.factories.iter().map(|f| f.id())
+    }
+}
+
+impl Default for BackendRegistry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+struct VbapFactory;
+impl BackendFactory for VbapFactory {
+    fn id(&self) -> &'static str {
+        "vbap"
+    }
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+        build_vbap_build_plan(ctx.layout, ctx.live, ctx.backend_rebuild_params?)
+    }
+}
+
+struct BarycenterFactory;
+impl BackendFactory for BarycenterFactory {
+    fn id(&self) -> &'static str {
+        "barycenter"
+    }
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+        Some(BackendBuildPlan::Barycenter(BarycenterBuildPlan {
+            speaker_positions: collect_spatializable_positions(ctx.layout),
+        }))
+    }
+}
+
+struct ExperimentalDistanceFactory;
+impl BackendFactory for ExperimentalDistanceFactory {
+    fn id(&self) -> &'static str {
+        "experimental_distance"
+    }
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+        Some(BackendBuildPlan::ExperimentalDistance(
+            ExperimentalDistanceBuildPlan {
+                speaker_positions: collect_spatializable_positions(ctx.layout),
+            },
+        ))
+    }
+}
+
+struct HybridFactory;
+impl BackendFactory for HybridFactory {
+    fn id(&self) -> &'static str {
+        "hybrid"
+    }
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+        // The hybrid backend composes two inner backends. Inner composition still
+        // goes through `build_inner_backend_plan` (vbap / barycenter /
+        // experimental_distance), so its supported inner set is unchanged.
+        let external = build_inner_backend_plan(
+            &ctx.live.hybrid.external_backend_id,
+            ctx.layout,
+            ctx.live,
+            ctx.backend_rebuild_params,
+        )?;
+        let internal = build_inner_backend_plan(
+            &ctx.live.hybrid.internal_backend_id,
+            ctx.layout,
+            ctx.live,
+            ctx.backend_rebuild_params,
+        )?;
+        Some(BackendBuildPlan::Hybrid(HybridBuildPlan {
+            external: Box::new(external),
+            internal: Box::new(internal),
+            curve: ctx.live.hybrid.curve.clone(),
+            curve_smoothing: ctx.live.hybrid.curve_smoothing,
+            metric: ctx.live.hybrid.metric,
+        }))
+    }
+}
+
 pub fn prepare_topology_build_plan(
     layout: SpeakerLayout,
     live: &LiveParams,
     backend_rebuild_params: Option<BackendRebuildParams>,
     evaluation_build_config: crate::render_backend::EvaluationBuildConfig,
 ) -> Option<TopologyBuildPlan> {
-    match live.backend_id() {
-        "barycenter" | "experimental_distance" => {
-            let backend_build =
-                build_inner_backend_plan(live.backend_id(), &layout, live, backend_rebuild_params)?;
-            let preferred = preferred_evaluation_mode(backend_rebuild_params);
-            Some(TopologyBuildPlan {
-                layout,
-                backend_id: live.backend_id().to_string(),
-                backend_build,
-                evaluation_mode: effective_live_evaluation_mode(live.evaluation.mode, preferred),
-                evaluation_build_config,
-                geometry_generation: 0,
-            })
-        }
-        "hybrid" => {
-            let external = build_inner_backend_plan(
-                &live.hybrid.external_backend_id,
-                &layout,
-                live,
-                backend_rebuild_params,
-            )?;
-            let internal = build_inner_backend_plan(
-                &live.hybrid.internal_backend_id,
-                &layout,
-                live,
-                backend_rebuild_params,
-            )?;
-            let preferred = preferred_evaluation_mode(backend_rebuild_params);
-            Some(TopologyBuildPlan {
-                layout,
-                backend_id: live.backend_id().to_string(),
-                backend_build: BackendBuildPlan::Hybrid(HybridBuildPlan {
-                    external: Box::new(external),
-                    internal: Box::new(internal),
-                    curve: live.hybrid.curve.clone(),
-                    curve_smoothing: live.hybrid.curve_smoothing,
-                    metric: live.hybrid.metric,
-                }),
-                evaluation_mode: effective_live_evaluation_mode(live.evaluation.mode, preferred),
-                evaluation_build_config,
-                geometry_generation: 0,
-            })
-        }
-        "vbap" => {
-            let rebuild_params = backend_rebuild_params?;
-            let effective_mode = effective_live_evaluation_mode(
-                live.evaluation.mode,
-                rebuild_params.preferred_evaluation_mode(),
-            );
-            let backend_build = build_vbap_build_plan(&layout, live, rebuild_params)?;
-            Some(TopologyBuildPlan {
-                layout,
-                backend_id: live.backend_id().to_string(),
-                backend_build,
-                evaluation_mode: effective_mode,
-                evaluation_build_config,
-                geometry_generation: 0,
-            })
-        }
-        _ => None,
-    }
+    // Dispatch through the registry instead of a hard-coded `match` on the id, so
+    // a backend's construction lives with the backend rather than here.
+    let registry = BackendRegistry::builtin();
+    let factory = registry.get(live.backend_id())?;
+    let ctx = BackendBuildCtx {
+        layout: &layout,
+        live,
+        backend_rebuild_params,
+    };
+    let backend_build = factory.build_plan(&ctx)?;
+    let preferred = preferred_evaluation_mode(backend_rebuild_params);
+    let evaluation_mode = effective_live_evaluation_mode(live.evaluation.mode, preferred);
+    Some(TopologyBuildPlan {
+        layout,
+        backend_id: live.backend_id().to_string(),
+        backend_build,
+        evaluation_mode,
+        evaluation_build_config,
+        geometry_generation: 0,
+    })
 }
 
 #[cfg(test)]
@@ -739,5 +841,41 @@ mod tests {
         let engine = realtime_engine(Box::new(GoodBackend));
         smoke_test_engine(&engine, &build_config(), "good_backend")
             .expect("well-behaved backend passes the smoke test");
+    }
+
+    struct DummyFactory(&'static str);
+    impl BackendFactory for DummyFactory {
+        fn id(&self) -> &'static str {
+            self.0
+        }
+        fn build_plan(&self, _ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+            None
+        }
+    }
+
+    #[test]
+    fn builtin_registry_exposes_known_backends() {
+        let registry = BackendRegistry::builtin();
+        let ids: Vec<_> = registry.ids().collect();
+        for expected in ["vbap", "barycenter", "experimental_distance", "hybrid"] {
+            assert!(
+                ids.contains(&expected),
+                "missing builtin backend {expected}"
+            );
+        }
+        assert!(registry.get("vbap").is_some());
+        assert!(registry.get("does_not_exist").is_none());
+    }
+
+    #[test]
+    fn register_adds_then_overrides_by_id() {
+        let mut registry = BackendRegistry::new();
+        registry.register(Box::new(DummyFactory("custom")));
+        assert!(registry.get("custom").is_some());
+
+        let count = registry.ids().count();
+        // Re-registering the same id replaces the entry instead of appending.
+        registry.register(Box::new(DummyFactory("custom")));
+        assert_eq!(registry.ids().count(), count);
     }
 }

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -90,6 +90,34 @@ fn smoke_test_engine(
     Ok(())
 }
 
+/// A backend plan whose gain model is produced by an opaque builder closure
+/// rather than one of the built-in typed variants. This is how an out-of-tree
+/// backend (one whose `BackendFactory` lives in another crate) plugs into the
+/// build pipeline: the factory captures whatever it needs from the build context
+/// into the closure. Cloneable (the closure is shared via `Arc`) so it can ride
+/// inside a `TopologyBuildPlan` like the typed variants.
+#[derive(Clone)]
+pub struct DynamicBackendPlan {
+    id: &'static str,
+    builder: Arc<dyn Fn() -> Result<Box<dyn GainModel>> + Send + Sync>,
+}
+
+impl DynamicBackendPlan {
+    pub fn new(
+        id: &'static str,
+        builder: impl Fn() -> Result<Box<dyn GainModel>> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            id,
+            builder: Arc::new(builder),
+        }
+    }
+
+    pub fn id(&self) -> &'static str {
+        self.id
+    }
+}
+
 #[derive(Clone)]
 pub enum BackendBuildPlan {
     Vbap(VbapTopologyBuildPlan),
@@ -100,6 +128,9 @@ pub enum BackendBuildPlan {
     Barycenter(BarycenterBuildPlan),
     ExperimentalDistance(ExperimentalDistanceBuildPlan),
     Hybrid(HybridBuildPlan),
+    /// A backend supplied by a registered [`BackendFactory`] that is not one of
+    /// the built-in variants (e.g. a contributor backend in its own crate).
+    Dynamic(DynamicBackendPlan),
 }
 
 impl BackendBuildPlan {
@@ -113,6 +144,7 @@ impl BackendBuildPlan {
             BackendBuildPlan::Barycenter(plan) => plan.build_gain_model(),
             BackendBuildPlan::ExperimentalDistance(plan) => plan.build_gain_model(),
             BackendBuildPlan::Hybrid(plan) => plan.build_gain_model(),
+            BackendBuildPlan::Dynamic(plan) => (plan.builder)(),
         }
     }
 }
@@ -351,6 +383,11 @@ impl TopologyBuildPlan {
                 inner_backend_summary(&plan.internal),
                 plan.curve.len()
             ),
+            BackendBuildPlan::Dynamic(plan) => format!(
+                "gain_model={} evaluation_mode={}",
+                plan.id(),
+                self.evaluation_mode().as_str()
+            ),
         }
     }
 }
@@ -362,6 +399,7 @@ fn inner_backend_summary(plan: &BackendBuildPlan) -> &'static str {
         BackendBuildPlan::Barycenter(_) => "barycenter",
         BackendBuildPlan::ExperimentalDistance(_) => "experimental_distance",
         BackendBuildPlan::Hybrid(_) => "hybrid",
+        BackendBuildPlan::Dynamic(plan) => plan.id(),
     }
 }
 
@@ -877,5 +915,48 @@ mod tests {
         // Re-registering the same id replaces the entry instead of appending.
         registry.register(Box::new(DummyFactory("custom")));
         assert_eq!(registry.ids().count(), count);
+    }
+
+    /// A factory for an out-of-tree backend: it produces a `Dynamic` plan whose
+    /// builder constructs an arbitrary `GainModel`, with no dedicated enum variant
+    /// and no central `match` edit.
+    struct DynamicFactory;
+    impl BackendFactory for DynamicFactory {
+        fn id(&self) -> &'static str {
+            "dynamic_example"
+        }
+        fn build_plan(&self, _ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+            Some(BackendBuildPlan::Dynamic(DynamicBackendPlan::new(
+                "dynamic_example",
+                || Ok(Box::new(GoodBackend)),
+            )))
+        }
+    }
+
+    #[test]
+    fn dynamic_plan_builds_an_arbitrary_gain_model() {
+        let plan = BackendBuildPlan::Dynamic(DynamicBackendPlan::new("dynamic_example", || {
+            Ok(Box::new(GoodBackend))
+        }));
+        // The plan is cloneable (it rides inside a TopologyBuildPlan)...
+        let cloned = plan.clone();
+        // ...and both build the model the closure returns.
+        assert_eq!(
+            plan.build_gain_model().unwrap().speaker_count(),
+            TEST_SPEAKERS
+        );
+        assert_eq!(
+            cloned.build_gain_model().unwrap().backend_id(),
+            "good_backend"
+        );
+    }
+
+    #[test]
+    fn registered_dynamic_factory_is_retrievable() {
+        let mut registry = BackendRegistry::builtin();
+        registry.register(Box::new(DynamicFactory));
+        // An out-of-tree factory registers and is found by id alongside builtins.
+        assert!(registry.get("dynamic_example").is_some());
+        assert!(registry.get("vbap").is_some());
     }
 }

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -656,9 +656,11 @@ pub struct RendererControl {
     pub diag_rate_hz_bits: Arc<std::sync::atomic::AtomicU32>,
 
     /// Available render backends, queried by `prepare_topology_rebuild_for_layout`
-    /// to build the active backend by id. Defaults to the built-ins; a host can
-    /// inject extra backends via [`RendererControl::new_with_registry`].
-    backend_registry: Arc<BackendRegistry>,
+    /// to build the active backend by id. Defaults to the built-ins; a host
+    /// registers extra backends at startup via [`RendererControl::register_backend`].
+    /// Behind a lock because registration happens after construction (the control
+    /// is already shared); only read off the audio hot path (topology rebuild).
+    backend_registry: RwLock<BackendRegistry>,
 }
 
 impl RendererControl {
@@ -673,24 +675,6 @@ impl RendererControl {
         initial_topology: RenderTopology,
         editable_layout: SpeakerLayout,
         backend_rebuild_params: Option<BackendRebuildParams>,
-    ) -> Arc<Self> {
-        Self::new_with_registry(
-            live,
-            initial_topology,
-            editable_layout,
-            backend_rebuild_params,
-            Arc::new(BackendRegistry::builtin()),
-        )
-    }
-
-    /// Like [`new`](Self::new) but with a host-provided backend registry, so a
-    /// host can register additional render backends before the control is shared.
-    pub fn new_with_registry(
-        live: LiveParams,
-        initial_topology: RenderTopology,
-        editable_layout: SpeakerLayout,
-        backend_rebuild_params: Option<BackendRebuildParams>,
-        backend_registry: Arc<BackendRegistry>,
     ) -> Arc<Self> {
         Arc::new(Self {
             live: RwLock::new(live),
@@ -714,13 +698,21 @@ impl RendererControl {
             // Seeded from config (or a host default) after construction.
             meter_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
             diag_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
-            backend_registry,
+            backend_registry: RwLock::new(BackendRegistry::builtin()),
         })
     }
 
-    /// The render backends available to this control.
-    pub fn backend_registry(&self) -> &BackendRegistry {
-        &self.backend_registry
+    /// Register an additional render backend. Call at startup, before audio runs;
+    /// a later registration with the same id overrides the earlier one. Selecting
+    /// the backend by its id (`LiveParams::backend_id`) then routes a topology
+    /// rebuild through it.
+    pub fn register_backend(&self, factory: Box<dyn crate::backend_registry::BackendFactory>) {
+        self.backend_registry.write().register(factory);
+    }
+
+    /// Whether a backend with this id is registered (built-in or host-registered).
+    pub fn has_backend(&self, id: &str) -> bool {
+        self.backend_registry.read().get(id).is_some()
     }
 
     /// Shared meter-cadence atomic (Hz bits) for `AudioMeter::new_with_rate_atomic`.
@@ -869,8 +861,9 @@ impl RendererControl {
             rebuild_params_allow_negative_z(backend_rebuild_params),
         );
         let geometry_generation = self.geometry_generation();
+        let registry = self.backend_registry.read();
         prepare_topology_build_plan(
-            &self.backend_registry,
+            &registry,
             layout,
             &live,
             backend_rebuild_params,

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
-use crate::backend_registry::{TopologyBuildPlan, prepare_topology_build_plan};
+use crate::backend_registry::{BackendRegistry, TopologyBuildPlan, prepare_topology_build_plan};
 use crate::render_backend::backend_descriptor_by_id;
 use crate::render_backend::{
     EvaluationBuildConfig, GainModelKind, PreparedRenderEngine, RenderBackendKind, RenderRequest,
@@ -654,6 +654,11 @@ pub struct RendererControl {
     /// OSC diag-publication cadence in Hz (`f32::to_bits`). Read lock-free by
     /// the diag publisher; OSC-adjustable and persisted to config.
     pub diag_rate_hz_bits: Arc<std::sync::atomic::AtomicU32>,
+
+    /// Available render backends, queried by `prepare_topology_rebuild_for_layout`
+    /// to build the active backend by id. Defaults to the built-ins; a host can
+    /// inject extra backends via [`RendererControl::new_with_registry`].
+    backend_registry: Arc<BackendRegistry>,
 }
 
 impl RendererControl {
@@ -668,6 +673,24 @@ impl RendererControl {
         initial_topology: RenderTopology,
         editable_layout: SpeakerLayout,
         backend_rebuild_params: Option<BackendRebuildParams>,
+    ) -> Arc<Self> {
+        Self::new_with_registry(
+            live,
+            initial_topology,
+            editable_layout,
+            backend_rebuild_params,
+            Arc::new(BackendRegistry::builtin()),
+        )
+    }
+
+    /// Like [`new`](Self::new) but with a host-provided backend registry, so a
+    /// host can register additional render backends before the control is shared.
+    pub fn new_with_registry(
+        live: LiveParams,
+        initial_topology: RenderTopology,
+        editable_layout: SpeakerLayout,
+        backend_rebuild_params: Option<BackendRebuildParams>,
+        backend_registry: Arc<BackendRegistry>,
     ) -> Arc<Self> {
         Arc::new(Self {
             live: RwLock::new(live),
@@ -691,7 +714,13 @@ impl RendererControl {
             // Seeded from config (or a host default) after construction.
             meter_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
             diag_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
+            backend_registry,
         })
+    }
+
+    /// The render backends available to this control.
+    pub fn backend_registry(&self) -> &BackendRegistry {
+        &self.backend_registry
     }
 
     /// Shared meter-cadence atomic (Hz bits) for `AudioMeter::new_with_rate_atomic`.
@@ -841,6 +870,7 @@ impl RendererControl {
         );
         let geometry_generation = self.geometry_generation();
         prepare_topology_build_plan(
+            &self.backend_registry,
             layout,
             &live,
             backend_rebuild_params,


### PR DESCRIPTION
## Why

Phase 1 of making the renderer welcoming to contributors. Adding a render
backend used to mean editing several central points: the `match
live.backend_id()` dispatch, the closed `BackendBuildPlan` enum, the
`RenderBackendKind` / `GainModelKind` enums and the static descriptor table.

This PR lands the **foundation**: a backend can now live in its own crate,
register itself, and be selected at runtime **without touching any central
enum or `match`** on the build path. The bundled `example_backend` proves it
end-to-end.

## What

Four incremental, behaviour-preserving steps:

1. **Registry dispatch** — `BackendFactory` (`id` + `build_plan(ctx)`),
   `BackendRegistry` (`register`/`get`/`ids`/`builtin`), `BackendBuildCtx`.
   `prepare_topology_build_plan` resolves a factory by id and delegates; the
   four builtin factories wrap the existing build helpers verbatim.
2. **Host-owned registry** — `RendererControl` holds the registry (behind a
   lock, read only off the audio hot path) and exposes `register_backend()` /
   `has_backend()`. Registration is a post-construction `&self` call, so we
   avoid threading a registry through the 33-arg `SpatialRenderer::new`.
3. **`BackendBuildPlan::Dynamic`** — a clonable `Arc`-shared builder closure
   producing any `Box<dyn GainModel>`, so an out-of-tree factory has something
   to return without a dedicated enum variant.
4. **End-to-end** — `example_backend::ExampleFactory` returns a `Dynamic` plan;
   `orender_engine` registers it and resolves the configured backend id against
   the enum aliases *and* the registry, so `render_backend = "example"` selects
   it and triggers the normal startup rebuild. The build-time smoke test (#25)
   covers it like any other backend.

## Behaviour

No change for the shipped backends — the builtin factories call the same
construction code, and the dispatch is equivalent. Backend capabilities already
flow from the live model instance (`snapshot.rs`), so a registered backend
reports its own capabilities to Studio.

## Not in this PR (follow-ups)

- Move identity / label / capabilities / a declarative **param schema** onto
  `BackendFactory` and retire the static descriptor table and the
  `RenderBackendKind` / `GainModelKind` enums.
- Generate the Studio controls from that param schema (retires the manual
  snake_case→camelCase bridge).

`example_backend`'s `kind()` still borrows `GainModelKind::Vbap` because that
enum is still closed — that is the first thing the identity follow-up removes.

## Validation

- `cargo build --workspace` green.
- `cargo test --workspace` green (registry dispatch/override, `Dynamic` plan
  build+clone, plus the existing suite incl. the backend smoke tests).
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)