### PR TITLE
feat(renderer): publish registry-sourced backend list in OSC state

### DIFF
--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -164,6 +164,10 @@ impl BackendFactory for ExampleFactory {
         "example"
     }
 
+    fn label(&self) -> &'static str {
+        "Example (cosine panner)"
+    }
+
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         // Capture the spatializable speaker directions now (build thread), so the
         // model builder closure owns everything it needs and the hot path does no

--- a/omniphony-renderer/orender_engine/src/osc/recompute.rs
+++ b/omniphony-renderer/orender_engine/src/osc/recompute.rs
@@ -95,7 +95,12 @@ pub(crate) fn trigger_layout_recompute(
                         let live = control_clone.live.read();
                         let topology = control_clone.active_topology();
                         let scale_m = control_clone.editable_layout().radius_m;
-                        build_renderer_state_json(&live, &topology, scale_m)
+                        build_renderer_state_json(
+                            &live,
+                            &topology,
+                            scale_m,
+                            control_clone.available_backends(),
+                        )
                     };
                     let layout_json = {
                         let layout = control_clone.editable_layout();

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -560,9 +560,22 @@ pub struct BackendBuildCtx<'a> {
 pub trait BackendFactory: Send + Sync {
     /// Stable identifier matched against `LiveParams::backend_id()` (e.g. `"vbap"`).
     fn id(&self) -> &'static str;
+    /// Human-facing name shown in the UI. Defaults to the id.
+    fn label(&self) -> &'static str {
+        self.id()
+    }
     /// Build this backend's plan, or `None` if it cannot be prepared for the
     /// given context (e.g. VBAP without geometry rebuild params).
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan>;
+}
+
+/// A registered backend's UI-facing identity, reported by
+/// [`BackendRegistry::available`] so a host can list the selectable backends
+/// (built-in and contributor-registered alike) without a hard-coded table.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct BackendListing {
+    pub id: &'static str,
+    pub label: &'static str,
 }
 
 /// Ordered set of backend factories keyed by id. Use [`BackendRegistry::builtin`]
@@ -610,6 +623,18 @@ impl BackendRegistry {
     pub fn ids(&self) -> impl Iterator<Item = &'static str> + '_ {
         self.factories.iter().map(|f| f.id())
     }
+
+    /// Id + label of every registered backend, in registration order — the list
+    /// a host publishes so the UI can offer them for selection.
+    pub fn available(&self) -> Vec<BackendListing> {
+        self.factories
+            .iter()
+            .map(|f| BackendListing {
+                id: f.id(),
+                label: f.label(),
+            })
+            .collect()
+    }
 }
 
 impl Default for BackendRegistry {
@@ -623,6 +648,9 @@ impl BackendFactory for VbapFactory {
     fn id(&self) -> &'static str {
         "vbap"
     }
+    fn label(&self) -> &'static str {
+        "VBAP"
+    }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         build_vbap_build_plan(ctx.layout, ctx.live, ctx.backend_rebuild_params?)
     }
@@ -632,6 +660,9 @@ struct BarycenterFactory;
 impl BackendFactory for BarycenterFactory {
     fn id(&self) -> &'static str {
         "barycenter"
+    }
+    fn label(&self) -> &'static str {
+        "Barycenter"
     }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         Some(BackendBuildPlan::Barycenter(BarycenterBuildPlan {
@@ -644,6 +675,9 @@ struct ExperimentalDistanceFactory;
 impl BackendFactory for ExperimentalDistanceFactory {
     fn id(&self) -> &'static str {
         "experimental_distance"
+    }
+    fn label(&self) -> &'static str {
+        "Distance"
     }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         Some(BackendBuildPlan::ExperimentalDistance(
@@ -658,6 +692,9 @@ struct HybridFactory;
 impl BackendFactory for HybridFactory {
     fn id(&self) -> &'static str {
         "hybrid"
+    }
+    fn label(&self) -> &'static str {
+        "Hybrid"
     }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         // The hybrid backend composes two inner backends. Inner composition still
@@ -949,6 +986,18 @@ mod tests {
             cloned.build_gain_model().unwrap().backend_id(),
             "good_backend"
         );
+    }
+
+    #[test]
+    fn available_lists_id_and_label() {
+        let listings = BackendRegistry::builtin().available();
+        let vbap = listings
+            .iter()
+            .find(|l| l.id == "vbap")
+            .expect("vbap listed");
+        assert_eq!(vbap.label, "VBAP");
+        // Every builtin reports a non-empty label.
+        assert!(listings.iter().all(|l| !l.label.is_empty()));
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -715,6 +715,12 @@ impl RendererControl {
         self.backend_registry.read().get(id).is_some()
     }
 
+    /// Id + label of every registered backend, for the host to publish so the UI
+    /// can list the selectable backends (built-in and contributor-registered).
+    pub fn available_backends(&self) -> Vec<crate::backend_registry::BackendListing> {
+        self.backend_registry.read().available()
+    }
+
     /// Shared meter-cadence atomic (Hz bits) for `AudioMeter::new_with_rate_atomic`.
     pub fn meter_rate_atomic(&self) -> Arc<std::sync::atomic::AtomicU32> {
         Arc::clone(&self.meter_rate_hz_bits)

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -38,6 +38,8 @@ pub struct RenderBackendStateSnapshot {
     pub selection: String,
     pub effective: String,
     pub effective_label: String,
+    /// Every selectable backend (built-in + host-registered), for the UI list.
+    pub available_backends: Vec<renderer::backend_registry::BackendListing>,
     pub capabilities: renderer::render_backend::BackendCapabilities,
     pub allowed_evaluation_modes: Vec<String>,
     pub frozen_room_ratio: bool,
@@ -69,6 +71,7 @@ fn allowed_evaluation_modes(
 pub fn build_render_backend_state_snapshot(
     live: &LiveParams,
     active_topology: &RenderTopology,
+    available_backends: Vec<renderer::backend_registry::BackendListing>,
 ) -> RenderBackendStateSnapshot {
     let backend = &active_topology.backend;
     let capabilities = backend.capabilities();
@@ -76,6 +79,7 @@ pub fn build_render_backend_state_snapshot(
         selection: live.backend_id().to_string(),
         effective: backend.backend_id().to_string(),
         effective_label: backend.backend_label().to_string(),
+        available_backends,
         capabilities,
         allowed_evaluation_modes: allowed_evaluation_modes(backend, capabilities),
         frozen_room_ratio: false,
@@ -105,19 +109,26 @@ pub fn build_render_backend_state_snapshot(
 pub fn build_render_backend_state_json(
     live: &LiveParams,
     active_topology: &RenderTopology,
+    available_backends: Vec<renderer::backend_registry::BackendListing>,
 ) -> String {
-    serde_json::to_string(&build_render_backend_state_snapshot(live, active_topology))
-        .unwrap_or_else(|_| "{}".to_string())
+    serde_json::to_string(&build_render_backend_state_snapshot(
+        live,
+        active_topology,
+        available_backends,
+    ))
+    .unwrap_or_else(|_| "{}".to_string())
 }
 
 pub fn build_renderer_state_json(
     live: &LiveParams,
     active_topology: &RenderTopology,
     room_scale_m: f32,
+    available_backends: Vec<renderer::backend_registry::BackendListing>,
 ) -> String {
     let effective_backend = active_topology.backend.kind().as_str();
     let effective_evaluation_mode = active_topology.backend.evaluation_mode().as_str();
-    let render_backend_state_json = build_render_backend_state_json(live, active_topology);
+    let render_backend_state_json =
+        build_render_backend_state_json(live, active_topology, available_backends);
     json!({
         "renderBackend": live.backend_id(),
         "renderBackendEffective": effective_backend,
@@ -300,8 +311,12 @@ pub fn build_live_state_bundle(
         (true, Some(dl)) => 10.0_f32.powf((-31 - dl as i32) as f32 / 20.0),
         _ => 1.0,
     };
-    let renderer_state_json =
-        build_renderer_state_json(&live, &active_topology, editable_layout.radius_m);
+    let renderer_state_json = build_renderer_state_json(
+        &live,
+        &active_topology,
+        editable_layout.radius_m,
+        control.available_backends(),
+    );
 
     let mut messages = vec![
         OscPacket::Message(OscMessage {


### PR DESCRIPTION
## Why

Follow-up to #28 (open backend frontier). The set of selectable backends shown
in Studio is currently a hard-coded HTML list, so a registered out-of-tree
backend (e.g. `example`) can be built and selected but never appears as a
choice. This starts moving backend **identity** off the static descriptor table
and onto the registry, and publishes the list so the UI can be driven by it.

## What

- `BackendFactory` gains `label()` (defaults to the id); the built-in and
  `example` factories declare their labels.
- `BackendRegistry::available() -> Vec<BackendListing { id, label }>` and
  `RendererControl::available_backends()` expose the registered set.
- The render-backend OSC state snapshot carries a new `available_backends`
  field, threaded into the state builders from the call sites that already hold
  the control. Nothing new is read on the audio hot path.

So the studio now receives the full set of selectable backends — built-in and
host-registered alike — instead of a hard-coded list.

## Not in this PR

- The Studio JS that consumes `available_backends` to populate the dropdown
  dynamically (follow-up).
- A declarative param schema on the factory, and dropping
  `BACKEND_DESCRIPTORS` / `RenderBackendKind` / `GainModelKind` (larger
  follow-ups).

## Validation

- `cargo build --workspace` green.
- `cargo test --workspace` green (incl. a new `available()` id/label test).
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)