### PR TITLE
feat: declarative backend param schema + OSC set loop

### DIFF
--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -34,6 +34,7 @@
 //!
 //! [`kind`]: GainModel::kind
 
+use renderer::backend_params::{ParamSpec, ParamValue};
 use renderer::backend_registry::{
     BackendBuildCtx, BackendBuildPlan, BackendFactory, DynamicBackendPlan,
 };
@@ -43,9 +44,8 @@ use renderer::render_backend::{
 use renderer::spatial_vbap::{Gains, spherical_to_adm};
 use renderer::speaker_layout::SpeakerLayout;
 
-/// Sharpness of the cosine lobe: higher = tighter localisation on the nearest
-/// speakers, lower = more spread. Purely a taste knob for this example.
-const SHARPNESS: f32 = 2.0;
+/// Default sharpness of the cosine lobe when the host has not set the param.
+const DEFAULT_SHARPNESS: f32 = 2.0;
 
 /// A cosine-panning gain model over a fixed set of speaker directions.
 pub struct ExampleBackend {
@@ -54,15 +54,20 @@ pub struct ExampleBackend {
     /// had no usable direction (e.g. one placed at the origin); it never wins
     /// any gain.
     speaker_dirs: Vec<[f32; 3]>,
+    /// Cosine-lobe exponent: higher = tighter localisation, lower = more spread.
+    sharpness: f32,
 }
 
 impl ExampleBackend {
     /// Build the backend from speaker positions in scene space. Positions are
     /// normalised to unit directions here, on the build thread — the expensive
     /// work stays out of `compute_gains`.
-    pub fn new(speaker_positions: &[[f32; 3]]) -> Self {
+    pub fn new(speaker_positions: &[[f32; 3]], sharpness: f32) -> Self {
         let speaker_dirs = speaker_positions.iter().map(|p| normalize(*p)).collect();
-        Self { speaker_dirs }
+        Self {
+            speaker_dirs,
+            sharpness,
+        }
     }
 }
 
@@ -120,7 +125,7 @@ impl GainModel for ExampleBackend {
         let mut sum_sq = 0.0f32;
         for (i, sd) in self.speaker_dirs.iter().enumerate() {
             let dot = dir[0] * sd[0] + dir[1] * sd[1] + dir[2] * sd[2];
-            let w = dot.max(0.0).powf(SHARPNESS);
+            let w = dot.max(0.0).powf(self.sharpness);
             gains[i] = w;
             sum_sq += w * w;
         }
@@ -168,6 +173,19 @@ impl BackendFactory for ExampleFactory {
         "Example (cosine panner)"
     }
 
+    fn param_schema(&self) -> Vec<ParamSpec> {
+        // One tunable, declared as data: the UI renders a slider and the host
+        // stores the value generically — no typed field anywhere in the renderer.
+        vec![ParamSpec::float(
+            "sharpness",
+            "Sharpness",
+            0.5,
+            8.0,
+            0.1,
+            DEFAULT_SHARPNESS,
+        )]
+    }
+
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         // Capture the spatializable speaker directions now (build thread), so the
         // model builder closure owns everything it needs and the hot path does no
@@ -181,9 +199,16 @@ impl BackendFactory for ExampleFactory {
             })
             .collect();
 
+        // Read the host-set sharpness (falling back to the default), resolved at
+        // build time and captured into the model.
+        let sharpness = ctx
+            .param("sharpness")
+            .and_then(ParamValue::as_f32)
+            .unwrap_or(DEFAULT_SHARPNESS);
+
         Some(BackendBuildPlan::Dynamic(DynamicBackendPlan::new(
             "example",
-            move || Ok(Box::new(ExampleBackend::new(&speaker_positions))),
+            move || Ok(Box::new(ExampleBackend::new(&speaker_positions, sharpness))),
         )))
     }
 }
@@ -236,12 +261,15 @@ mod tests {
 
     /// A square of four speakers in the horizontal plane.
     fn quad() -> ExampleBackend {
-        ExampleBackend::new(&[
-            [1.0, 1.0, 0.0],
-            [-1.0, 1.0, 0.0],
-            [-1.0, -1.0, 0.0],
-            [1.0, -1.0, 0.0],
-        ])
+        ExampleBackend::new(
+            &[
+                [1.0, 1.0, 0.0],
+                [-1.0, 1.0, 0.0],
+                [-1.0, -1.0, 0.0],
+                [1.0, -1.0, 0.0],
+            ],
+            DEFAULT_SHARPNESS,
+        )
     }
 
     fn energy(gains: &[f32]) -> f32 {
@@ -277,6 +305,19 @@ mod tests {
         // Equal power: every speaker gets the same gain.
         let first = gains[0];
         assert!(gains.iter().all(|g| (g - first).abs() < 1e-6));
+    }
+
+    #[test]
+    fn declares_a_sharpness_param() {
+        let schema = ExampleFactory.param_schema();
+        let sharpness = schema
+            .iter()
+            .find(|p| p.key == "sharpness")
+            .expect("sharpness param declared");
+        assert!(matches!(
+            sharpness.kind,
+            renderer::backend_params::ParamKind::Float { .. }
+        ));
     }
 
     #[test]

--- a/omniphony-renderer/orender_engine/src/osc/recompute.rs
+++ b/omniphony-renderer/orender_engine/src/osc/recompute.rs
@@ -100,6 +100,7 @@ pub(crate) fn trigger_layout_recompute(
                             &topology,
                             scale_m,
                             control_clone.available_backends(),
+                            control_clone.backend_params_for(live.backend_id()),
                         )
                     };
                     let layout_json = {

--- a/omniphony-renderer/renderer/src/backend_params.rs
+++ b/omniphony-renderer/renderer/src/backend_params.rs
@@ -1,0 +1,175 @@
+//! Declarative backend parameter schema.
+//!
+//! A render backend describes its tunable parameters as data
+//! ([`BackendFactory::param_schema`](crate::backend_registry::BackendFactory::param_schema)),
+//! so the UI can render controls and the host can store/transport values
+//! generically — no per-backend typed field in the renderer core, and no
+//! hand-written serde bridge. Values live in a generic `key -> ParamValue` map
+//! (see `RendererControl::backend_params`) and are read at **build time** via
+//! [`BackendBuildCtx::param`](crate::backend_registry::BackendBuildCtx::param),
+//! never on the audio hot path.
+
+/// A single tunable parameter exposed by a backend.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ParamSpec {
+    /// Stable key used to store/transport the value (e.g. `"sharpness"`).
+    pub key: &'static str,
+    /// Human-facing label for the UI.
+    pub label: &'static str,
+    /// Control type and its bounds.
+    pub kind: ParamKind,
+    /// Value used when the host has not set one. The backend applies the same
+    /// default in code; the schema mirrors it so the UI can show it.
+    pub default: ParamValue,
+    /// Optional capability that gates this control's visibility (e.g. only show
+    /// when the backend `supports_distance_model`). `None` = always shown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requires: Option<&'static str>,
+}
+
+impl ParamSpec {
+    /// Float control with inclusive `[min, max]` bounds and a UI step.
+    pub fn float(
+        key: &'static str,
+        label: &'static str,
+        min: f32,
+        max: f32,
+        step: f32,
+        default: f32,
+    ) -> Self {
+        Self {
+            key,
+            label,
+            kind: ParamKind::Float { min, max, step },
+            default: ParamValue::Float(default),
+            requires: None,
+        }
+    }
+
+    /// Integer control with inclusive `[min, max]` bounds.
+    pub fn int(key: &'static str, label: &'static str, min: i64, max: i64, default: i64) -> Self {
+        Self {
+            key,
+            label,
+            kind: ParamKind::Int { min, max },
+            default: ParamValue::Int(default),
+            requires: None,
+        }
+    }
+
+    /// Boolean (checkbox) control.
+    pub fn bool(key: &'static str, label: &'static str, default: bool) -> Self {
+        Self {
+            key,
+            label,
+            kind: ParamKind::Bool,
+            default: ParamValue::Bool(default),
+            requires: None,
+        }
+    }
+
+    /// Gate this control behind a backend capability flag.
+    pub fn requires(mut self, capability: &'static str) -> Self {
+        self.requires = Some(capability);
+        self
+    }
+}
+
+/// Control type and bounds for a [`ParamSpec`]. Tagged so the UI gets a discriminator.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ParamKind {
+    Float { min: f32, max: f32, step: f32 },
+    Int { min: i64, max: i64 },
+    Bool,
+    Enum { options: Vec<ParamOption> },
+}
+
+/// One choice of an [`ParamKind::Enum`] control.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ParamOption {
+    pub value: String,
+    pub label: String,
+}
+
+/// A concrete parameter value. Untagged so it serialises to a bare JSON scalar
+/// (`1.5`, `true`, `"x"`) for the UI.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum ParamValue {
+    Bool(bool),
+    Int(i64),
+    Float(f32),
+    Text(String),
+}
+
+impl ParamValue {
+    pub fn as_f32(&self) -> Option<f32> {
+        match self {
+            ParamValue::Float(v) => Some(*v),
+            ParamValue::Int(v) => Some(*v as f32),
+            _ => None,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            ParamValue::Int(v) => Some(*v),
+            ParamValue::Float(v) => Some(*v as i64),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            ParamValue::Bool(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            ParamValue::Text(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_accessors_and_numeric_coercion() {
+        assert_eq!(ParamValue::Float(1.5).as_f32(), Some(1.5));
+        // Int coerces to f32 and vice versa, so a UI sending an integer for a
+        // float param still resolves.
+        assert_eq!(ParamValue::Int(3).as_f32(), Some(3.0));
+        assert_eq!(ParamValue::Float(2.9).as_i64(), Some(2));
+        assert_eq!(ParamValue::Bool(true).as_f32(), None);
+        assert_eq!(ParamValue::Bool(true).as_bool(), Some(true));
+        assert_eq!(ParamValue::Text("x".into()).as_str(), Some("x"));
+    }
+
+    #[test]
+    fn float_value_serialises_to_a_bare_scalar() {
+        // Untagged: the UI receives `2.0`, not `{"Float":2.0}`.
+        let json = serde_json::to_string(&ParamValue::Float(2.0)).unwrap();
+        assert_eq!(json, "2.0");
+    }
+
+    #[test]
+    fn spec_builders_set_kind_and_default() {
+        let spec = ParamSpec::float("sharpness", "Sharpness", 0.5, 8.0, 0.1, 2.0);
+        assert_eq!(spec.key, "sharpness");
+        assert!(matches!(spec.kind, ParamKind::Float { .. }));
+        assert_eq!(spec.default.as_f32(), Some(2.0));
+        assert!(spec.requires.is_none());
+        assert_eq!(
+            ParamSpec::bool("x", "X", true)
+                .requires("supports_x")
+                .requires,
+            Some("supports_x")
+        );
+    }
+}

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -549,6 +549,18 @@ pub struct BackendBuildCtx<'a> {
     pub layout: &'a SpeakerLayout,
     pub live: &'a LiveParams,
     pub backend_rebuild_params: Option<BackendRebuildParams>,
+    /// Host-set values for *this* backend's declared params, keyed by
+    /// [`ParamSpec::key`](crate::backend_params::ParamSpec::key). Missing keys
+    /// mean "use the backend's default". Read here at build time, then captured
+    /// into the model — never read on the audio hot path.
+    pub params: &'a std::collections::HashMap<String, crate::backend_params::ParamValue>,
+}
+
+impl BackendBuildCtx<'_> {
+    /// The host-set value for `key`, or `None` to fall back to the backend default.
+    pub fn param(&self, key: &str) -> Option<&crate::backend_params::ParamValue> {
+        self.params.get(key)
+    }
 }
 
 /// A render backend's registration entry: a stable id plus how to build its gain
@@ -564,6 +576,12 @@ pub trait BackendFactory: Send + Sync {
     fn label(&self) -> &'static str {
         self.id()
     }
+    /// Tunable parameters this backend exposes, as data. The host stores values
+    /// generically and the UI renders controls from this; the backend reads the
+    /// values via [`BackendBuildCtx::param`] when building. Defaults to none.
+    fn param_schema(&self) -> Vec<crate::backend_params::ParamSpec> {
+        Vec::new()
+    }
     /// Build this backend's plan, or `None` if it cannot be prepared for the
     /// given context (e.g. VBAP without geometry rebuild params).
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan>;
@@ -572,10 +590,13 @@ pub trait BackendFactory: Send + Sync {
 /// A registered backend's UI-facing identity, reported by
 /// [`BackendRegistry::available`] so a host can list the selectable backends
 /// (built-in and contributor-registered alike) without a hard-coded table.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct BackendListing {
     pub id: &'static str,
     pub label: &'static str,
+    /// This backend's declared tunable parameters, so the UI can render controls
+    /// for it when selected.
+    pub params: Vec<crate::backend_params::ParamSpec>,
 }
 
 /// Ordered set of backend factories keyed by id. Use [`BackendRegistry::builtin`]
@@ -632,6 +653,7 @@ impl BackendRegistry {
             .map(|f| BackendListing {
                 id: f.id(),
                 label: f.label(),
+                params: f.param_schema(),
             })
             .collect()
     }
@@ -727,6 +749,7 @@ pub fn prepare_topology_build_plan(
     layout: SpeakerLayout,
     live: &LiveParams,
     backend_rebuild_params: Option<BackendRebuildParams>,
+    backend_params: &std::collections::HashMap<String, crate::backend_params::ParamValue>,
     evaluation_build_config: crate::render_backend::EvaluationBuildConfig,
 ) -> Option<TopologyBuildPlan> {
     // Dispatch through the registry instead of a hard-coded `match` on the id, so
@@ -736,6 +759,7 @@ pub fn prepare_topology_build_plan(
         layout: &layout,
         live,
         backend_rebuild_params,
+        params: backend_params,
     };
     let backend_build = factory.build_plan(&ctx)?;
     let preferred = preferred_evaluation_mode(backend_rebuild_params);

--- a/omniphony-renderer/renderer/src/lib.rs
+++ b/omniphony-renderer/renderer/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backend_params;
 pub mod backend_registry;
 pub mod band_gaintable;
 pub mod config;

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -661,6 +661,11 @@ pub struct RendererControl {
     /// Behind a lock because registration happens after construction (the control
     /// is already shared); only read off the audio hot path (topology rebuild).
     backend_registry: RwLock<BackendRegistry>,
+
+    /// Host-set backend parameter values, keyed by `backend_id` then param key
+    /// (see [`crate::backend_params`]). Generic so a backend's params need no
+    /// typed field here. Read at topology-build time, never on the audio hot path.
+    backend_params: RwLock<HashMap<String, HashMap<String, crate::backend_params::ParamValue>>>,
 }
 
 impl RendererControl {
@@ -699,6 +704,7 @@ impl RendererControl {
             meter_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
             diag_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
             backend_registry: RwLock::new(BackendRegistry::builtin()),
+            backend_params: RwLock::new(HashMap::new()),
         })
     }
 
@@ -719,6 +725,34 @@ impl RendererControl {
     /// can list the selectable backends (built-in and contributor-registered).
     pub fn available_backends(&self) -> Vec<crate::backend_registry::BackendListing> {
         self.backend_registry.read().available()
+    }
+
+    /// Set one backend parameter value (host/OSC). Stored generically and applied
+    /// at the next topology rebuild.
+    pub fn set_backend_param(
+        &self,
+        backend_id: &str,
+        key: &str,
+        value: crate::backend_params::ParamValue,
+    ) {
+        self.backend_params
+            .write()
+            .entry(backend_id.to_string())
+            .or_default()
+            .insert(key.to_string(), value);
+    }
+
+    /// A clone of the stored param values for `backend_id` (empty if none set),
+    /// for the host to publish alongside the backend's schema.
+    pub fn backend_params_for(
+        &self,
+        backend_id: &str,
+    ) -> HashMap<String, crate::backend_params::ParamValue> {
+        self.backend_params
+            .read()
+            .get(backend_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Shared meter-cadence atomic (Hz bits) for `AudioMeter::new_with_rate_atomic`.
@@ -868,11 +902,15 @@ impl RendererControl {
         );
         let geometry_generation = self.geometry_generation();
         let registry = self.backend_registry.read();
+        let params_guard = self.backend_params.read();
+        let empty_params = HashMap::new();
+        let backend_params = params_guard.get(live.backend_id()).unwrap_or(&empty_params);
         prepare_topology_build_plan(
             &registry,
             layout,
             &live,
             backend_rebuild_params,
+            backend_params,
             evaluation_build_config,
         )
         .map(|mut plan| {

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -666,16 +666,20 @@ pub fn apply_simple_osc_control(
     // source of truth for both, persisted to config.
 
     if addr == "/omniphony/control/render_backend" {
-        let requested = parse_string_arg(msg.args.first())
-            .and_then(|value| RenderBackendKind::from_str(&value));
-        if let Some(requested) = requested {
+        // Accept enum names/aliases (e.g. "distance") and any registered backend
+        // id (e.g. a contributor's "example"), so the dropdown can offer them all.
+        let requested_id = parse_string_arg(msg.args.first()).and_then(|value| {
+            RenderBackendKind::from_str(&value)
+                .map(|kind| kind.as_str().to_string())
+                .or_else(|| ctx.renderer.has_backend(&value).then_some(value))
+        });
+        if let Some(requested_id) = requested_id {
             let mut live = ctx.renderer.live.write();
-            if live.backend_id() != requested.as_str() {
-                live.backend_id = requested.as_str().to_string();
+            if live.backend_id() != requested_id {
+                live.backend_id = requested_id.clone();
                 effects.mark_dirty = true;
                 effects.trigger_layout_recompute = true;
-                effects.log_message =
-                    Some(format!("OSC: render_backend -> {}", requested.as_str()));
+                effects.log_message = Some(format!("OSC: render_backend -> {requested_id}"));
             }
         }
         return Some(effects);
@@ -686,6 +690,30 @@ pub fn apply_simple_osc_control(
             "OSC: render_backend/restore is no longer supported after removing from_file"
                 .to_string(),
         );
+        return Some(effects);
+    }
+
+    // Generic backend parameter set: `[string key, <scalar value>]`, applied to
+    // the currently selected backend. Values are stored generically (no typed
+    // field per backend) and read at the next topology rebuild via the schema.
+    if addr == "/omniphony/control/backend/param" {
+        let key = parse_string_arg(msg.args.first());
+        let value = msg.args.get(1).and_then(|arg| match arg {
+            OscType::Float(f) => Some(renderer::backend_params::ParamValue::Float(*f)),
+            OscType::Double(d) => Some(renderer::backend_params::ParamValue::Float(*d as f32)),
+            OscType::Int(i) => Some(renderer::backend_params::ParamValue::Int(*i as i64)),
+            OscType::Long(i) => Some(renderer::backend_params::ParamValue::Int(*i)),
+            OscType::Bool(b) => Some(renderer::backend_params::ParamValue::Bool(*b)),
+            OscType::String(s) => Some(renderer::backend_params::ParamValue::Text(s.clone())),
+            _ => None,
+        });
+        if let (Some(key), Some(value)) = (key, value) {
+            let backend_id = ctx.renderer.live.read().backend_id().to_string();
+            ctx.renderer.set_backend_param(&backend_id, &key, value);
+            effects.mark_dirty = true;
+            effects.trigger_layout_recompute = true;
+            effects.log_message = Some(format!("OSC: backend param {backend_id}.{key} updated"));
+        }
         return Some(effects);
     }
 

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -38,8 +38,13 @@ pub struct RenderBackendStateSnapshot {
     pub selection: String,
     pub effective: String,
     pub effective_label: String,
-    /// Every selectable backend (built-in + host-registered), for the UI list.
+    /// Every selectable backend (built-in + host-registered) with its param
+    /// schema, for the UI list and control generation.
     pub available_backends: Vec<renderer::backend_registry::BackendListing>,
+    /// Host-set param values for the *active* backend, keyed by param key. The
+    /// UI seeds its controls from these (falling back to the schema defaults).
+    pub backend_param_values:
+        std::collections::HashMap<String, renderer::backend_params::ParamValue>,
     pub capabilities: renderer::render_backend::BackendCapabilities,
     pub allowed_evaluation_modes: Vec<String>,
     pub frozen_room_ratio: bool,
@@ -72,6 +77,7 @@ pub fn build_render_backend_state_snapshot(
     live: &LiveParams,
     active_topology: &RenderTopology,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
+    backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
 ) -> RenderBackendStateSnapshot {
     let backend = &active_topology.backend;
     let capabilities = backend.capabilities();
@@ -80,6 +86,7 @@ pub fn build_render_backend_state_snapshot(
         effective: backend.backend_id().to_string(),
         effective_label: backend.backend_label().to_string(),
         available_backends,
+        backend_param_values,
         capabilities,
         allowed_evaluation_modes: allowed_evaluation_modes(backend, capabilities),
         frozen_room_ratio: false,
@@ -110,11 +117,13 @@ pub fn build_render_backend_state_json(
     live: &LiveParams,
     active_topology: &RenderTopology,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
+    backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
 ) -> String {
     serde_json::to_string(&build_render_backend_state_snapshot(
         live,
         active_topology,
         available_backends,
+        backend_param_values,
     ))
     .unwrap_or_else(|_| "{}".to_string())
 }
@@ -124,11 +133,16 @@ pub fn build_renderer_state_json(
     active_topology: &RenderTopology,
     room_scale_m: f32,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
+    backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
 ) -> String {
     let effective_backend = active_topology.backend.kind().as_str();
     let effective_evaluation_mode = active_topology.backend.evaluation_mode().as_str();
-    let render_backend_state_json =
-        build_render_backend_state_json(live, active_topology, available_backends);
+    let render_backend_state_json = build_render_backend_state_json(
+        live,
+        active_topology,
+        available_backends,
+        backend_param_values,
+    );
     json!({
         "renderBackend": live.backend_id(),
         "renderBackendEffective": effective_backend,
@@ -316,6 +330,7 @@ pub fn build_live_state_bundle(
         &active_topology,
         editable_layout.radius_m,
         control.available_backends(),
+        control.backend_params_for(live.backend_id()),
     );
 
     let mut messages = vec![


### PR DESCRIPTION
## Why

Continues opening the backend frontier (#28, #29). A contributor backend can now
declare its tunable parameters **as data** and have them set at runtime, with no
typed field in the renderer core and no hand-written serde bridge — the design
fork chosen was the generic value bag (option A).

## What

**Schema (declaration).** New `backend_params` module:
- `ParamSpec { key, label, kind, default, requires }` with builder helpers.
- `ParamKind` (Float / Int / Bool / Enum) — tagged, so the UI gets a discriminator.
- `ParamValue` (Bool / Int / Float / Text) — untagged, so it serialises to a bare
  JSON scalar; with numeric coercion accessors.
- `BackendFactory::param_schema()` (defaults to none).

**Storage + read.** Values live generically in `RendererControl.backend_params`
(`backend_id -> key -> ParamValue`), behind a lock, read only at topology-build
time via the new `BackendBuildCtx::param()` — never on the audio hot path.
`set_backend_param()` / `backend_params_for()` manage them.

**Transport.** The render-backend OSC state now carries each backend's `params`
schema (inside `available_backends`) and the active backend's current
`backend_param_values`, so Studio can render controls and seed them. A generic
OSC handler `/omniphony/control/backend/param [string key, <scalar>]` sets a
value and rebuilds. `/control/render_backend` now also accepts any registered
backend id (not just enum names), so a contributor backend is selectable.

**Demonstration.** `example_backend` declares a `sharpness` float param and reads
it at build (falling back to its default) — the full declare → set → read loop
with zero core edits.

## Behaviour

Unchanged: with no value set, every backend uses its default (the example's old
constant). Selecting/tuning a backend follows the existing rebuild path.

## Not in this PR (follow-ups)

- Config persistence of the value bag (YAML round-trip).
- Migrating the scalar built-ins (barycenter / experimental_distance) off their
  typed fields onto the schema.
- Studio JS: populate the dropdown from `available_backends`, render controls
  from `params`, send `/control/backend/param`.

## Validation

- `cargo build --workspace` green.
- `cargo test --workspace` green (param value/kind/spec unit tests, example
  declares-and-reads, plus the existing suite).
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)