### PR TITLE
feat(config): persist generic backend param values

### DIFF
--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -447,6 +447,18 @@ pub fn build_spatial_renderer(
                 .or_else(|| control.has_backend(raw).then(|| raw.to_string()))
         });
         let mut requires_rebuild = false;
+        // Replay persisted generic backend param values; they are read at the
+        // rebuild below via each backend's schema.
+        if let Some(cfg) = render_cfg {
+            for (backend_id, params) in &cfg.backend_params {
+                for (key, value) in params {
+                    control.set_backend_param(backend_id, key, value.clone());
+                }
+            }
+            if !cfg.backend_params.is_empty() {
+                requires_rebuild = true;
+            }
+        }
         {
             let mut live = control.live.write();
             if let Some(configured_backend) = &configured_backend {

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -66,6 +66,14 @@ pub struct RenderConfig {
     pub vbap_distance_max: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub render_backend: Option<String>,
+    /// Generic per-backend parameter values (see [`crate::backend_params`]),
+    /// keyed by backend id then param key. Lets a contributor backend's params
+    /// round-trip through config without a typed field here.
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub backend_params: std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, crate::backend_params::ParamValue>,
+    >,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub render_evaluation_mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -551,6 +559,46 @@ render:
         assert!(
             out.contains("cli_specific_thing: 42"),
             "unknown field erased on save:\n{out}"
+        );
+    }
+
+    #[test]
+    fn backend_params_round_trip() {
+        use crate::backend_params::ParamValue;
+
+        let yaml = "\
+render:
+  render_backend: example
+  backend_params:
+    example:
+      sharpness: 3.5
+";
+        let cfg: Config = serde_yaml_ng::from_str(yaml).expect("parse");
+        let render = cfg.render.as_ref().unwrap();
+        assert_eq!(
+            render.backend_params["example"]["sharpness"],
+            ParamValue::Float(3.5)
+        );
+
+        // Round-trips back out.
+        let out = serde_yaml_ng::to_string(&cfg).expect("serialize");
+        let reparsed: Config = serde_yaml_ng::from_str(&out).expect("reparse");
+        assert_eq!(
+            reparsed.render.unwrap().backend_params["example"]["sharpness"],
+            ParamValue::Float(3.5)
+        );
+    }
+
+    #[test]
+    fn empty_backend_params_are_not_serialised() {
+        let cfg = Config {
+            render: Some(RenderConfig::default()),
+            ..Default::default()
+        };
+        let out = serde_yaml_ng::to_string(&cfg).expect("serialize");
+        assert!(
+            !out.contains("backend_params"),
+            "empty map should be skipped:\n{out}"
         );
     }
 }

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -755,6 +755,14 @@ impl RendererControl {
             .unwrap_or_default()
     }
 
+    /// A clone of the entire backend-param store (`backend_id -> key -> value`),
+    /// for the host to persist to config.
+    pub fn all_backend_params(
+        &self,
+    ) -> HashMap<String, HashMap<String, crate::backend_params::ParamValue>> {
+        self.backend_params.read().clone()
+    }
+
     /// Shared meter-cadence atomic (Hz bits) for `AudioMeter::new_with_rate_atomic`.
     pub fn meter_rate_atomic(&self) -> Arc<std::sync::atomic::AtomicU32> {
         Arc::clone(&self.meter_rate_hz_bits)

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -81,6 +81,8 @@ pub fn save_live_config(
         "vbap" => None,
         other => Some(other.to_string()),
     };
+    // Generic per-backend param values, persisted verbatim (empty map is skipped).
+    render.backend_params = control.all_backend_params();
     render.render_evaluation_mode = match live.requested_evaluation_mode() {
         LiveEvaluationMode::Auto => None,
         other => Some(other.as_str().to_string()),


### PR DESCRIPTION
## Why

Follow-up to #30. Backend param values were in-memory only; this round-trips
them through the YAML config so a tuned backend keeps its settings between runs.

## What

- `RenderConfig.backend_params` (`backend_id -> key -> ParamValue`), skipped
  when empty and preserved like the other render keys.
- **Save**: `persist::save_live_config` writes `control.all_backend_params()`.
- **Load**: `orender_engine` replays `render.backend_params` into the control
  (`set_backend_param`) at startup and rebuilds so values take effect.

Generic end to end — no per-backend config key or typed field, consistent with
the "preserve unknown keys" philosophy.

## Validation

- `cargo build --workspace` green.
- `cargo test --workspace` green (new tests: serde round-trip of
  `backend_params`; empty map is not serialised).
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)