### PR TITLE
refactor(renderer): make built-in backend params build-time (de-cruft RenderRequest)

### DIFF
--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -249,12 +249,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: Default::default(),
-            experimental_distance_distance_floor: 0.0,
-            experimental_distance_min_active_speakers: 1,
-            experimental_distance_max_active_speakers: 1,
-            experimental_distance_position_error_floor: 0.0,
-            experimental_distance_position_error_nearest_scale: 0.0,
-            experimental_distance_position_error_span_scale: 0.0,
         }
     }
 

--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -249,7 +249,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: Default::default(),
-            barycenter_localize: 0.0,
             experimental_distance_distance_floor: 0.0,
             experimental_distance_min_active_speakers: 1,
             experimental_distance_max_active_speakers: 1,

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -191,6 +191,9 @@ pub struct ExperimentalDistanceBuildPlan {
 #[derive(Clone)]
 pub struct BarycenterBuildPlan {
     pub speaker_positions: Vec<[f32; 3]>,
+    /// Localisation bias, baked into the model at build (no longer a per-request
+    /// field). Sourced from the live params; changing it triggers a rebuild.
+    pub localize: f32,
 }
 
 #[derive(Clone)]
@@ -250,6 +253,7 @@ impl BarycenterBuildPlan {
     pub fn build_gain_model(&self) -> Result<Box<dyn GainModel>> {
         Ok(Box::new(crate::render_backend::BarycenterBackend::new(
             self.speaker_positions.clone(),
+            self.localize,
         )))
     }
 }
@@ -520,6 +524,7 @@ fn build_inner_backend_plan(
     match backend_id {
         "barycenter" => Some(BackendBuildPlan::Barycenter(BarycenterBuildPlan {
             speaker_positions: collect_spatializable_positions(layout),
+            localize: live.barycenter.localize,
         })),
         "experimental_distance" => Some(BackendBuildPlan::ExperimentalDistance(
             ExperimentalDistanceBuildPlan {
@@ -689,6 +694,7 @@ impl BackendFactory for BarycenterFactory {
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         Some(BackendBuildPlan::Barycenter(BarycenterBuildPlan {
             speaker_positions: collect_spatializable_positions(ctx.layout),
+            localize: ctx.live.barycenter.localize,
         }))
     }
 }
@@ -819,7 +825,6 @@ mod tests {
                 distance_diffuse_threshold: 1.0,
                 distance_diffuse_curve: 1.0,
                 distance_model: DistanceModel::default(),
-                barycenter_localize: 0.0,
                 experimental_distance_distance_floor: 0.0,
                 experimental_distance_min_active_speakers: 1,
                 experimental_distance_max_active_speakers: 1,

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -186,6 +186,9 @@ impl HybridBuildPlan {
 #[derive(Clone)]
 pub struct ExperimentalDistanceBuildPlan {
     pub speaker_positions: Vec<[f32; 3]>,
+    /// Tuning params, baked into the model at build (no longer per-request).
+    /// Sourced from the live params; changing them triggers a rebuild.
+    pub params: crate::live_params::ExperimentalDistanceLiveParams,
 }
 
 #[derive(Clone)]
@@ -244,7 +247,10 @@ impl VbapTopologyBuildPlan {
 impl ExperimentalDistanceBuildPlan {
     pub fn build_gain_model(&self) -> Result<Box<dyn GainModel>> {
         Ok(Box::new(
-            crate::render_backend::ExperimentalDistanceBackend::new(self.speaker_positions.clone()),
+            crate::render_backend::ExperimentalDistanceBackend::new(
+                self.speaker_positions.clone(),
+                self.params,
+            ),
         ))
     }
 }
@@ -529,6 +535,7 @@ fn build_inner_backend_plan(
         "experimental_distance" => Some(BackendBuildPlan::ExperimentalDistance(
             ExperimentalDistanceBuildPlan {
                 speaker_positions: collect_spatializable_positions(layout),
+                params: live.experimental_distance,
             },
         )),
         "vbap" => {
@@ -711,6 +718,7 @@ impl BackendFactory for ExperimentalDistanceFactory {
         Some(BackendBuildPlan::ExperimentalDistance(
             ExperimentalDistanceBuildPlan {
                 speaker_positions: collect_spatializable_positions(ctx.layout),
+                params: ctx.live.experimental_distance,
             },
         ))
     }
@@ -825,12 +833,6 @@ mod tests {
                 distance_diffuse_threshold: 1.0,
                 distance_diffuse_curve: 1.0,
                 distance_model: DistanceModel::default(),
-                experimental_distance_distance_floor: 0.0,
-                experimental_distance_min_active_speakers: 1,
-                experimental_distance_max_active_speakers: 1,
-                experimental_distance_position_error_floor: 0.0,
-                experimental_distance_position_error_nearest_scale: 0.0,
-                experimental_distance_position_error_span_scale: 0.0,
             },
             position_interpolation: false,
             cartesian: CartesianEvaluationConfig {

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -448,22 +448,6 @@ fn evaluation_build_config_from_live(
             distance_diffuse_threshold: live.distance_diffuse_threshold,
             distance_diffuse_curve: live.distance_diffuse_curve,
             distance_model: live.distance_model,
-            experimental_distance_distance_floor: live.experimental_distance.distance_floor,
-            experimental_distance_min_active_speakers: live
-                .experimental_distance
-                .min_active_speakers,
-            experimental_distance_max_active_speakers: live
-                .experimental_distance
-                .max_active_speakers,
-            experimental_distance_position_error_floor: live
-                .experimental_distance
-                .position_error_floor,
-            experimental_distance_position_error_nearest_scale: live
-                .experimental_distance
-                .position_error_nearest_scale,
-            experimental_distance_position_error_span_scale: live
-                .experimental_distance
-                .position_error_span_scale,
         },
         position_interpolation: live.evaluation.position_interpolation,
         cartesian: crate::render_backend::CartesianEvaluationConfig {

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -448,7 +448,6 @@ fn evaluation_build_config_from_live(
             distance_diffuse_threshold: live.distance_diffuse_threshold,
             distance_diffuse_curve: live.distance_diffuse_curve,
             distance_model: live.distance_model,
-            barycenter_localize: live.barycenter.localize,
             experimental_distance_distance_floor: live.experimental_distance.distance_floor,
             experimental_distance_min_active_speakers: live
                 .experimental_distance

--- a/omniphony-renderer/renderer/src/ramp_strategy/mod.rs
+++ b/omniphony-renderer/renderer/src/ramp_strategy/mod.rs
@@ -21,12 +21,6 @@ pub struct RampRenderParams {
     pub distance_diffuse_threshold: f32,
     pub distance_diffuse_curve: f32,
     pub distance_model: DistanceModel,
-    pub experimental_distance_distance_floor: f32,
-    pub experimental_distance_min_active_speakers: usize,
-    pub experimental_distance_max_active_speakers: usize,
-    pub experimental_distance_position_error_floor: f32,
-    pub experimental_distance_position_error_nearest_scale: f32,
-    pub experimental_distance_position_error_span_scale: f32,
 }
 
 impl RampRenderParams {
@@ -53,17 +47,6 @@ impl RampRenderParams {
             distance_diffuse_threshold: self.distance_diffuse_threshold,
             distance_diffuse_curve: self.distance_diffuse_curve,
             distance_model: self.distance_model,
-            experimental_distance_distance_floor: self.experimental_distance_distance_floor,
-            experimental_distance_min_active_speakers: self
-                .experimental_distance_min_active_speakers,
-            experimental_distance_max_active_speakers: self
-                .experimental_distance_max_active_speakers,
-            experimental_distance_position_error_floor: self
-                .experimental_distance_position_error_floor,
-            experimental_distance_position_error_nearest_scale: self
-                .experimental_distance_position_error_nearest_scale,
-            experimental_distance_position_error_span_scale: self
-                .experimental_distance_position_error_span_scale,
         }
     }
 }

--- a/omniphony-renderer/renderer/src/ramp_strategy/mod.rs
+++ b/omniphony-renderer/renderer/src/ramp_strategy/mod.rs
@@ -21,7 +21,6 @@ pub struct RampRenderParams {
     pub distance_diffuse_threshold: f32,
     pub distance_diffuse_curve: f32,
     pub distance_model: DistanceModel,
-    pub barycenter_localize: f32,
     pub experimental_distance_distance_floor: f32,
     pub experimental_distance_min_active_speakers: usize,
     pub experimental_distance_max_active_speakers: usize,
@@ -54,7 +53,6 @@ impl RampRenderParams {
             distance_diffuse_threshold: self.distance_diffuse_threshold,
             distance_diffuse_curve: self.distance_diffuse_curve,
             distance_model: self.distance_model,
-            barycenter_localize: self.barycenter_localize,
             experimental_distance_distance_floor: self.experimental_distance_distance_floor,
             experimental_distance_min_active_speakers: self
                 .experimental_distance_min_active_speakers,

--- a/omniphony-renderer/renderer/src/render_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend.rs
@@ -225,12 +225,6 @@ pub struct RenderRequest {
     pub distance_diffuse_threshold: f32,
     pub distance_diffuse_curve: f32,
     pub distance_model: DistanceModel,
-    pub experimental_distance_distance_floor: f32,
-    pub experimental_distance_min_active_speakers: usize,
-    pub experimental_distance_max_active_speakers: usize,
-    pub experimental_distance_position_error_floor: f32,
-    pub experimental_distance_position_error_nearest_scale: f32,
-    pub experimental_distance_position_error_span_scale: f32,
 }
 
 pub struct RenderResponse {

--- a/omniphony-renderer/renderer/src/render_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend.rs
@@ -225,7 +225,6 @@ pub struct RenderRequest {
     pub distance_diffuse_threshold: f32,
     pub distance_diffuse_curve: f32,
     pub distance_model: DistanceModel,
-    pub barycenter_localize: f32,
     pub experimental_distance_distance_floor: f32,
     pub experimental_distance_min_active_speakers: usize,
     pub experimental_distance_max_active_speakers: usize,

--- a/omniphony-renderer/renderer/src/render_backend/barycenter_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/barycenter_backend.rs
@@ -7,6 +7,9 @@ use crate::speaker_layout::SpeakerLayout;
 
 pub struct BarycenterBackend {
     speaker_positions: Vec<[f32; 3]>,
+    /// Localisation bias toward nearer speakers, baked at construction. It only
+    /// changes via a topology rebuild, so it is not a per-request input.
+    localize: f32,
 }
 
 const MAX_PROJECTED_GRADIENT_ITERS: usize = 48;
@@ -14,8 +17,11 @@ const RESIDUAL_TOLERANCE_SQ: f32 = 1e-8;
 const WEIGHT_TOLERANCE: f32 = 1e-6;
 
 impl BarycenterBackend {
-    pub fn new(speaker_positions: Vec<[f32; 3]>) -> Self {
-        Self { speaker_positions }
+    pub fn new(speaker_positions: Vec<[f32; 3]>, localize: f32) -> Self {
+        Self {
+            speaker_positions,
+            localize: localize.max(0.0),
+        }
     }
 
     pub fn speaker_count(&self) -> usize {
@@ -68,7 +74,7 @@ impl BarycenterBackend {
         weights[..speaker_count].fill(uniform_weight);
 
         let step_size = projected_gradient_step_size(&transformed_speakers, speaker_count);
-        let localize = req.barycenter_localize.max(0.0);
+        let localize = self.localize;
         for _ in 0..MAX_PROJECTED_GRADIENT_ITERS {
             let rendered = weighted_position(&transformed_speakers, &weights, speaker_count);
             let residual = subtract(rendered, target);
@@ -289,7 +295,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::None,
-            barycenter_localize: 0.0,
             experimental_distance_distance_floor: 0.0,
             experimental_distance_min_active_speakers: 1,
             experimental_distance_max_active_speakers: 1,
@@ -301,12 +306,15 @@ mod tests {
 
     #[test]
     fn barycenter_backend_normalizes_energy() {
-        let backend = BarycenterBackend::new(vec![
-            [-1.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ]);
+        let backend = BarycenterBackend::new(
+            vec![
+                [-1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            0.0,
+        );
 
         let gains = backend.compute_gains(&request([0.2, 0.4, 0.1])).gains;
         let energy: f32 = gains.iter().map(|gain| gain * gain).sum();
@@ -315,12 +323,15 @@ mod tests {
 
     #[test]
     fn barycenter_backend_reconstructs_interior_target() {
-        let backend = BarycenterBackend::new(vec![
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ]);
+        let backend = BarycenterBackend::new(
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            0.0,
+        );
 
         let target = [0.2, 0.3, 0.1];
         let gains = backend.compute_gains(&request(target)).gains;
@@ -340,8 +351,10 @@ mod tests {
 
     #[test]
     fn barycenter_backend_hits_exact_speaker() {
-        let backend =
-            BarycenterBackend::new(vec![[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+        let backend = BarycenterBackend::new(
+            vec![[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            0.0,
+        );
 
         let gains = backend.compute_gains(&request([1.0, 0.0, 0.0])).gains;
         assert!(gains[1] > 0.999);
@@ -351,17 +364,20 @@ mod tests {
 
     #[test]
     fn barycenter_backend_localize_biases_toward_near_speakers() {
-        let backend = BarycenterBackend::new(vec![
+        let positions = vec![
             [-1.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
             [0.0, 1.0, 0.0],
             [0.0, -1.0, 0.0],
-        ]);
+        ];
+        // `localize` is now baked at construction, so compare two backends.
+        let base_backend = BarycenterBackend::new(positions.clone(), 0.0);
+        let localized_backend = BarycenterBackend::new(positions, 2.0);
 
-        let base = backend.compute_gains(&request([0.2, 0.0, 0.0])).gains;
-        let mut localized_req = request([0.2, 0.0, 0.0]);
-        localized_req.barycenter_localize = 2.0;
-        let localized = backend.compute_gains(&localized_req).gains;
+        let base = base_backend.compute_gains(&request([0.2, 0.0, 0.0])).gains;
+        let localized = localized_backend
+            .compute_gains(&request([0.2, 0.0, 0.0]))
+            .gains;
 
         assert!(
             localized[1] > base[1],

--- a/omniphony-renderer/renderer/src/render_backend/barycenter_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/barycenter_backend.rs
@@ -295,12 +295,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::None,
-            experimental_distance_distance_floor: 0.0,
-            experimental_distance_min_active_speakers: 1,
-            experimental_distance_max_active_speakers: 1,
-            experimental_distance_position_error_floor: 0.0,
-            experimental_distance_position_error_nearest_scale: 0.0,
-            experimental_distance_position_error_span_scale: 0.0,
         }
     }
 

--- a/omniphony-renderer/renderer/src/render_backend/distance_attenuation.rs
+++ b/omniphony-renderer/renderer/src/render_backend/distance_attenuation.rs
@@ -100,7 +100,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model,
-            barycenter_localize: 0.0,
             experimental_distance_distance_floor: 0.0,
             experimental_distance_min_active_speakers: 1,
             experimental_distance_max_active_speakers: 2,
@@ -121,7 +120,7 @@ mod tests {
 
     fn wrapped() -> DistanceAttenuatedModel {
         DistanceAttenuatedModel::new(
-            Box::new(BarycenterBackend::new(speakers())),
+            Box::new(BarycenterBackend::new(speakers(), 0.0)),
             DistanceMetric::Spherical,
         )
     }
@@ -132,7 +131,7 @@ mod tests {
         let decorated = wrapped()
             .compute_gains(&request(position, DistanceModel::None))
             .gains;
-        let bare = BarycenterBackend::new(speakers())
+        let bare = BarycenterBackend::new(speakers(), 0.0)
             .compute_gains(&request(position, DistanceModel::None))
             .gains;
         for (a, b) in decorated.iter().zip(bare.iter()) {
@@ -164,7 +163,7 @@ mod tests {
         // attenuation, confirming the metric is honoured.
         let position = [0.6, 0.5, 0.0];
         let chebyshev = DistanceAttenuatedModel::new(
-            Box::new(BarycenterBackend::new(speakers())),
+            Box::new(BarycenterBackend::new(speakers(), 0.0)),
             DistanceMetric::Chebyshev,
         );
         let gains = chebyshev

--- a/omniphony-renderer/renderer/src/render_backend/distance_attenuation.rs
+++ b/omniphony-renderer/renderer/src/render_backend/distance_attenuation.rs
@@ -100,12 +100,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model,
-            experimental_distance_distance_floor: 0.0,
-            experimental_distance_min_active_speakers: 1,
-            experimental_distance_max_active_speakers: 2,
-            experimental_distance_position_error_floor: 0.0,
-            experimental_distance_position_error_nearest_scale: 0.0,
-            experimental_distance_position_error_span_scale: 0.0,
         }
     }
 

--- a/omniphony-renderer/renderer/src/render_backend/distance_diffuse.rs
+++ b/omniphony-renderer/renderer/src/render_backend/distance_diffuse.rs
@@ -127,12 +127,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::None,
-            experimental_distance_distance_floor: 0.0,
-            experimental_distance_min_active_speakers: 1,
-            experimental_distance_max_active_speakers: 2,
-            experimental_distance_position_error_floor: 0.0,
-            experimental_distance_position_error_nearest_scale: 0.0,
-            experimental_distance_position_error_span_scale: 0.0,
         }
     }
 

--- a/omniphony-renderer/renderer/src/render_backend/distance_diffuse.rs
+++ b/omniphony-renderer/renderer/src/render_backend/distance_diffuse.rs
@@ -127,7 +127,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::None,
-            barycenter_localize: 0.0,
             experimental_distance_distance_floor: 0.0,
             experimental_distance_min_active_speakers: 1,
             experimental_distance_max_active_speakers: 2,
@@ -148,7 +147,7 @@ mod tests {
 
     fn wrapped() -> DistanceDiffuseModel {
         DistanceDiffuseModel::new(
-            Box::new(BarycenterBackend::new(speakers())),
+            Box::new(BarycenterBackend::new(speakers(), 0.0)),
             DistanceMetric::Spherical,
         )
     }
@@ -157,7 +156,7 @@ mod tests {
     fn disabled_is_a_noop() {
         let position = [0.4, 0.2, 0.1];
         let decorated = wrapped().compute_gains(&request(position, false)).gains;
-        let bare = BarycenterBackend::new(speakers())
+        let bare = BarycenterBackend::new(speakers(), 0.0)
             .compute_gains(&request(position, false))
             .gains;
         for (a, b) in decorated.iter().zip(bare.iter()) {
@@ -171,7 +170,7 @@ mod tests {
         // direct backend's energy regardless of the mirror contribution.
         let position = [0.3, 0.1, 0.2];
         let blended = wrapped().compute_gains(&request(position, true)).gains;
-        let direct = BarycenterBackend::new(speakers())
+        let direct = BarycenterBackend::new(speakers(), 0.0)
             .compute_gains(&request(position, true))
             .gains;
         let energy_blended: f32 = blended.iter().map(|g| g * g).sum();

--- a/omniphony-renderer/renderer/src/render_backend/experimental_distance_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/experimental_distance_backend.rs
@@ -7,6 +7,9 @@ use crate::speaker_layout::SpeakerLayout;
 
 pub struct ExperimentalDistanceBackend {
     speaker_positions: Vec<[f32; 3]>,
+    /// Tuning params, baked at construction. They only change via a topology
+    /// rebuild, so they are not per-request inputs.
+    params: crate::live_params::ExperimentalDistanceLiveParams,
 }
 
 #[derive(Clone, Copy)]
@@ -17,8 +20,14 @@ struct ExperimentalSpeakerCandidate {
 }
 
 impl ExperimentalDistanceBackend {
-    pub fn new(speaker_positions: Vec<[f32; 3]>) -> Self {
-        Self { speaker_positions }
+    pub fn new(
+        speaker_positions: Vec<[f32; 3]>,
+        params: crate::live_params::ExperimentalDistanceLiveParams,
+    ) -> Self {
+        Self {
+            speaker_positions,
+            params,
+        }
     }
 
     pub fn speaker_count(&self) -> usize {
@@ -67,8 +76,9 @@ impl ExperimentalDistanceBackend {
         }
 
         candidates.sort_unstable_by(|a, b| a.distance.total_cmp(&b.distance));
-        let active_count = select_experimental_active_count(target, &candidates, req);
-        let energy = write_experimental_subset_gains(&mut gains, &candidates[..active_count], req);
+        let active_count = select_experimental_active_count(target, &candidates, &self.params);
+        let energy =
+            write_experimental_subset_gains(&mut gains, &candidates[..active_count], &self.params);
         if energy > 1e-12 {
             let norm = energy.sqrt();
             for gain in gains.iter_mut() {
@@ -148,15 +158,12 @@ fn experimental_distance_weight(distance: f32) -> f32 {
 fn write_experimental_subset_gains(
     gains: &mut Gains,
     candidates: &[ExperimentalSpeakerCandidate],
-    req: &RenderRequest,
+    params: &crate::live_params::ExperimentalDistanceLiveParams,
 ) -> f32 {
     let mut energy = 0.0f32;
     for candidate in candidates {
-        let weight = experimental_distance_weight(
-            candidate
-                .distance
-                .max(req.experimental_distance_distance_floor.max(0.0)),
-        );
+        let weight =
+            experimental_distance_weight(candidate.distance.max(params.distance_floor.max(0.0)));
         gains.set(candidate.index, weight);
         energy += weight * weight;
     }
@@ -166,18 +173,14 @@ fn write_experimental_subset_gains(
 fn select_experimental_active_count(
     target: [f32; 3],
     candidates: &[ExperimentalSpeakerCandidate],
-    req: &RenderRequest,
+    params: &crate::live_params::ExperimentalDistanceLiveParams,
 ) -> usize {
     if candidates.is_empty() {
         return 0;
     }
 
-    let min_active = candidates
-        .len()
-        .min(req.experimental_distance_min_active_speakers.max(1));
-    let max_active = candidates
-        .len()
-        .min(req.experimental_distance_max_active_speakers.max(1));
+    let min_active = candidates.len().min(params.min_active_speakers.max(1));
+    let max_active = candidates.len().min(params.max_active_speakers.max(1));
     let nearest_distance = candidates[0].distance;
     let mut best_count = 1usize;
     let mut best_error = f32::MAX;
@@ -193,15 +196,10 @@ fn select_experimental_active_count(
 
         if count >= min_active {
             let span = candidate_subset_span(subset);
-            let threshold = req
-                .experimental_distance_position_error_floor
-                .max(
-                    nearest_distance
-                        * req
-                            .experimental_distance_position_error_nearest_scale
-                            .max(0.0),
-                )
-                .max(span * req.experimental_distance_position_error_span_scale.max(0.0));
+            let threshold = params
+                .position_error_floor
+                .max(nearest_distance * params.position_error_nearest_scale.max(0.0))
+                .max(span * params.position_error_span_scale.max(0.0));
             if error <= threshold {
                 return count;
             }

--- a/omniphony-renderer/renderer/src/render_backend/few_speaker_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/few_speaker_backend.rs
@@ -216,12 +216,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::default(),
-            experimental_distance_distance_floor: 0.0,
-            experimental_distance_min_active_speakers: 1,
-            experimental_distance_max_active_speakers: 1,
-            experimental_distance_position_error_floor: 0.0,
-            experimental_distance_position_error_nearest_scale: 0.0,
-            experimental_distance_position_error_span_scale: 0.0,
         }
     }
 

--- a/omniphony-renderer/renderer/src/render_backend/few_speaker_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/few_speaker_backend.rs
@@ -216,7 +216,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::default(),
-            barycenter_localize: 0.0,
             experimental_distance_distance_floor: 0.0,
             experimental_distance_min_active_speakers: 1,
             experimental_distance_max_active_speakers: 1,

--- a/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
@@ -319,12 +319,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::None,
-            experimental_distance_distance_floor: 0.0,
-            experimental_distance_min_active_speakers: 1,
-            experimental_distance_max_active_speakers: 2,
-            experimental_distance_position_error_floor: 0.0,
-            experimental_distance_position_error_nearest_scale: 0.0,
-            experimental_distance_position_error_span_scale: 0.0,
         }
     }
 
@@ -339,7 +333,10 @@ mod tests {
 
     fn hybrid(curve: BlendCurve) -> HybridBackend {
         HybridBackend::new(
-            Box::new(ExperimentalDistanceBackend::new(speakers())),
+            Box::new(ExperimentalDistanceBackend::new(
+                speakers(),
+                crate::live_params::ExperimentalDistanceLiveParams::default(),
+            )),
             Box::new(BarycenterBackend::new(speakers(), 0.0)),
             curve,
             crate::spatial_vbap::DistanceMetric::Chebyshev,
@@ -403,9 +400,12 @@ mod tests {
         let blended = hybrid(BlendCurve::new(vec![[0.0, 1.0], [1.0, 1.0]], 0.0))
             .compute_gains(&request(position))
             .gains;
-        let external = ExperimentalDistanceBackend::new(speakers())
-            .compute_gains(&request(position))
-            .gains;
+        let external = ExperimentalDistanceBackend::new(
+            speakers(),
+            crate::live_params::ExperimentalDistanceLiveParams::default(),
+        )
+        .compute_gains(&request(position))
+        .gains;
         for (a, b) in blended.iter().zip(external.iter()) {
             assert!((a - b).abs() < 1e-5, "{a} vs {b}");
         }

--- a/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
@@ -319,7 +319,6 @@ mod tests {
             distance_diffuse_threshold: 1.0,
             distance_diffuse_curve: 1.0,
             distance_model: crate::spatial_vbap::DistanceModel::None,
-            barycenter_localize: 0.0,
             experimental_distance_distance_floor: 0.0,
             experimental_distance_min_active_speakers: 1,
             experimental_distance_max_active_speakers: 2,
@@ -341,7 +340,7 @@ mod tests {
     fn hybrid(curve: BlendCurve) -> HybridBackend {
         HybridBackend::new(
             Box::new(ExperimentalDistanceBackend::new(speakers())),
-            Box::new(BarycenterBackend::new(speakers())),
+            Box::new(BarycenterBackend::new(speakers(), 0.0)),
             curve,
             crate::spatial_vbap::DistanceMetric::Chebyshev,
         )
@@ -390,7 +389,7 @@ mod tests {
         let blended = hybrid(BlendCurve::new(vec![[0.0, 0.0], [1.0, 0.0]], 0.0))
             .compute_gains(&request(position))
             .gains;
-        let internal = BarycenterBackend::new(speakers())
+        let internal = BarycenterBackend::new(speakers(), 0.0)
             .compute_gains(&request(position))
             .gains;
         for (a, b) in blended.iter().zip(internal.iter()) {
@@ -425,7 +424,7 @@ mod tests {
             .expect("vbap panner")
             .with_negative_z(true);
         let external: Box<dyn GainModel> = Box::new(VbapBackend::new(panner));
-        let internal: Box<dyn GainModel> = Box::new(BarycenterBackend::new(speakers()));
+        let internal: Box<dyn GainModel> = Box::new(BarycenterBackend::new(speakers(), 0.0));
         let model: Box<dyn GainModel> = Box::new(HybridBackend::new(
             external,
             internal,

--- a/omniphony-renderer/renderer/src/spatial_renderer.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer.rs
@@ -385,7 +385,6 @@ struct LiveSnapshot<'a> {
     use_distance_diffuse: bool,
     distance_diffuse_threshold: f32,
     distance_diffuse_curve: f32,
-    experimental_distance: crate::live_params::ExperimentalDistanceLiveParams,
 }
 
 /// Spatial audio renderer using VBAP
@@ -599,24 +598,6 @@ impl SpatialRenderer {
                         distance_diffuse_threshold,
                         distance_diffuse_curve,
                         distance_model,
-                        experimental_distance_distance_floor:
-                            crate::live_params::ExperimentalDistanceLiveParams::default()
-                                .distance_floor,
-                        experimental_distance_min_active_speakers:
-                            crate::live_params::ExperimentalDistanceLiveParams::default()
-                                .min_active_speakers,
-                        experimental_distance_max_active_speakers:
-                            crate::live_params::ExperimentalDistanceLiveParams::default()
-                                .max_active_speakers,
-                        experimental_distance_position_error_floor:
-                            crate::live_params::ExperimentalDistanceLiveParams::default()
-                                .position_error_floor,
-                        experimental_distance_position_error_nearest_scale:
-                            crate::live_params::ExperimentalDistanceLiveParams::default()
-                                .position_error_nearest_scale,
-                        experimental_distance_position_error_span_scale:
-                            crate::live_params::ExperimentalDistanceLiveParams::default()
-                                .position_error_span_scale,
                     },
                     vbap_position_interpolation,
                     table_mode,
@@ -1159,22 +1140,6 @@ impl SpatialRenderer {
             distance_diffuse_threshold: live.distance_diffuse_threshold,
             distance_diffuse_curve: live.distance_diffuse_curve,
             distance_model: self.distance_model,
-            experimental_distance_distance_floor: live.experimental_distance.distance_floor,
-            experimental_distance_min_active_speakers: live
-                .experimental_distance
-                .min_active_speakers,
-            experimental_distance_max_active_speakers: live
-                .experimental_distance
-                .max_active_speakers,
-            experimental_distance_position_error_floor: live
-                .experimental_distance
-                .position_error_floor,
-            experimental_distance_position_error_nearest_scale: live
-                .experimental_distance
-                .position_error_nearest_scale,
-            experimental_distance_position_error_span_scale: live
-                .experimental_distance
-                .position_error_span_scale,
         })
     }
 
@@ -1389,7 +1354,6 @@ impl SpatialRenderer {
                 use_distance_diffuse: g.use_distance_diffuse,
                 distance_diffuse_threshold: g.distance_diffuse_threshold,
                 distance_diffuse_curve: g.distance_diffuse_curve,
-                experimental_distance: g.experimental_distance,
             }
         };
         // Push the live read-time interpolation flag into the precomputed

--- a/omniphony-renderer/renderer/src/spatial_renderer.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer.rs
@@ -385,7 +385,6 @@ struct LiveSnapshot<'a> {
     use_distance_diffuse: bool,
     distance_diffuse_threshold: f32,
     distance_diffuse_curve: f32,
-    barycenter: crate::live_params::BarycenterLiveParams,
     experimental_distance: crate::live_params::ExperimentalDistanceLiveParams,
 }
 
@@ -600,7 +599,6 @@ impl SpatialRenderer {
                         distance_diffuse_threshold,
                         distance_diffuse_curve,
                         distance_model,
-                        barycenter_localize: 0.0,
                         experimental_distance_distance_floor:
                             crate::live_params::ExperimentalDistanceLiveParams::default()
                                 .distance_floor,
@@ -862,8 +860,8 @@ impl SpatialRenderer {
             distance_diffuse_curve,
             drc_mode: "Off".to_string(),
             drc_weight: 1.0,
-            experimental_distance: crate::live_params::ExperimentalDistanceLiveParams::default(),
             barycenter: crate::live_params::BarycenterLiveParams::default(),
+            experimental_distance: crate::live_params::ExperimentalDistanceLiveParams::default(),
             hybrid: crate::live_params::HybridLiveParams::default(),
         }
     }
@@ -1161,7 +1159,6 @@ impl SpatialRenderer {
             distance_diffuse_threshold: live.distance_diffuse_threshold,
             distance_diffuse_curve: live.distance_diffuse_curve,
             distance_model: self.distance_model,
-            barycenter_localize: live.barycenter.localize,
             experimental_distance_distance_floor: live.experimental_distance.distance_floor,
             experimental_distance_min_active_speakers: live
                 .experimental_distance
@@ -1392,7 +1389,6 @@ impl SpatialRenderer {
                 use_distance_diffuse: g.use_distance_diffuse,
                 distance_diffuse_threshold: g.distance_diffuse_threshold,
                 distance_diffuse_curve: g.distance_diffuse_curve,
-                barycenter: g.barycenter,
                 experimental_distance: g.experimental_distance,
             }
         };


### PR DESCRIPTION
## Why

While preparing to migrate the scalar built-in backends (barycenter,
experimental_distance) onto the generic param bag, it turned out their params
were **consumed per-frame** via the shared `RenderRequest` — `render_frame`
re-filled `barycenter_localize` and the six `experimental_distance_*` fields for
every object every frame, even though those values only ever change through a
path that triggers a topology rebuild (OSC handler, config load). There is no
live-only path. So the per-frame plumbing was dead weight on the audio hot path,
and `RenderRequest` had become a kitchen-sink carrying backend-specific tuning
for backends that weren't even active.

This is the "fix it before migrating" step: turn these into genuine build-time
params, baked into the model at construction.

## What

- `BarycenterBackend` / `ExperimentalDistanceBackend` take their tuning params at
  construction (carried by their build plans, sourced unchanged from
  `live.barycenter` / `live.experimental_distance`). `compute_gains` reads
  `self.*` instead of `req.*`; the experimental pure-helpers take the params
  struct.
- Removed all seven backend-tuning fields from `RenderRequest`, from the ramp
  `RampRenderParams`, and from the per-frame `LiveSnapshot`; `render_frame` no
  longer populates them, and the `*: 0.0` filler in every other backend's
  request builders is gone.

`RenderRequest` now carries only genuinely per-object/per-frame inputs
(position, size, spread, room, distance model).

## Behaviour

Unchanged. These params already triggered a rebuild on change, so baking them at
build is equivalent; precomputed tables sample a model that already has them
baked, so realtime and precomputed paths produce identical gains.

## Follow-up

Now that they are build-time params, routing them through the generic param bag
(`ctx.param`, replacing the `live.*` source) — the actual migration — is natural
and is the next step.

## Validation

- `cargo build --workspace` green.
- `cargo test --workspace` green (barycenter/experimental/hybrid suites updated
  to construct backends with their params).
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)