### PR TITLE
feat(studio): show registered backends in the dropdown

### DIFF
--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -216,6 +216,25 @@ pub struct RenderBackendState {
     #[serde(rename = "experimentalDistance", alias = "experimental_distance")]
     pub experimental_distance: ExperimentalDistanceState,
     pub hybrid: HybridState,
+    /// Selectable backends with their declared param schema: `[{ id, label,
+    /// params: [...] }]`. Passed through verbatim so the UI can populate the
+    /// backend dropdown and generate per-backend controls.
+    #[serde(
+        rename = "availableBackends",
+        alias = "available_backends",
+        default,
+        skip_serializing_if = "serde_json::Value::is_null"
+    )]
+    pub available_backends: serde_json::Value,
+    /// Host-set param values for the active backend (`{ key: value }`), used to
+    /// seed the generated controls.
+    #[serde(
+        rename = "backendParamValues",
+        alias = "backend_param_values",
+        default,
+        skip_serializing_if = "serde_json::Value::is_null"
+    )]
+    pub backend_param_values: serde_json::Value,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -307,6 +307,30 @@ export function updateEvaluationMode() {
   scheduleUIFlush();
 }
 
+// Populate the backend dropdown from the engine-published list of selectable
+// backends (built-in + contributor-registered). Falls back to the static HTML
+// options when the engine doesn't send a list (older builds).
+function syncBackendOptions(selectEl) {
+  const available = app.renderBackendState && Array.isArray(app.renderBackendState.availableBackends)
+    ? app.renderBackendState.availableBackends
+    : null;
+  if (!selectEl || !available || available.length === 0) return;
+  const desired = available.map((b) => ({
+    value: String(b.id),
+    label: String(b.label || b.id),
+  }));
+  const current = Array.from(selectEl.options).map((o) => `${o.value}=${o.textContent}`).join('|');
+  const next = desired.map((d) => `${d.value}=${d.label}`).join('|');
+  if (current === next) return;
+  selectEl.replaceChildren();
+  for (const d of desired) {
+    const opt = document.createElement('option');
+    opt.value = d.value;
+    opt.textContent = d.label;
+    selectEl.appendChild(opt);
+  }
+}
+
 export function renderRenderBackend() {
   const renderBackendSelectEl = getRenderBackendSelectEl();
   const restoreBackendBtnEl = getRestoreBackendBtnEl();
@@ -316,6 +340,7 @@ export function renderRenderBackend() {
   const visibleBackend = effective || selection;
   const frozen = app.renderBackendState.frozenSpeakers === true;
   if (renderBackendSelectEl) {
+    syncBackendOptions(renderBackendSelectEl);
     renderBackendSelectEl.value = selection;
     renderBackendSelectEl.disabled = frozen;
   }


### PR DESCRIPTION
## Why

The backend selector in Studio was a static HTML list, so a registered
contributor backend (e.g. `example`) could be built and selected by id but
never appeared as a choice. The engine already publishes the selectable
backends (id + label + param schema) in the render-backend state — surface them.

## What

- `app_state.rs`: `RenderBackendState` now passes through `availableBackends`
  and `backendParamValues` (snake-case from the engine → camelCase for JS).
- `vbap.js`: `renderRenderBackend` rebuilds the dropdown options from
  `availableBackends`, falling back to the static HTML list for older engines.
  Selecting one sends the existing `control_render_backend`, which already
  accepts any registered backend id.

The contributor loop is now visible end to end: a backend in its own crate
shows up in Studio's dropdown and can be selected.

## Follow-up

Generate the per-backend param controls from the `params` schema (seeded by
`backendParamValues`) and retire the bespoke barycenter / experimental_distance
control blocks.

## Validation

- `npm run build` (Vite) green.
- `src-tauri` `cargo build` green.
- (UI behaviour not automatically testable; the dropdown rebuild is guarded to
  no-op when the list is unchanged or absent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)