### PR TITLE
feat(studio): generate param controls for contributor backends

### DIFF
--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -906,11 +906,11 @@ fn control_render_evaluation_cartesian_z_neg_size(state: State<SharedState>, val
 
 #[tauri::command]
 fn control_render_backend(state: State<SharedState>, value: String) {
+    // Forward any non-empty id; the engine validates it against its backend
+    // registry (which includes contributor-registered backends), so we must not
+    // hard-code the built-in set here.
     let normalized = value.trim().to_ascii_lowercase();
-    if !matches!(
-        normalized.as_str(),
-        "vbap" | "barycenter" | "experimental_distance" | "hybrid"
-    ) {
+    if normalized.is_empty() {
         return;
     }
     send_control(
@@ -918,6 +918,26 @@ fn control_render_backend(state: State<SharedState>, value: String) {
         OscControlMsg::SendString {
             address: "/omniphony/control/render_backend".to_string(),
             value: normalized,
+        },
+    );
+}
+
+/// Generic backend param setter: forwards `[string key, <scalar>]` to the engine
+/// for the currently selected backend. The scalar type follows the JSON value
+/// (bool / number / string), matching the param schema's kind.
+#[tauri::command]
+fn control_backend_param(state: State<SharedState>, key: String, value: serde_json::Value) {
+    let arg = match value {
+        serde_json::Value::Bool(b) => rosc::OscType::Bool(b),
+        serde_json::Value::Number(n) => rosc::OscType::Float(n.as_f64().unwrap_or(0.0) as f32),
+        serde_json::Value::String(s) => rosc::OscType::String(s),
+        _ => return,
+    };
+    send_control(
+        &state.osc_tx,
+        OscControlMsg::SendArgs {
+            address: "/omniphony/control/backend/param".to_string(),
+            args: vec![rosc::OscType::String(key), arg],
         },
     );
 }
@@ -2661,6 +2681,7 @@ fn main() {
             control_render_evaluation_cartesian_z_size,
             control_render_evaluation_cartesian_z_neg_size,
             control_render_backend,
+            control_backend_param,
             control_barycenter_localize,
             control_restore_render_backend,
             control_render_evaluation_mode,

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -4,6 +4,7 @@
  * Extracted from app.js (lines 3711-3852).
  */
 
+import { invoke } from '@tauri-apps/api/core';
 import { app, dirty } from '../state.js';
 import { t, tf } from '../i18n.js';
 import { formatNumber } from '../coordinates.js';
@@ -331,6 +332,110 @@ function syncBackendOptions(selectEl) {
   }
 }
 
+// Built-in backends that already have hand-written control sections. Everything
+// else (e.g. a contributor backend) gets its controls generated from the schema.
+const BESPOKE_BACKENDS = ['vbap', 'barycenter', 'experimental_distance', 'hybrid'];
+
+function sendBackendParam(key, value) {
+  invoke('control_backend_param', { key, value });
+}
+
+// Build one control row for a param spec, seeded with `current`. Returns the row
+// element with a `_setValue` hook used to refresh it without a rebuild.
+function buildParamControl(spec, current) {
+  const row = document.createElement('div');
+  row.className = 'control-row generated-param-row';
+  const label = document.createElement('label');
+  label.textContent = spec.label || spec.key;
+  row.appendChild(label);
+  const kind = spec.kind || {};
+  if (kind.type === 'bool') {
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = current === true;
+    input.addEventListener('change', () => sendBackendParam(spec.key, input.checked));
+    row.appendChild(input);
+    row._setValue = (v) => { input.checked = v === true; };
+  } else if (kind.type === 'enum') {
+    const select = document.createElement('select');
+    for (const opt of (kind.options || [])) {
+      const o = document.createElement('option');
+      o.value = String(opt.value);
+      o.textContent = String(opt.label || opt.value);
+      select.appendChild(o);
+    }
+    select.value = String(current);
+    select.addEventListener('change', () => sendBackendParam(spec.key, select.value));
+    row.appendChild(select);
+    row._setValue = (v) => { select.value = String(v); };
+  } else {
+    const isInt = kind.type === 'int';
+    const input = document.createElement('input');
+    input.type = 'range';
+    input.min = String(kind.min ?? 0);
+    input.max = String(kind.max ?? 1);
+    input.step = String(isInt ? 1 : (kind.step ?? 0.01));
+    input.value = String(current);
+    const valEl = document.createElement('span');
+    valEl.className = 'val';
+    valEl.textContent = String(current);
+    const parse = (v) => (isInt ? Math.round(Number(v)) : Number(v));
+    input.addEventListener('input', () => { valEl.textContent = input.value; });
+    input.addEventListener('change', () => sendBackendParam(spec.key, parse(input.value)));
+    row.appendChild(input);
+    row.appendChild(valEl);
+    row._setValue = (v) => { input.value = String(v); valEl.textContent = String(v); };
+  }
+  return row;
+}
+
+// Generate controls for the active backend from its published param schema.
+// Only used for backends without a hand-written section (contributor backends).
+function renderGenericBackendParams(activeBackend) {
+  const host = getBackendParametersSectionEl();
+  if (!host) return;
+  let container = document.getElementById('backendGenericParamsSection');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'backendGenericParamsSection';
+    container.className = 'control-section';
+    host.appendChild(container);
+  }
+
+  const available = app.renderBackendState && Array.isArray(app.renderBackendState.availableBackends)
+    ? app.renderBackendState.availableBackends
+    : [];
+  const entry = available.find((b) => String(b.id) === String(activeBackend));
+  const schema = entry && Array.isArray(entry.params) ? entry.params : [];
+
+  if (BESPOKE_BACKENDS.includes(activeBackend) || schema.length === 0) {
+    container.style.display = 'none';
+    return;
+  }
+  container.style.display = '';
+
+  const values = (app.renderBackendState && app.renderBackendState.backendParamValues) || {};
+  const valueFor = (spec) => (spec.key in values ? values[spec.key] : spec.default);
+
+  // Rebuild controls only when the backend changed; otherwise refresh values so
+  // an external change (OSC) is reflected without dropping focus.
+  if (container.dataset.backend !== String(activeBackend)) {
+    container.replaceChildren();
+    container.dataset.backend = String(activeBackend);
+    for (const spec of schema) {
+      container.appendChild(buildParamControl(spec, valueFor(spec)));
+    }
+  } else {
+    const rows = container.querySelectorAll('.generated-param-row');
+    schema.forEach((spec, i) => {
+      const row = rows[i];
+      if (row && typeof row._setValue === 'function' && document.activeElement !== row.querySelector('input, select')) {
+        row._setValue(valueFor(spec));
+      }
+    });
+  }
+}
+
 export function renderRenderBackend() {
   const renderBackendSelectEl = getRenderBackendSelectEl();
   const restoreBackendBtnEl = getRestoreBackendBtnEl();
@@ -363,6 +468,7 @@ export function renderRenderBackend() {
   applyRendererBackendVisibility(visibleBackend);
   renderBarycenterOptions();
   renderExperimentalDistanceOptions();
+  renderGenericBackendParams(visibleBackend);
   renderHybridOptions();
   renderEvaluationMode();
 }

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -184,25 +184,17 @@ export function applyInitState(payload) {
   }
   updateVbapCartesian();
   if (payload.renderBackendState && typeof payload.renderBackendState === 'object') {
+    // Accept any backend id the engine reports (built-in or contributor-
+    // registered); the engine already validated it against its registry.
     if (typeof payload.renderBackendState.selection === 'string') {
       const selection = payload.renderBackendState.selection.trim().toLowerCase();
-      if (
-        selection === 'vbap'
-        || selection === 'barycenter'
-        || selection === 'experimental_distance'
-        || selection === 'hybrid'
-      ) {
+      if (selection) {
         app.renderBackendState.selection = selection;
       }
     }
     if (typeof payload.renderBackendState.effective === 'string') {
       const effective = payload.renderBackendState.effective.trim().toLowerCase();
-      if (
-        effective === 'vbap'
-        || effective === 'barycenter'
-        || effective === 'experimental_distance'
-        || effective === 'hybrid'
-      ) {
+      if (effective) {
         app.renderBackendState.effective = effective;
       }
     }
@@ -220,6 +212,16 @@ export function applyInitState(payload) {
     app.renderBackendState.frozenRoomRatio = payload.renderBackendState.frozenRoomRatio === true;
     app.renderBackendState.frozenSpeakers = payload.renderBackendState.frozenSpeakers === true;
     app.renderBackendState.restoreBackendAvailable = payload.renderBackendState.restoreBackendAvailable === true;
+    // Engine-published list of selectable backends (id + label + param schema)
+    // and the active backend's current param values — drive the dynamic dropdown
+    // and the generated per-backend controls.
+    app.renderBackendState.availableBackends = Array.isArray(payload.renderBackendState.availableBackends)
+      ? payload.renderBackendState.availableBackends
+      : [];
+    app.renderBackendState.backendParamValues = payload.renderBackendState.backendParamValues
+      && typeof payload.renderBackendState.backendParamValues === 'object'
+      ? payload.renderBackendState.backendParamValues
+      : {};
     const barycenter = payload.renderBackendState.barycenter;
     if (barycenter && typeof barycenter === 'object') {
       app.renderBackendState.barycenter.localize =

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -129,6 +129,8 @@ export const app = {
     frozenRoomRatio: false,
     frozenSpeakers: false,
     restoreBackendAvailable: false,
+    availableBackends: [],
+    backendParamValues: {},
     barycenter: {
       localize: null
     },


### PR DESCRIPTION
## ⚠️ Needs a visual check before merge

UI rendering / interaction is not covered by CI. Please verify in a running
Studio: select `example`, confirm a **Sharpness** slider appears and moving it
audibly/visibly changes the render (and that built-in backends are unaffected).

## Why

After the previous PR a registered backend appears in the dropdown but had no
controls — and was in fact rejected on selection by a hard-coded allowlist.
This makes a contributor backend fully usable from the UI.

## What

- **src-tauri**: generic `control_backend_param(key, value)` command forwarding
  `[string key, <scalar>]` to `/omniphony/control/backend/param` (bool / number /
  string per the schema kind). `control_render_backend` no longer hard-codes the
  built-in set — it forwards any non-empty id, which the engine validates against
  its registry.
- **vbap.js**: `renderGenericBackendParams` builds a control per schema param
  (range for float/int, checkbox for bool, select for enum), seeded from
  `backendParamValues` / defaults, sending `control_backend_param` on change.
  Rows refresh in place (no focus loss) and rebuild only on backend change.

## Scope decision

Generated controls show only for backends **without** a hand-written section.
The built-in barycenter / experimental_distance blocks are intentionally kept —
they double as the inner-backend param editors inside the hybrid tabs, so
retiring them is a separate, careful change.

## Validation

- `npm run build` (Vite) green.
- `src-tauri` `cargo build` green.
- UI behaviour: **manual visual check required** (see top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)