### PR TITLE
refactor(renderer): retire the closed backend-kind enums

### DIFF
--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -27,20 +27,15 @@
 //! Implement [`BackendFactory`] (see [`ExampleFactory`]) and a host registers it
 //! with `RendererControl::register_backend`; selecting `backend_id = "example"`
 //! then routes a topology rebuild through it — no central enum or `match` to edit.
-//!
-//! One rough edge remains: [`GainModelKind`] is still a closed enum in `renderer`,
-//! so [`kind`] below has to borrow an existing variant. Moving identity onto the
-//! factory (to retire that enum) is the next step.
-//!
-//! [`kind`]: GainModel::kind
+//! The backend's identity lives entirely on this crate: its `backend_id`,
+//! `backend_label` and parameter schema come from the [`GainModel`] impl and
+//! [`BackendFactory`], with no closed enum in `renderer` to extend.
 
 use renderer::backend_params::{ParamSpec, ParamValue};
 use renderer::backend_registry::{
     BackendBuildCtx, BackendBuildPlan, BackendFactory, DynamicBackendPlan,
 };
-use renderer::render_backend::{
-    BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse,
-};
+use renderer::render_backend::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use renderer::spatial_vbap::{Gains, spherical_to_adm};
 use renderer::speaker_layout::SpeakerLayout;
 
@@ -72,12 +67,6 @@ impl ExampleBackend {
 }
 
 impl GainModel for ExampleBackend {
-    fn kind(&self) -> GainModelKind {
-        // Borrowed: the enum lives in `renderer` and an external crate cannot
-        // extend it yet. See the module-level "Known limitation" note.
-        GainModelKind::Vbap
-    }
-
     fn backend_id(&self) -> &'static str {
         "example"
     }

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, anyhow, bail};
 use bridge_api::{RVbapCartesianDefaults, RVbapTableMode};
 use renderer::config::RenderConfig;
 use renderer::live_params::{LiveEvaluationMode, PreferredEvaluationMode};
-use renderer::render_backend::RenderBackendKind;
+use renderer::render_backend::canonical_builtin_backend_id;
 use renderer::spatial_renderer::SpatialRenderer;
 use renderer::spatial_vbap::{DistanceModel, VbapTableMode};
 use renderer::speaker_layout::SpeakerLayout;
@@ -408,11 +408,11 @@ pub fn build_spatial_renderer(
         let control = renderer.renderer_control();
         // Register the demonstration backend so `backend_id = "example"` resolves.
         control.register_backend(Box::new(example_backend::ExampleFactory));
-        // Resolve the configured backend id: enum names/aliases first (e.g.
+        // Resolve the configured backend id: built-in ids/aliases first (e.g.
         // "distance" -> experimental_distance), then any registered backend id.
         let configured_backend = configured_backend_cfg.and_then(|raw| {
-            RenderBackendKind::from_str(raw)
-                .map(|kind| kind.as_str().to_string())
+            canonical_builtin_backend_id(raw)
+                .map(|id| id.to_string())
                 .or_else(|| control.has_backend(raw).then(|| raw.to_string()))
         });
         let mut requires_rebuild = false;

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -7,8 +7,7 @@ use crate::live_params::{
 };
 use crate::render_backend::{
     BlendCurve, EffectiveEvaluationMode, EvaluationBuildConfig, FewSpeakerBackend, GainModel,
-    GainModelKind, HybridBackend, PreparedRenderEngine, RenderBackendKind,
-    backend_descriptor_by_id, build_prepared_render_engine, wrap_prepared_engine,
+    HybridBackend, PreparedRenderEngine, build_prepared_render_engine, wrap_prepared_engine,
 };
 use crate::speaker_layout::SpeakerLayout;
 
@@ -341,16 +340,6 @@ impl TopologyBuildPlan {
 
     pub fn backend_id(&self) -> &str {
         self.backend_id.as_str()
-    }
-
-    pub fn backend_kind(&self) -> Option<RenderBackendKind> {
-        RenderBackendKind::from_str(self.backend_id())
-    }
-
-    pub fn gain_model_kind(&self) -> GainModelKind {
-        backend_descriptor_by_id(self.backend_id())
-            .map(|descriptor| descriptor.gain_model_kind)
-            .unwrap_or(GainModelKind::Vbap)
     }
 
     pub fn evaluation_mode(&self) -> LiveEvaluationMode {
@@ -960,9 +949,6 @@ mod tests {
         ($name:ident, $id:literal, $compute:expr) => {
             struct $name;
             impl GainModel for $name {
-                fn kind(&self) -> GainModelKind {
-                    GainModelKind::Vbap
-                }
                 fn backend_id(&self) -> &'static str {
                     $id
                 }

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -21,10 +21,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
 use crate::backend_registry::{BackendRegistry, TopologyBuildPlan, prepare_topology_build_plan};
-use crate::render_backend::backend_descriptor_by_id;
-use crate::render_backend::{
-    EvaluationBuildConfig, GainModelKind, PreparedRenderEngine, RenderBackendKind, RenderRequest,
-};
+use crate::render_backend::{EvaluationBuildConfig, PreparedRenderEngine, RenderRequest};
 use crate::spatial_vbap::VbapTableMode;
 use crate::speaker_layout::SpeakerLayout;
 
@@ -360,16 +357,6 @@ impl LiveParams {
         self.backend_id.as_str()
     }
 
-    pub fn backend_kind(&self) -> Option<RenderBackendKind> {
-        RenderBackendKind::from_str(self.backend_id())
-    }
-
-    pub fn gain_model_kind(&self) -> GainModelKind {
-        backend_descriptor_by_id(self.backend_id())
-            .map(|descriptor| descriptor.gain_model_kind)
-            .unwrap_or(GainModelKind::Vbap)
-    }
-
     pub fn requested_evaluation_mode(&self) -> LiveEvaluationMode {
         self.evaluation.mode
     }
@@ -407,12 +394,6 @@ pub struct BackendRebuildParams {
 impl BackendRebuildParams {
     pub fn preferred_evaluation_mode(&self) -> PreferredEvaluationMode {
         self.preferred_evaluation_mode
-    }
-
-    pub fn gain_model_kind(&self) -> GainModelKind {
-        backend_descriptor_by_id(self.backend_id)
-            .map(|descriptor| descriptor.gain_model_kind)
-            .unwrap_or(GainModelKind::Vbap)
     }
 }
 

--- a/omniphony-renderer/renderer/src/render_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend.rs
@@ -45,144 +45,20 @@ pub struct BackendCapabilities {
     pub supports_table_export: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct BackendDescriptor {
-    pub kind: RenderBackendKind,
-    pub gain_model_kind: GainModelKind,
-    pub id: &'static str,
-    pub label: &'static str,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum GainModelKind {
-    Vbap,
-    Barycenter,
-    ExperimentalDistance,
-    Hybrid,
-}
-
-impl GainModelKind {
-    pub fn as_str(self) -> &'static str {
-        backend_descriptor_by_gain_model_kind(self).id
+/// Canonical id for a built-in backend, accepting the legacy aliases that older
+/// configs and OSC clients may still send (`"barycentre"`, `"distance"`,
+/// `"distance_based"`). Returns `None` for anything that is not a shipped
+/// built-in; callers then fall back to the
+/// [`BackendRegistry`](crate::backend_registry::BackendRegistry) to resolve
+/// contributor-registered backend ids.
+pub fn canonical_builtin_backend_id(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "vbap" => Some("vbap"),
+        "barycenter" | "barycentre" => Some("barycenter"),
+        "experimental_distance" | "distance" | "distance_based" => Some("experimental_distance"),
+        "hybrid" => Some("hybrid"),
+        _ => None,
     }
-
-    pub fn from_str(value: &str) -> Option<Self> {
-        let normalized = value.trim().to_ascii_lowercase();
-        if let Some(descriptor) = backend_descriptor_by_id(&normalized) {
-            return Some(descriptor.gain_model_kind);
-        }
-        match normalized.as_str() {
-            "barycentre" | "barycenter" => Some(Self::Barycenter),
-            "distance" | "distance_based" => Some(Self::ExperimentalDistance),
-            "hybrid" => Some(Self::Hybrid),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RenderBackendKind {
-    Vbap,
-    Barycenter,
-    ExperimentalDistance,
-    Hybrid,
-}
-
-impl RenderBackendKind {
-    pub fn as_str(self) -> &'static str {
-        backend_descriptor(self).id
-    }
-
-    pub fn from_str(value: &str) -> Option<Self> {
-        let normalized = value.trim().to_ascii_lowercase();
-        if let Some(descriptor) = backend_descriptor_by_id(&normalized) {
-            return Some(descriptor.kind);
-        }
-        match normalized.as_str() {
-            "barycentre" | "barycenter" => Some(Self::Barycenter),
-            "distance" | "distance_based" => Some(Self::ExperimentalDistance),
-            "hybrid" => Some(Self::Hybrid),
-            _ => None,
-        }
-    }
-
-    pub fn as_gain_model_kind(self) -> GainModelKind {
-        backend_descriptor(self).gain_model_kind
-    }
-
-    pub fn label(self) -> &'static str {
-        backend_descriptor(self).label
-    }
-}
-
-impl From<GainModelKind> for RenderBackendKind {
-    fn from(value: GainModelKind) -> Self {
-        match value {
-            GainModelKind::Vbap => Self::Vbap,
-            GainModelKind::Barycenter => Self::Barycenter,
-            GainModelKind::ExperimentalDistance => Self::ExperimentalDistance,
-            GainModelKind::Hybrid => Self::Hybrid,
-        }
-    }
-}
-
-impl From<RenderBackendKind> for GainModelKind {
-    fn from(value: RenderBackendKind) -> Self {
-        value.as_gain_model_kind()
-    }
-}
-
-const BACKEND_DESCRIPTORS: [BackendDescriptor; 4] = [
-    BackendDescriptor {
-        kind: RenderBackendKind::Vbap,
-        gain_model_kind: GainModelKind::Vbap,
-        id: "vbap",
-        label: "VBAP",
-    },
-    BackendDescriptor {
-        kind: RenderBackendKind::Barycenter,
-        gain_model_kind: GainModelKind::Barycenter,
-        id: "barycenter",
-        label: "Barycenter",
-    },
-    BackendDescriptor {
-        kind: RenderBackendKind::ExperimentalDistance,
-        gain_model_kind: GainModelKind::ExperimentalDistance,
-        id: "experimental_distance",
-        label: "Distance",
-    },
-    BackendDescriptor {
-        kind: RenderBackendKind::Hybrid,
-        gain_model_kind: GainModelKind::Hybrid,
-        id: "hybrid",
-        label: "Hybrid",
-    },
-];
-
-pub fn backend_descriptors() -> &'static [BackendDescriptor] {
-    &BACKEND_DESCRIPTORS
-}
-
-pub fn backend_descriptor(kind: RenderBackendKind) -> &'static BackendDescriptor {
-    backend_descriptors()
-        .iter()
-        .find(|descriptor| descriptor.kind == kind)
-        .expect("missing backend descriptor")
-}
-
-pub fn backend_descriptor_by_gain_model_kind(kind: GainModelKind) -> &'static BackendDescriptor {
-    backend_descriptors()
-        .iter()
-        .find(|descriptor| descriptor.gain_model_kind == kind)
-        .expect("missing backend descriptor")
-}
-
-pub fn backend_descriptor_by_id(id: &str) -> Option<&'static BackendDescriptor> {
-    backend_descriptors()
-        .iter()
-        .find(|descriptor| descriptor.id == id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -280,7 +156,6 @@ pub struct EvaluationBuildConfig {
 /// thread — but that guard only catches the build-time probe, so honouring the
 /// contract above is still required for correct realtime behaviour.
 pub trait GainModel: Send + Sync + 'static {
-    fn kind(&self) -> GainModelKind;
     fn backend_id(&self) -> &'static str;
     fn backend_label(&self) -> &'static str;
     fn capabilities(&self) -> BackendCapabilities;
@@ -730,7 +605,6 @@ impl EvaluationStrategy for PrecomputedPolarStrategy {
 }
 
 pub struct PreparedRenderEngine {
-    gain_model_kind: GainModelKind,
     backend_id: &'static str,
     backend_label: &'static str,
     capabilities: BackendCapabilities,
@@ -741,7 +615,6 @@ pub struct PreparedRenderEngine {
 
 impl PreparedRenderEngine {
     pub fn new(
-        gain_model_kind: GainModelKind,
         backend_id: &'static str,
         backend_label: &'static str,
         capabilities: BackendCapabilities,
@@ -750,7 +623,6 @@ impl PreparedRenderEngine {
         evaluator: Box<dyn PreparedEvaluator>,
     ) -> Self {
         Self {
-            gain_model_kind,
             backend_id,
             backend_label,
             capabilities,
@@ -758,14 +630,6 @@ impl PreparedRenderEngine {
             backend_restore_snapshot,
             evaluator,
         }
-    }
-
-    pub fn kind(&self) -> RenderBackendKind {
-        self.gain_model_kind.into()
-    }
-
-    pub fn gain_model_kind(&self) -> GainModelKind {
-        self.gain_model_kind
     }
 
     pub fn backend_id(&self) -> &'static str {
@@ -868,7 +732,6 @@ pub fn wrap_prepared_engine(
     evaluation_mode: EffectiveEvaluationMode,
     config: &EvaluationBuildConfig,
 ) -> Result<PreparedRenderEngine> {
-    let gain_model_kind = model.kind();
     let backend_id = model.backend_id();
     let backend_label = model.backend_label();
     let capabilities = model.capabilities();
@@ -882,7 +745,6 @@ pub fn wrap_prepared_engine(
         }
     };
     Ok(PreparedRenderEngine::new(
-        gain_model_kind,
         backend_id,
         backend_label,
         capabilities,

--- a/omniphony-renderer/renderer/src/render_backend/barycenter_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/barycenter_backend.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::room_transform::room_scaled_position;
-use super::{BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use crate::spatial_vbap::{Gains, MAX_SPEAKERS};
 use crate::speaker_layout::SpeakerLayout;
 
@@ -123,10 +123,6 @@ impl BarycenterBackend {
 }
 
 impl GainModel for BarycenterBackend {
-    fn kind(&self) -> GainModelKind {
-        GainModelKind::Barycenter
-    }
-
     fn backend_id(&self) -> &'static str {
         "barycenter"
     }

--- a/omniphony-renderer/renderer/src/render_backend/distance_attenuation.rs
+++ b/omniphony-renderer/renderer/src/render_backend/distance_attenuation.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::room_transform::room_scaled_position;
-use super::{BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use crate::spatial_vbap::{DistanceMetric, calculate_distance_attenuation};
 use crate::speaker_layout::SpeakerLayout;
 
@@ -26,10 +26,6 @@ impl DistanceAttenuatedModel {
 }
 
 impl GainModel for DistanceAttenuatedModel {
-    fn kind(&self) -> GainModelKind {
-        self.inner.kind()
-    }
-
     fn backend_id(&self) -> &'static str {
         self.inner.backend_id()
     }

--- a/omniphony-renderer/renderer/src/render_backend/distance_diffuse.rs
+++ b/omniphony-renderer/renderer/src/render_backend/distance_diffuse.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::{BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use crate::spatial_vbap::{DistanceMetric, Gains};
 use crate::speaker_layout::SpeakerLayout;
 
@@ -28,10 +28,6 @@ impl DistanceDiffuseModel {
 }
 
 impl GainModel for DistanceDiffuseModel {
-    fn kind(&self) -> GainModelKind {
-        self.inner.kind()
-    }
-
     fn backend_id(&self) -> &'static str {
         self.inner.backend_id()
     }

--- a/omniphony-renderer/renderer/src/render_backend/experimental_distance_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/experimental_distance_backend.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use super::room_transform::room_scaled_position;
-use super::{BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use crate::spatial_vbap::Gains;
 use crate::speaker_layout::SpeakerLayout;
 
@@ -101,10 +101,6 @@ impl ExperimentalDistanceBackend {
 }
 
 impl GainModel for ExperimentalDistanceBackend {
-    fn kind(&self) -> GainModelKind {
-        GainModelKind::ExperimentalDistance
-    }
-
     fn backend_id(&self) -> &'static str {
         "experimental_distance"
     }

--- a/omniphony-renderer/renderer/src/render_backend/few_speaker_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/few_speaker_backend.rs
@@ -3,7 +3,7 @@ use std::f32::consts::FRAC_1_SQRT_2;
 use anyhow::Result;
 
 use super::room_transform::room_scaled_position;
-use super::{BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use crate::spatial_vbap::{Gains, spherical_to_adm};
 use crate::speaker_layout::SpeakerLayout;
 
@@ -151,11 +151,7 @@ impl FewSpeakerBackend {
 }
 
 impl GainModel for FewSpeakerBackend {
-    fn kind(&self) -> GainModelKind {
-        // Degenerate VBAP — reuse the VBAP identity (no separate UI backend).
-        GainModelKind::Vbap
-    }
-
+    // Degenerate VBAP — reuses the VBAP identity (no separate UI backend).
     fn backend_id(&self) -> &'static str {
         "vbap"
     }

--- a/omniphony-renderer/renderer/src/render_backend/file_loaded_evaluator.rs
+++ b/omniphony-renderer/renderer/src/render_backend/file_loaded_evaluator.rs
@@ -378,7 +378,6 @@ pub fn build_from_file_render_engine(
     position_interpolation: bool,
 ) -> super::PreparedRenderEngine {
     super::PreparedRenderEngine::new(
-        super::GainModelKind::Vbap,
         "vbap",
         "VBAP",
         FileLoadedEvaluator::capabilities(),

--- a/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::{BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
 use crate::spatial_vbap::{DistanceMetric, Gains};
 use crate::speaker_layout::SpeakerLayout;
 
@@ -104,10 +104,6 @@ impl HybridBackend {
 }
 
 impl GainModel for HybridBackend {
-    fn kind(&self) -> GainModelKind {
-        GainModelKind::Hybrid
-    }
-
     fn backend_id(&self) -> &'static str {
         "hybrid"
     }

--- a/omniphony-renderer/renderer/src/render_backend/vbap_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/vbap_backend.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 
 use super::room_transform::room_scaled_position;
-use super::{
-    BackendCapabilities, GainModel, GainModelKind, RenderRequest, RenderResponse,
-    reduce_size_to_spread,
-};
+use super::{BackendCapabilities, GainModel, RenderRequest, RenderResponse, reduce_size_to_spread};
 use crate::spatial_vbap::{VbapPanner, adm_to_spherical};
 use crate::speaker_layout::SpeakerLayout;
 
@@ -78,10 +75,6 @@ impl VbapBackend {
 }
 
 impl GainModel for VbapBackend {
-    fn kind(&self) -> GainModelKind {
-        GainModelKind::Vbap
-    }
-
     fn backend_id(&self) -> &'static str {
         "vbap"
     }

--- a/omniphony-renderer/renderer/src/spatial_renderer.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer.rs
@@ -77,8 +77,7 @@ use crate::ramp_strategy::{
 use crate::render_backend::RenderRequest;
 use crate::render_backend::{
     CartesianEvaluationConfig, EffectiveEvaluationMode, EvaluationBuildConfig, MultiBandTable,
-    PolarEvaluationConfig, PreparedRenderEngine, RenderBackendKind, VbapBackend,
-    build_prepared_render_engine,
+    PolarEvaluationConfig, PreparedRenderEngine, VbapBackend, build_prepared_render_engine,
 };
 use crate::spatial_vbap::{DistanceModel, Gains};
 use crate::spatial_vbap::{VbapPanner, VbapTableMode};
@@ -667,7 +666,7 @@ impl SpatialRenderer {
             topology,
             editable_layout,
             Some(crate::live_params::BackendRebuildParams {
-                backend_id: RenderBackendKind::Vbap.as_str(),
+                backend_id: "vbap",
                 preferred_evaluation_mode,
                 allow_negative_z,
                 vbap: Some(crate::live_params::VbapModelRebuildParams {
@@ -805,7 +804,7 @@ impl SpatialRenderer {
             spread_distance_curve,
             size_to_spread_mode: Default::default(),
             ramp_mode,
-            backend_id: RenderBackendKind::Vbap.as_str().to_string(),
+            backend_id: "vbap".to_string(),
             evaluation: EvaluationLiveParams {
                 mode: initial_evaluation_mode,
                 position_interpolation: vbap_position_interpolation,

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -1,6 +1,6 @@
 use crate::context::RuntimeControlContext;
 use renderer::live_params::LiveEvaluationMode;
-use renderer::render_backend::RenderBackendKind;
+use renderer::render_backend::canonical_builtin_backend_id;
 use rosc::{OscMessage, OscType};
 use serde::Deserialize;
 use std::hash::{Hash, Hasher};
@@ -666,11 +666,11 @@ pub fn apply_simple_osc_control(
     // source of truth for both, persisted to config.
 
     if addr == "/omniphony/control/render_backend" {
-        // Accept enum names/aliases (e.g. "distance") and any registered backend
+        // Accept built-in ids/aliases (e.g. "distance") and any registered backend
         // id (e.g. a contributor's "example"), so the dropdown can offer them all.
         let requested_id = parse_string_arg(msg.args.first()).and_then(|value| {
-            RenderBackendKind::from_str(&value)
-                .map(|kind| kind.as_str().to_string())
+            canonical_builtin_backend_id(&value)
+                .map(|id| id.to_string())
                 .or_else(|| ctx.renderer.has_backend(&value).then_some(value))
         });
         if let Some(requested_id) = requested_id {
@@ -732,7 +732,7 @@ pub fn apply_simple_osc_control(
                 effects.evaluation_only = true;
             }
             {
-                if live.backend_kind() == Some(RenderBackendKind::Vbap) {
+                if live.backend_id() == "vbap" {
                     effects.mark_dirty = true;
                 }
                 effects.log_message = Some(format!(

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -164,7 +164,7 @@ pub fn build_renderer_state_json(
     available_backends: Vec<renderer::backend_registry::BackendListing>,
     backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
 ) -> String {
-    let effective_backend = active_topology.backend.kind().as_str();
+    let effective_backend = active_topology.backend.backend_id();
     let effective_evaluation_mode = active_topology.backend.evaluation_mode().as_str();
     let render_backend_state_json = build_render_backend_state_json(
         live,

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -930,7 +930,7 @@ impl From<RampModeArg> for RampMode {
 }
 
 /// Spatial render backend selector. The string forms match the canonical
-/// backend ids in `renderer::render_backend` (`RenderBackendKind::from_str`).
+/// backend ids in `renderer::render_backend` (`canonical_builtin_backend_id`).
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum RenderBackendArg {
     Vbap,


### PR DESCRIPTION
## Why

`GainModelKind` and `RenderBackendKind` were closed 4-variant enums that duplicated the now-authoritative `BackendRegistry`. Every backend had to implement `GainModel::kind()` returning one of the four variants, and a static `BACKEND_DESCRIPTORS` table mapped them to ids/labels. A contributor backend could not extend either enum — so the shipped `example` backend had to **borrow** `GainModelKind::Vbap` as a fake identity.

This was the last closed-enum friction point on the backend frontier opened in Phase 1.

## What

Backend identity now lives entirely on each backend via the existing `backend_id()` / `backend_label()` trait methods and the factory param schema.

- Drop `GainModel::kind()` from the trait and from all **nine** impls (vbap, barycenter, experimental_distance, hybrid, few_speaker, example, the two distance decorators, and the test macro).
- Remove `gain_model_kind` from `PreparedRenderEngine` (struct field + `new` arg).
- Replace the only real reader (`snapshot.rs`) with `backend_id()`. This **also fixes a reporting bug**: the effective backend used to surface `example` as `"vbap"` because it borrowed the VBAP variant; it now reports `"example"`.
- Delete `GainModelKind`, `RenderBackendKind`, `BackendDescriptor`, the `BACKEND_DESCRIPTORS` table and their lookup helpers.
- Replace the enums' `from_str` alias handling (`barycentre`, `distance`, `distance_based`) with a single free function `canonical_builtin_backend_id`, used by the OSC and config backend-id resolvers.
- Drop the now-dead `backend_kind()` / `gain_model_kind()` helper methods.

## Impact

No behaviour change. **Net −215 lines across 17 files.** Workspace builds, `cargo fmt --check` is clean, and the full test suite passes (149 tests, 0 failures).

## Follow-up

`docs/custom-render-backend-integration.md` still describes the old "add an enum variant + edit `BACKEND_DESCRIPTORS`" workflow and is now obsolete — a rewrite to the registry/factory path is the next step (Phase 4 doc work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)