### PR TITLE
refactor(studio): plumb per-backend param values and explicit-target param set

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc/recompute.rs
+++ b/omniphony-renderer/orender_engine/src/osc/recompute.rs
@@ -101,6 +101,7 @@ pub(crate) fn trigger_layout_recompute(
                             scale_m,
                             control_clone.available_backends(),
                             control_clone.backend_params_for(live.backend_id()),
+                            control_clone.all_backend_params(),
                         )
                     };
                     let layout_json = {

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -693,12 +693,24 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    // Generic backend parameter set: `[string key, <scalar value>]`, applied to
-    // the currently selected backend. Values are stored generically (no typed
-    // field per backend) and read at the next topology rebuild via the schema.
+    // Generic backend parameter set. Two forms:
+    //   `[string key, <scalar value>]`              -> currently selected backend
+    //   `[string backend_id, string key, <value>]`  -> an explicit backend
+    // The explicit form lets the UI address an inner backend (e.g. the hybrid
+    // barycenter tab) even though it is not the active selection. Values are
+    // stored generically (no typed field per backend) and read at the next
+    // topology rebuild via the schema.
     if addr == "/omniphony/control/backend/param" {
-        let key = parse_string_arg(msg.args.first());
-        let value = msg.args.get(1).and_then(|arg| match arg {
+        let (target, key, value_arg) = if msg.args.len() >= 3 {
+            (
+                parse_string_arg(msg.args.first()),
+                parse_string_arg(msg.args.get(1)),
+                msg.args.get(2),
+            )
+        } else {
+            (None, parse_string_arg(msg.args.first()), msg.args.get(1))
+        };
+        let value = value_arg.and_then(|arg| match arg {
             OscType::Float(f) => Some(renderer::backend_params::ParamValue::Float(*f)),
             OscType::Double(d) => Some(renderer::backend_params::ParamValue::Float(*d as f32)),
             OscType::Int(i) => Some(renderer::backend_params::ParamValue::Int(*i as i64)),
@@ -708,7 +720,8 @@ pub fn apply_simple_osc_control(
             _ => None,
         });
         if let (Some(key), Some(value)) = (key, value) {
-            let backend_id = ctx.renderer.live.read().backend_id().to_string();
+            let backend_id =
+                target.unwrap_or_else(|| ctx.renderer.live.read().backend_id().to_string());
             ctx.renderer.set_backend_param(&backend_id, &key, value);
             effects.mark_dirty = true;
             effects.trigger_layout_recompute = true;

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -45,6 +45,13 @@ pub struct RenderBackendStateSnapshot {
     /// UI seeds its controls from these (falling back to the schema defaults).
     pub backend_param_values:
         std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    /// Host-set param values for *every* backend, keyed by backend id then param
+    /// key. The UI reads an inner backend's values from here (e.g. the hybrid
+    /// barycenter tab), independent of the active selection.
+    pub backend_param_values_by_id: std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    >,
     pub capabilities: renderer::render_backend::BackendCapabilities,
     pub allowed_evaluation_modes: Vec<String>,
     pub frozen_room_ratio: bool,
@@ -78,6 +85,10 @@ pub fn build_render_backend_state_snapshot(
     active_topology: &RenderTopology,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
     backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    backend_param_values_by_id: std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    >,
 ) -> RenderBackendStateSnapshot {
     let backend = &active_topology.backend;
     let capabilities = backend.capabilities();
@@ -125,6 +136,7 @@ pub fn build_render_backend_state_snapshot(
         effective_label: backend.backend_label().to_string(),
         available_backends,
         backend_param_values,
+        backend_param_values_by_id,
         capabilities,
         allowed_evaluation_modes: allowed_evaluation_modes(backend, capabilities),
         frozen_room_ratio: false,
@@ -147,12 +159,17 @@ pub fn build_render_backend_state_json(
     active_topology: &RenderTopology,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
     backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    backend_param_values_by_id: std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    >,
 ) -> String {
     serde_json::to_string(&build_render_backend_state_snapshot(
         live,
         active_topology,
         available_backends,
         backend_param_values,
+        backend_param_values_by_id,
     ))
     .unwrap_or_else(|_| "{}".to_string())
 }
@@ -163,6 +180,10 @@ pub fn build_renderer_state_json(
     room_scale_m: f32,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
     backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    backend_param_values_by_id: std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, renderer::backend_params::ParamValue>,
+    >,
 ) -> String {
     let effective_backend = active_topology.backend.backend_id();
     let effective_evaluation_mode = active_topology.backend.evaluation_mode().as_str();
@@ -171,6 +192,7 @@ pub fn build_renderer_state_json(
         active_topology,
         available_backends,
         backend_param_values,
+        backend_param_values_by_id,
     );
     json!({
         "renderBackend": live.backend_id(),
@@ -360,6 +382,7 @@ pub fn build_live_state_bundle(
         editable_layout.radius_m,
         control.available_backends(),
         control.backend_params_for(live.backend_id()),
+        control.all_backend_params(),
     );
 
     let mut messages = vec![

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -235,6 +235,16 @@ pub struct RenderBackendState {
         skip_serializing_if = "serde_json::Value::is_null"
     )]
     pub backend_param_values: serde_json::Value,
+    /// Host-set param values for every backend (`{ backendId: { key: value } }`),
+    /// used to seed generated controls for a backend that is not the active
+    /// selection (e.g. a hybrid inner-backend tab).
+    #[serde(
+        rename = "backendParamValuesById",
+        alias = "backend_param_values_by_id",
+        default,
+        skip_serializing_if = "serde_json::Value::is_null"
+    )]
+    pub backend_param_values_by_id: serde_json::Value,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -922,22 +922,36 @@ fn control_render_backend(state: State<SharedState>, value: String) {
     );
 }
 
-/// Generic backend param setter: forwards `[string key, <scalar>]` to the engine
-/// for the currently selected backend. The scalar type follows the JSON value
-/// (bool / number / string), matching the param schema's kind.
+/// Generic backend param setter. The scalar type follows the JSON value (bool /
+/// number / string), matching the param schema's kind. When `backend` is given,
+/// the value is applied to that specific backend (e.g. a hybrid inner backend);
+/// otherwise it targets the currently selected backend.
 #[tauri::command]
-fn control_backend_param(state: State<SharedState>, key: String, value: serde_json::Value) {
+fn control_backend_param(
+    state: State<SharedState>,
+    key: String,
+    value: serde_json::Value,
+    backend: Option<String>,
+) {
     let arg = match value {
         serde_json::Value::Bool(b) => rosc::OscType::Bool(b),
         serde_json::Value::Number(n) => rosc::OscType::Float(n.as_f64().unwrap_or(0.0) as f32),
         serde_json::Value::String(s) => rosc::OscType::String(s),
         _ => return,
     };
+    let args = match backend {
+        Some(backend) => vec![
+            rosc::OscType::String(backend),
+            rosc::OscType::String(key),
+            arg,
+        ],
+        None => vec![rosc::OscType::String(key), arg],
+    };
     send_control(
         &state.osc_tx,
         OscControlMsg::SendArgs {
             address: "/omniphony/control/backend/param".to_string(),
-            args: vec![rosc::OscType::String(key), arg],
+            args,
         },
     );
 }


### PR DESCRIPTION
## Why

Groundwork for retiring the hand-written barycenter / experimental-distance control sections in Studio and rendering them from the generic param schema instead — including their reuse as **hybrid inner-backend tabs**.

The generic param path today only handles the *selected* backend: the snapshot publishes param values for the active backend only (`backendParamValues`, flat), and `/control/backend/param` writes to `live.backend_id()`. A hybrid inner tab (e.g. barycenter while *hybrid* is selected) needs to read and write a backend that is **not** the active selection. The bespoke sections work only because they go through fixed-id OSC aliases (`/control/barycenter/*`).

## What (all additive — no behaviour change)

- **snapshot:** emit `backend_param_values_by_id` (the full param bag, keyed by backend id then key) alongside the existing active-backend `backend_param_values`. Threaded through the state builders and sourced from `RendererControl::all_backend_params()` on both the recompute and the full-state-on-connect paths.
- **OSC `/control/backend/param`:** accept a 3-arg `[backend_id, key, value]` form targeting an explicit backend; keep the 2-arg `[key, value]` form for the selected backend.
- **Tauri `control_backend_param`:** optional `backend` argument selecting the explicit-target form.
- **app_state:** pass `backendParamValuesById` through to the frontend (camelCase rename + snake_case alias), mirroring `backendParamValues`.

Numeric int/float ambiguity is already handled downstream (`ParamValue::as_f32`/`as_i64` cross-convert), so the generic setter can keep sending numbers as float.

## Next

PR 2 (pure JS) switches barycenter + experimental_distance to the generic schema-driven controls (standalone and as hybrid inner tabs) and deletes the bespoke HTML, listeners, dedicated Tauri commands, and snapshot fields.

## Validation

Renderer workspace and Studio Tauri app build; `cargo fmt --check` clean on both; renderer test suite passes (95 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)