### PR TITLE
feat(renderer): add optional help text to backend param schema

### DIFF
--- a/omniphony-renderer/example_backend/src/lib.rs
+++ b/omniphony-renderer/example_backend/src/lib.rs
@@ -165,14 +165,10 @@ impl BackendFactory for ExampleFactory {
     fn param_schema(&self) -> Vec<ParamSpec> {
         // One tunable, declared as data: the UI renders a slider and the host
         // stores the value generically — no typed field anywhere in the renderer.
-        vec![ParamSpec::float(
-            "sharpness",
-            "Sharpness",
-            0.5,
-            8.0,
-            0.1,
-            DEFAULT_SHARPNESS,
-        )]
+        vec![
+            ParamSpec::float("sharpness", "Sharpness", 0.5, 8.0, 0.1, DEFAULT_SHARPNESS)
+                .help("Cosine-lobe exponent: higher = tighter localisation, lower = more spread."),
+        ]
     }
 
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {

--- a/omniphony-renderer/renderer/src/backend_params.rs
+++ b/omniphony-renderer/renderer/src/backend_params.rs
@@ -25,6 +25,10 @@ pub struct ParamSpec {
     /// when the backend `supports_distance_model`). `None` = always shown.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<&'static str>,
+    /// Optional one-line help shown next to the control (e.g. as an info tooltip).
+    /// `None` = no help affordance.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<&'static str>,
 }
 
 impl ParamSpec {
@@ -43,6 +47,7 @@ impl ParamSpec {
             kind: ParamKind::Float { min, max, step },
             default: ParamValue::Float(default),
             requires: None,
+            help: None,
         }
     }
 
@@ -54,6 +59,7 @@ impl ParamSpec {
             kind: ParamKind::Int { min, max },
             default: ParamValue::Int(default),
             requires: None,
+            help: None,
         }
     }
 
@@ -65,12 +71,19 @@ impl ParamSpec {
             kind: ParamKind::Bool,
             default: ParamValue::Bool(default),
             requires: None,
+            help: None,
         }
     }
 
     /// Gate this control behind a backend capability flag.
     pub fn requires(mut self, capability: &'static str) -> Self {
         self.requires = Some(capability);
+        self
+    }
+
+    /// Attach a one-line help string, shown next to the control in the UI.
+    pub fn help(mut self, help: &'static str) -> Self {
+        self.help = Some(help);
         self
     }
 }

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -741,9 +741,14 @@ impl BackendFactory for BarycenterFactory {
         "Barycenter"
     }
     fn param_schema(&self) -> Vec<crate::backend_params::ParamSpec> {
-        vec![crate::backend_params::ParamSpec::float(
-            "localize", "Localize", 0.0, 4.0, 0.05, 0.0,
-        )]
+        vec![
+            crate::backend_params::ParamSpec::float("localize", "Localize", 0.0, 4.0, 0.05, 0.0)
+                .help(
+                    "Higher values collapse energy more tightly toward the target point; lower \
+                     values stay broader and softer. Barycenter blends nearby speakers around a \
+                     weighted center instead of VBAP triplet selection.",
+                ),
+        ]
     }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
         build_inner_backend_plan(ctx, self.id())
@@ -769,6 +774,10 @@ impl BackendFactory for ExperimentalDistanceFactory {
                 1.0,
                 0.01,
                 d.distance_floor,
+            )
+            .help(
+                "Minimum distance used when scoring speakers, so a speaker right on the target \
+                 point cannot dominate without bound.",
             ),
             ParamSpec::int(
                 "min_active_speakers",
@@ -776,14 +785,16 @@ impl BackendFactory for ExperimentalDistanceFactory {
                 1,
                 32,
                 d.min_active_speakers as i64,
-            ),
+            )
+            .help("Fewest speakers allowed to share energy for one object."),
             ParamSpec::int(
                 "max_active_speakers",
                 "Max active speakers",
                 1,
                 32,
                 d.max_active_speakers as i64,
-            ),
+            )
+            .help("Most speakers allowed to share energy for one object."),
             ParamSpec::float(
                 "position_error_floor",
                 "Position error floor",
@@ -791,7 +802,8 @@ impl BackendFactory for ExperimentalDistanceFactory {
                 1.0,
                 0.01,
                 d.position_error_floor,
-            ),
+            )
+            .help("Position error tolerated before gains start to be clamped or spread wider."),
             ParamSpec::float(
                 "position_error_nearest_scale",
                 "Position error nearest scale",
@@ -799,7 +811,8 @@ impl BackendFactory for ExperimentalDistanceFactory {
                 4.0,
                 0.05,
                 d.position_error_nearest_scale,
-            ),
+            )
+            .help("How aggressively the nearest speakers dominate as position error grows."),
             ParamSpec::float(
                 "position_error_span_scale",
                 "Position error span scale",
@@ -807,7 +820,8 @@ impl BackendFactory for ExperimentalDistanceFactory {
                 4.0,
                 0.05,
                 d.position_error_span_scale,
-            ),
+            )
+            .help("How much energy spreads to more speakers as position error grows."),
         ]
     }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -347,6 +347,14 @@ function buildParamControl(spec, current) {
   row.className = 'control-row generated-param-row';
   const label = document.createElement('label');
   label.textContent = spec.label || spec.key;
+  if (spec.help) {
+    const info = document.createElement('span');
+    info.className = 'info-icon-btn';
+    info.textContent = 'i';
+    info.title = spec.help;
+    info.style.marginLeft = '0.35rem';
+    label.appendChild(info);
+  }
   row.appendChild(label);
   const kind = spec.kind || {};
   if (kind.type === 'bool') {


### PR DESCRIPTION
## Why

Switching the built-in barycenter / experimental-distance backends to the generic schema-driven controls would drop their info "i" help modals, since the schema had no place for help text. This adds that place — and gives **contributor** backends per-parameter documentation for free.

## What

- `ParamSpec` gains an optional `help: Option<&'static str>` field with a `.help(...)` builder; serde-skipped when absent.
- The generic Studio control (`buildParamControl`) renders an info "i" with a tooltip next to the control label when `help` is present.
- The built-in `barycenter` (localize) and `experimental_distance` (6 params) schemas declare help ported from their existing info modals; the example backend documents `sharpness`.

Additive — no behaviour change. Groundwork for the upcoming PR that retires the bespoke barycenter/experimental control sections.

## Validation

Renderer workspace builds, `cargo fmt --check` clean, full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)