### PR TITLE
feat(studio): render barycenter/distance from the generic param schema

### DIFF
--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -717,77 +717,6 @@ fn control_distance_diffuse_metric(state: State<SharedState>, value: String) {
 }
 
 #[tauri::command]
-fn control_experimental_distance_distance_floor(state: State<SharedState>, value: f32) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendFloat {
-            address: "/omniphony/control/experimental_distance/distance_floor".to_string(),
-            value: value.max(0.0),
-        },
-    );
-}
-
-#[tauri::command]
-fn control_experimental_distance_min_active_speakers(state: State<SharedState>, value: i32) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendInt {
-            address: "/omniphony/control/experimental_distance/min_active_speakers".to_string(),
-            value: value.max(1),
-        },
-    );
-}
-
-#[tauri::command]
-fn control_experimental_distance_max_active_speakers(state: State<SharedState>, value: i32) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendInt {
-            address: "/omniphony/control/experimental_distance/max_active_speakers".to_string(),
-            value: value.max(1),
-        },
-    );
-}
-
-#[tauri::command]
-fn control_experimental_distance_position_error_floor(state: State<SharedState>, value: f32) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendFloat {
-            address: "/omniphony/control/experimental_distance/position_error_floor".to_string(),
-            value: value.max(0.0),
-        },
-    );
-}
-
-#[tauri::command]
-fn control_experimental_distance_position_error_nearest_scale(
-    state: State<SharedState>,
-    value: f32,
-) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendFloat {
-            address: "/omniphony/control/experimental_distance/position_error_nearest_scale"
-                .to_string(),
-            value: value.max(0.0),
-        },
-    );
-}
-
-#[tauri::command]
-fn control_experimental_distance_position_error_span_scale(state: State<SharedState>, value: f32) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendFloat {
-            address: "/omniphony/control/experimental_distance/position_error_span_scale"
-                .to_string(),
-            value: value.max(0.0),
-        },
-    );
-}
-
-#[tauri::command]
 fn control_hybrid_external_backend(state: State<SharedState>, value: String) {
     let normalized = value.trim().to_ascii_lowercase();
     if !matches!(
@@ -952,17 +881,6 @@ fn control_backend_param(
         OscControlMsg::SendArgs {
             address: "/omniphony/control/backend/param".to_string(),
             args,
-        },
-    );
-}
-
-#[tauri::command]
-fn control_barycenter_localize(state: State<SharedState>, value: f32) {
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendFloat {
-            address: "/omniphony/control/barycenter/localize".to_string(),
-            value: value.max(0.0),
         },
     );
 }
@@ -2679,12 +2597,6 @@ fn main() {
             control_distance_model,
             control_distance_model_metric,
             control_distance_diffuse_metric,
-            control_experimental_distance_distance_floor,
-            control_experimental_distance_min_active_speakers,
-            control_experimental_distance_max_active_speakers,
-            control_experimental_distance_position_error_floor,
-            control_experimental_distance_position_error_nearest_scale,
-            control_experimental_distance_position_error_span_scale,
             control_hybrid_external_backend,
             control_hybrid_internal_backend,
             control_hybrid_curve,
@@ -2696,7 +2608,6 @@ fn main() {
             control_render_evaluation_cartesian_z_neg_size,
             control_render_backend,
             control_backend_param,
-            control_barycenter_localize,
             control_restore_render_backend,
             control_render_evaluation_mode,
             control_render_evaluation_polar_azimuth_resolution,

--- a/omniphony-studio/src/app.js
+++ b/omniphony-studio/src/app.js
@@ -66,10 +66,8 @@ import { initRenderSurfaceController } from './core/render/render-surface-contro
 // ── Flush callback wiring ──────────────────────────────────────────────────
 import { renderSpreadDisplay } from './controls/spread.js';
 import {
-  renderBarycenterOptions,
   renderVbapStatus,
   renderEvaluationMode,
-  renderExperimentalDistanceOptions,
   renderHybridOptions,
   renderRenderBackend,
   renderVbapCartesian,
@@ -104,8 +102,6 @@ flushCallbacks.renderRoomRatioDisplay = renderRoomRatioDisplay;
 flushCallbacks.renderSpreadDisplay = renderSpreadDisplay;
 flushCallbacks.renderEvaluationMode = renderEvaluationMode;
 flushCallbacks.renderRenderBackend = renderRenderBackend;
-flushCallbacks.renderBarycenterOptions = renderBarycenterOptions;
-flushCallbacks.renderExperimentalDistanceOptions = renderExperimentalDistanceOptions;
 flushCallbacks.renderHybridOptions = renderHybridOptions;
 flushCallbacks.renderVbapCartesian = renderVbapCartesian;
 flushCallbacks.renderVbapPolar = renderVbapPolar;

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -355,6 +355,14 @@ function buildParamControl(spec, current, backend) {
     info.className = 'info-icon-btn';
     info.textContent = 'i';
     info.title = spec.help;
+    // `info-icon-btn` sizes a fixed square box, but a <span> is inline by
+    // default so width/height are ignored and it renders oblong. inline-flex
+    // applies the box and centers the glyph.
+    info.style.display = 'inline-flex';
+    info.style.alignItems = 'center';
+    info.style.justifyContent = 'center';
+    info.style.verticalAlign = 'middle';
+    info.style.flex = '0 0 auto';
     info.style.marginLeft = '0.35rem';
     label.appendChild(info);
   }
@@ -390,6 +398,11 @@ function buildParamControl(spec, current, backend) {
     const valEl = document.createElement('span');
     valEl.className = 'val';
     valEl.textContent = String(current);
+    // Fixed-width, right-aligned readout so the value's changing digit count
+    // does not resize its grid column and shift the slider as you drag.
+    valEl.style.display = 'inline-block';
+    valEl.style.minWidth = '3.5em';
+    valEl.style.textAlign = 'right';
     const parse = (v) => (isInt ? Math.round(Number(v)) : Number(v));
     input.addEventListener('input', () => { valEl.textContent = input.value; });
     input.addEventListener('change', () => sendBackendParam(spec.key, parse(input.value), backend));

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -24,8 +24,6 @@ function getBackendSpecificParamsSectionEl() { return inRendererPanel('backendSp
 function getEvaluationSectionEl() { return inRendererPanel('evaluationSection'); }
 function getSpreadSectionEl() { return inRendererPanel('spreadSection'); }
 function getSpreadFromDistanceSectionEl() { return inRendererPanel('spreadFromDistanceSection'); }
-function getBarycenterSectionEl() { return inRendererPanel('barycenterSection'); }
-function getExperimentalDistanceSectionEl() { return inRendererPanel('experimentalDistanceSection'); }
 function getHybridSectionEl() { return inRendererPanel('hybridSection'); }
 function getHybridExternalBackendSelectEl() { return inRendererPanel('hybridExternalBackendSelect'); }
 function getHybridInternalBackendSelectEl() { return inRendererPanel('hybridInternalBackendSelect'); }
@@ -49,14 +47,6 @@ function getVbapPolarAzStepInfoEl() { return inRendererPanel('vbapPolarAzStepInf
 function getVbapPolarElStepInfoEl() { return inRendererPanel('vbapPolarElStepInfo'); }
 function getVbapPolarDistStepInfoEl() { return inRendererPanel('vbapPolarDistStepInfo'); }
 function getVbapPositionInterpolationToggleEl() { return inRendererPanel('vbapPositionInterpolationToggleEl'); }
-function getBarycenterLocalizeInputEl() { return inRendererPanel('barycenterLocalizeInput'); }
-function getBarycenterLocalizeValEl() { return inRendererPanel('barycenterLocalizeVal'); }
-function getExperimentalDistanceFloorInputEl() { return inRendererPanel('experimentalDistanceFloorInput'); }
-function getExperimentalDistanceMinActiveInputEl() { return inRendererPanel('experimentalDistanceMinActiveInput'); }
-function getExperimentalDistanceMaxActiveInputEl() { return inRendererPanel('experimentalDistanceMaxActiveInput'); }
-function getExperimentalDistanceErrorFloorInputEl() { return inRendererPanel('experimentalDistanceErrorFloorInput'); }
-function getExperimentalDistanceNearestScaleInputEl() { return inRendererPanel('experimentalDistanceNearestScaleInput'); }
-function getExperimentalDistanceSpanScaleInputEl() { return inRendererPanel('experimentalDistanceSpanScaleInput'); }
 
 // These are called from renderVbapCartesian but defined elsewhere in app.js.
 // They must be provided via the callback registry or imported separately.
@@ -97,8 +87,6 @@ function applyRendererBackendVisibility(backend) {
   const backendSpecificParamsSectionEl = getBackendSpecificParamsSectionEl();
   const spreadSectionEl = getSpreadSectionEl();
   const spreadFromDistanceSectionEl = getSpreadFromDistanceSectionEl();
-  const experimentalDistanceSectionEl = getExperimentalDistanceSectionEl();
-  const barycenterSectionEl = getBarycenterSectionEl();
   const hybridSectionEl = getHybridSectionEl();
   const hybridConfigPanelEl = getHybridConfigPanelEl();
   const capabilities = backendCapabilities();
@@ -125,8 +113,13 @@ function applyRendererBackendVisibility(backend) {
   const supportsSpreadFromDistance = isHybrid
     ? paramBackend === 'vbap'
     : capabilities?.supportsSpreadFromDistance === true;
-  const showsBarycenter = paramBackend === 'barycenter';
-  const showsExperimentalDistance = paramBackend === 'experimental_distance';
+  // Backends without a hand-written section (barycenter, distance, contributor
+  // backends) render their controls from the schema. `paramBackend` is null on
+  // the hybrid mix-config tab, where only the config panel shows.
+  const showsGeneric =
+    !!paramBackend
+    && !BESPOKE_BACKENDS.includes(paramBackend)
+    && backendSchemaParams(paramBackend).length > 0;
   const showsHybrid = isHybrid;
   if (backendParametersSectionEl) {
     backendParametersSectionEl.style.display = '';
@@ -140,9 +133,7 @@ function applyRendererBackendVisibility(backend) {
     // all tab content, including the inner-backend param sections that follow it
     // in the DOM.
     backendSpecificParamsSectionEl.style.display =
-      supportsSpread || showsBarycenter || showsExperimentalDistance || showsHybrid
-        ? 'flex'
-        : 'none';
+      supportsSpread || showsGeneric || showsHybrid ? 'flex' : 'none';
   }
   if (spreadSectionEl) {
     spreadSectionEl.style.display = supportsSpread ? '' : 'none';
@@ -150,18 +141,14 @@ function applyRendererBackendVisibility(backend) {
   if (spreadFromDistanceSectionEl) {
     spreadFromDistanceSectionEl.style.display = supportsSpreadFromDistance ? '' : 'none';
   }
-  if (experimentalDistanceSectionEl) {
-    experimentalDistanceSectionEl.style.display = showsExperimentalDistance ? '' : 'none';
-  }
-  if (barycenterSectionEl) {
-    barycenterSectionEl.style.display = showsBarycenter ? '' : 'none';
-  }
   if (hybridSectionEl) {
     hybridSectionEl.style.display = showsHybrid ? '' : 'none';
   }
   if (hybridConfigPanelEl) {
     hybridConfigPanelEl.style.display = isHybrid && hybridTab === 'hybrid' ? '' : 'none';
   }
+  // Schema-generated controls for the active (possibly inner) backend.
+  renderGenericBackendParams(paramBackend);
 }
 
 /** Distinct inner backends currently selected for the hybrid backend. */
@@ -332,17 +319,33 @@ function syncBackendOptions(selectEl) {
   }
 }
 
-// Built-in backends that already have hand-written control sections. Everything
-// else (e.g. a contributor backend) gets its controls generated from the schema.
-const BESPOKE_BACKENDS = ['vbap', 'barycenter', 'experimental_distance', 'hybrid'];
+// Backends that keep hand-written control sections instead of schema-generated
+// ones: VBAP (its spread/distance controls map to shared params) and Hybrid (the
+// mix-config tab). Every other backend — built-in barycenter/distance included,
+// and any contributor backend — gets its controls generated from the schema.
+const BESPOKE_BACKENDS = ['vbap', 'hybrid'];
 
-function sendBackendParam(key, value) {
-  invoke('control_backend_param', { key, value });
+// Param schema (`[{ key, label, kind, default, help? }]`) published for a
+// backend, or `[]` if it has none / is unknown.
+function backendSchemaParams(backendId) {
+  const available = app.renderBackendState && Array.isArray(app.renderBackendState.availableBackends)
+    ? app.renderBackendState.availableBackends
+    : [];
+  const entry = available.find((b) => String(b.id) === String(backendId));
+  return entry && Array.isArray(entry.params) ? entry.params : [];
+}
+
+// Set a param on a specific backend. `backend` is passed so an inner hybrid
+// backend (not the active selection) is addressed correctly; omitted, the engine
+// applies it to the currently selected backend.
+function sendBackendParam(key, value, backend) {
+  invoke('control_backend_param', backend ? { key, value, backend } : { key, value });
 }
 
 // Build one control row for a param spec, seeded with `current`. Returns the row
-// element with a `_setValue` hook used to refresh it without a rebuild.
-function buildParamControl(spec, current) {
+// element with a `_setValue` hook used to refresh it without a rebuild. Edits are
+// sent to `backend`.
+function buildParamControl(spec, current, backend) {
   const row = document.createElement('div');
   row.className = 'control-row generated-param-row';
   const label = document.createElement('label');
@@ -361,7 +364,7 @@ function buildParamControl(spec, current) {
     const input = document.createElement('input');
     input.type = 'checkbox';
     input.checked = current === true;
-    input.addEventListener('change', () => sendBackendParam(spec.key, input.checked));
+    input.addEventListener('change', () => sendBackendParam(spec.key, input.checked, backend));
     row.appendChild(input);
     row._setValue = (v) => { input.checked = v === true; };
   } else if (kind.type === 'enum') {
@@ -373,7 +376,7 @@ function buildParamControl(spec, current) {
       select.appendChild(o);
     }
     select.value = String(current);
-    select.addEventListener('change', () => sendBackendParam(spec.key, select.value));
+    select.addEventListener('change', () => sendBackendParam(spec.key, select.value, backend));
     row.appendChild(select);
     row._setValue = (v) => { select.value = String(v); };
   } else {
@@ -389,7 +392,7 @@ function buildParamControl(spec, current) {
     valEl.textContent = String(current);
     const parse = (v) => (isInt ? Math.round(Number(v)) : Number(v));
     input.addEventListener('input', () => { valEl.textContent = input.value; });
-    input.addEventListener('change', () => sendBackendParam(spec.key, parse(input.value)));
+    input.addEventListener('change', () => sendBackendParam(spec.key, parse(input.value), backend));
     row.appendChild(input);
     row.appendChild(valEl);
     row._setValue = (v) => { input.value = String(v); valEl.textContent = String(v); };
@@ -397,10 +400,16 @@ function buildParamControl(spec, current) {
   return row;
 }
 
-// Generate controls for the active backend from its published param schema.
-// Only used for backends without a hand-written section (contributor backends).
-function renderGenericBackendParams(activeBackend) {
-  const host = getBackendParametersSectionEl();
+// Generate controls for `targetBackend` from its published param schema. Used
+// for every backend without a hand-written section — the built-in barycenter and
+// distance backends as well as contributor backends — both when selected on their
+// own and as the active hybrid inner-backend tab. Values are read per backend id
+// (`backendParamValuesById`), and edits are addressed to `targetBackend`, so an
+// inner hybrid backend is tuned independently of the active selection. The
+// container lives in `backendSpecificParamsSection` so it sits below the hybrid
+// tab bar when one is shown.
+function renderGenericBackendParams(targetBackend) {
+  const host = getBackendSpecificParamsSectionEl();
   if (!host) return;
   let container = document.getElementById('backendGenericParamsSection');
   if (!container) {
@@ -410,28 +419,28 @@ function renderGenericBackendParams(activeBackend) {
     host.appendChild(container);
   }
 
-  const available = app.renderBackendState && Array.isArray(app.renderBackendState.availableBackends)
-    ? app.renderBackendState.availableBackends
+  const schema = targetBackend && !BESPOKE_BACKENDS.includes(targetBackend)
+    ? backendSchemaParams(targetBackend)
     : [];
-  const entry = available.find((b) => String(b.id) === String(activeBackend));
-  const schema = entry && Array.isArray(entry.params) ? entry.params : [];
 
-  if (BESPOKE_BACKENDS.includes(activeBackend) || schema.length === 0) {
+  if (schema.length === 0) {
     container.style.display = 'none';
+    container.dataset.backend = '';
     return;
   }
   container.style.display = '';
 
-  const values = (app.renderBackendState && app.renderBackendState.backendParamValues) || {};
+  const byId = (app.renderBackendState && app.renderBackendState.backendParamValuesById) || {};
+  const values = byId[targetBackend] || {};
   const valueFor = (spec) => (spec.key in values ? values[spec.key] : spec.default);
 
-  // Rebuild controls only when the backend changed; otherwise refresh values so
-  // an external change (OSC) is reflected without dropping focus.
-  if (container.dataset.backend !== String(activeBackend)) {
+  // Rebuild controls only when the target backend changed; otherwise refresh
+  // values so an external change (OSC) is reflected without dropping focus.
+  if (container.dataset.backend !== String(targetBackend)) {
     container.replaceChildren();
-    container.dataset.backend = String(activeBackend);
+    container.dataset.backend = String(targetBackend);
     for (const spec of schema) {
-      container.appendChild(buildParamControl(spec, valueFor(spec)));
+      container.appendChild(buildParamControl(spec, valueFor(spec), targetBackend));
     }
   } else {
     const rows = container.querySelectorAll('.generated-param-row');
@@ -474,76 +483,14 @@ export function renderRenderBackend() {
   if (importLayoutBtnEl) importLayoutBtnEl.disabled = layoutFrozen;
   if (exportLayoutBtnEl) exportLayoutBtnEl.disabled = layoutFrozen;
   applyRendererBackendVisibility(visibleBackend);
-  renderBarycenterOptions();
-  renderExperimentalDistanceOptions();
-  renderGenericBackendParams(visibleBackend);
   renderHybridOptions();
   renderEvaluationMode();
 }
 
 export function updateRenderBackend() {
   dirty.renderBackend = true;
-  dirty.barycenter = true;
-  dirty.experimentalDistance = true;
   dirty.hybrid = true;
   dirty.vbapMode = true;
-  scheduleUIFlush();
-}
-
-export function renderBarycenterOptions() {
-  const barycenterLocalizeInputEl = getBarycenterLocalizeInputEl();
-  const barycenterLocalizeValEl = getBarycenterLocalizeValEl();
-  const state = app.renderBackendState.barycenter || {};
-  const value = typeof state.localize === 'number' ? state.localize : 0;
-  if (barycenterLocalizeInputEl) {
-    barycenterLocalizeInputEl.value = String(value);
-  }
-  if (barycenterLocalizeValEl) {
-    barycenterLocalizeValEl.textContent = formatNumber(value, 2);
-  }
-}
-
-export function updateBarycenterOptions() {
-  dirty.barycenter = true;
-  scheduleUIFlush();
-}
-
-export function renderExperimentalDistanceOptions() {
-  const experimentalDistanceFloorInputEl = getExperimentalDistanceFloorInputEl();
-  const experimentalDistanceMinActiveInputEl = getExperimentalDistanceMinActiveInputEl();
-  const experimentalDistanceMaxActiveInputEl = getExperimentalDistanceMaxActiveInputEl();
-  const experimentalDistanceErrorFloorInputEl = getExperimentalDistanceErrorFloorInputEl();
-  const experimentalDistanceNearestScaleInputEl = getExperimentalDistanceNearestScaleInputEl();
-  const experimentalDistanceSpanScaleInputEl = getExperimentalDistanceSpanScaleInputEl();
-  const state = app.renderBackendState.experimentalDistance || {};
-  if (experimentalDistanceFloorInputEl) {
-    experimentalDistanceFloorInputEl.value =
-      typeof state.distanceFloor === 'number' ? String(state.distanceFloor) : '';
-  }
-  if (experimentalDistanceMinActiveInputEl) {
-    experimentalDistanceMinActiveInputEl.value =
-      typeof state.minActiveSpeakers === 'number' ? String(state.minActiveSpeakers) : '';
-  }
-  if (experimentalDistanceMaxActiveInputEl) {
-    experimentalDistanceMaxActiveInputEl.value =
-      typeof state.maxActiveSpeakers === 'number' ? String(state.maxActiveSpeakers) : '';
-  }
-  if (experimentalDistanceErrorFloorInputEl) {
-    experimentalDistanceErrorFloorInputEl.value =
-      typeof state.positionErrorFloor === 'number' ? String(state.positionErrorFloor) : '';
-  }
-  if (experimentalDistanceNearestScaleInputEl) {
-    experimentalDistanceNearestScaleInputEl.value =
-      typeof state.positionErrorNearestScale === 'number' ? String(state.positionErrorNearestScale) : '';
-  }
-  if (experimentalDistanceSpanScaleInputEl) {
-    experimentalDistanceSpanScaleInputEl.value =
-      typeof state.positionErrorSpanScale === 'number' ? String(state.positionErrorSpanScale) : '';
-  }
-}
-
-export function updateExperimentalDistanceOptions() {
-  dirty.experimentalDistance = true;
   scheduleUIFlush();
 }
 

--- a/omniphony-studio/src/flush.js
+++ b/omniphony-studio/src/flush.js
@@ -36,8 +36,6 @@ export const flushCallbacks = {
   renderSpreadDisplay: null,
   renderEvaluationMode: null,
   renderRenderBackend: null,
-  renderBarycenterOptions: null,
-  renderExperimentalDistanceOptions: null,
   renderHybridOptions: null,
   renderVbapCartesian: null,
   renderVbapPolar: null,
@@ -152,16 +150,6 @@ export function flushUI() {
   if (dirty.renderBackend) {
     flushCallbacks.renderRenderBackend?.();
     dirty.renderBackend = false;
-  }
-
-  if (dirty.barycenter) {
-    flushCallbacks.renderBarycenterOptions?.();
-    dirty.barycenter = false;
-  }
-
-  if (dirty.experimentalDistance) {
-    flushCallbacks.renderExperimentalDistanceOptions?.();
-    dirty.experimentalDistance = false;
   }
 
   if (dirty.hybrid) {

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -715,33 +715,6 @@
       </div>
     </div>
 
-    <div id="barycenterInfoModal" class="info-modal" aria-hidden="true">
-      <div class="info-modal-card">
-        <div class="info-modal-title" data-i18n="barycenter.infoTitle">Barycenter backend</div>
-        <div class="info-modal-text" data-i18n-html="barycenter.infoBody">
-          Barycenter backend places energy by blending nearby speakers around a weighted center instead of using the VBAP triplet selection logic.<br /><br />
-          <strong>Localize</strong> increases how tightly energy collapses toward the target point. Lower values stay broader and softer; higher values bias toward a more focused image.
-        </div>
-        <div class="info-modal-actions">
-          <button id="barycenterInfoCloseBtn" type="button" class="toggle-btn" data-i18n="common.close">Close</button>
-        </div>
-      </div>
-    </div>
-
-    <div id="experimentalDistanceInfoModal" class="info-modal" aria-hidden="true">
-      <div class="info-modal-card">
-        <div class="info-modal-title" data-i18n="experimentalDistance.infoTitle">Distance backend</div>
-        <div class="info-modal-text" data-i18n-html="experimentalDistance.infoBody">
-          Distance backend is an experimental renderer that scores speakers from their geometric relationship to the target point.<br /><br />
-          The exposed controls tune how many speakers can participate, how aggressively nearest speakers dominate, and how much position error is tolerated before gains are clamped or spread wider.<br /><br />
-          Use it for backend comparison and tuning, not as the safest default.
-        </div>
-        <div class="info-modal-actions">
-          <button id="experimentalDistanceInfoCloseBtn" type="button" class="toggle-btn" data-i18n="common.close">Close</button>
-        </div>
-      </div>
-    </div>
-
     <div id="inputInfoModal" class="info-modal" aria-hidden="true">
       <div class="info-modal-card">
         <div class="info-modal-title" data-i18n="input.infoTitle">Audio Input</div>

--- a/omniphony-studio/src/listeners/modal-and-toggle-listeners.js
+++ b/omniphony-studio/src/listeners/modal-and-toggle-listeners.js
@@ -6,8 +6,7 @@ import {
   setRampModeInfoModalOpen, setVbapPositionInterpolationInfoModalOpen,
   setSpreadFromDistanceInfoModalOpen, setDistanceDiffuseInfoModalOpen,
   setEvaluationInfoModalOpen, setBackendInfoModalOpen,
-  setDistanceModelInfoModalOpen, setBarycenterInfoModalOpen,
-  setExperimentalDistanceInfoModalOpen, setInputInfoModalOpen,
+  setDistanceModelInfoModalOpen, setInputInfoModalOpen,
   setInputClockInfoModalOpen, setInputLfeInfoModalOpen,
   setDrcInfoModalOpen, setHeatmapInfoModalOpen,
   setTelemetryGaugesOpen,
@@ -140,22 +139,6 @@ export function setupModalAndToggleListeners() {
     modalId: 'distanceModelInfoModal',
     open: () => setDistanceModelInfoModalOpen(true),
     close: () => setDistanceModelInfoModalOpen(false)
-  });
-
-  bindModalOpenClose({
-    buttonId: 'barycenterInfoBtn',
-    closeButtonId: 'barycenterInfoCloseBtn',
-    modalId: 'barycenterInfoModal',
-    open: () => setBarycenterInfoModalOpen(true),
-    close: () => setBarycenterInfoModalOpen(false)
-  });
-
-  bindModalOpenClose({
-    buttonId: 'experimentalDistanceInfoBtn',
-    closeButtonId: 'experimentalDistanceInfoCloseBtn',
-    modalId: 'experimentalDistanceInfoModal',
-    open: () => setExperimentalDistanceInfoModalOpen(true),
-    close: () => setExperimentalDistanceInfoModalOpen(false)
   });
 
   bindModalOpenClose({
@@ -294,8 +277,6 @@ export function setupModalAndToggleListeners() {
       setEvaluationInfoModalOpen(false);
       setBackendInfoModalOpen(false);
       setDistanceModelInfoModalOpen(false);
-      setBarycenterInfoModalOpen(false);
-      setExperimentalDistanceInfoModalOpen(false);
       setInputInfoModalOpen(false);
       setInputClockInfoModalOpen(false);
       setInputLfeInfoModalOpen(false);

--- a/omniphony-studio/src/listeners/renderer-panel-listeners.js
+++ b/omniphony-studio/src/listeners/renderer-panel-listeners.js
@@ -3,9 +3,7 @@ import { app } from '../state.js';
 import { formatNumber } from '../coordinates.js';
 import {
   renderVbapStatus,
-  updateBarycenterOptions,
   updateEvaluationMode,
-  updateExperimentalDistanceOptions,
   updateRenderBackend,
   updateVbapCartesian,
   updateVbapPolar,
@@ -45,13 +43,6 @@ export function setupRendererPanelListeners() {
   const distanceDiffuseThresholdValEl = document.getElementById('distanceDiffuseThresholdVal');
   const distanceDiffuseCurveSliderEl = document.getElementById('distanceDiffuseCurveSlider');
   const distanceDiffuseCurveValEl = document.getElementById('distanceDiffuseCurveVal');
-  const barycenterLocalizeInputEl = document.getElementById('barycenterLocalizeInput');
-  const experimentalDistanceFloorInputEl = document.getElementById('experimentalDistanceFloorInput');
-  const experimentalDistanceMinActiveInputEl = document.getElementById('experimentalDistanceMinActiveInput');
-  const experimentalDistanceMaxActiveInputEl = document.getElementById('experimentalDistanceMaxActiveInput');
-  const experimentalDistanceErrorFloorInputEl = document.getElementById('experimentalDistanceErrorFloorInput');
-  const experimentalDistanceNearestScaleInputEl = document.getElementById('experimentalDistanceNearestScaleInput');
-  const experimentalDistanceSpanScaleInputEl = document.getElementById('experimentalDistanceSpanScaleInput');
   const hybridExternalBackendSelectEl = document.getElementById('hybridExternalBackendSelect');
   const hybridInternalBackendSelectEl = document.getElementById('hybridInternalBackendSelect');
   const hybridMetricSelectEl = document.getElementById('hybridMetricSelect');
@@ -166,88 +157,6 @@ export function setupRendererPanelListeners() {
       app.vbapRecomputing = true;
       renderVbapStatus();
       invoke('control_distance_diffuse_metric', { value });
-    });
-  }
-
-  if (barycenterLocalizeInputEl) {
-    barycenterLocalizeInputEl.addEventListener('input', () => {
-      const value = Math.max(0, Number(barycenterLocalizeInputEl.value) || 0);
-      app.renderBackendState.barycenter.localize = value;
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateBarycenterOptions();
-      invoke('control_barycenter_localize', { value });
-    });
-  }
-
-  if (experimentalDistanceFloorInputEl) {
-    experimentalDistanceFloorInputEl.addEventListener('change', () => {
-      const value = Math.max(0, Number(experimentalDistanceFloorInputEl.value) || 0);
-      app.renderBackendState.experimentalDistance.distanceFloor = value;
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateExperimentalDistanceOptions();
-      invoke('control_experimental_distance_distance_floor', { value });
-    });
-  }
-
-  if (experimentalDistanceMinActiveInputEl) {
-    experimentalDistanceMinActiveInputEl.addEventListener('change', () => {
-      const value = Math.max(1, Math.round(Number(experimentalDistanceMinActiveInputEl.value) || 1));
-      const currentMax = Number(app.renderBackendState.experimentalDistance.maxActiveSpeakers) || value;
-      app.renderBackendState.experimentalDistance.minActiveSpeakers = value;
-      if (currentMax < value) {
-        app.renderBackendState.experimentalDistance.maxActiveSpeakers = value;
-      }
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateExperimentalDistanceOptions();
-      invoke('control_experimental_distance_min_active_speakers', { value });
-    });
-  }
-
-  if (experimentalDistanceMaxActiveInputEl) {
-    experimentalDistanceMaxActiveInputEl.addEventListener('change', () => {
-      const minValue = Number(app.renderBackendState.experimentalDistance.minActiveSpeakers) || 1;
-      const value = Math.max(minValue, Math.round(Number(experimentalDistanceMaxActiveInputEl.value) || minValue));
-      app.renderBackendState.experimentalDistance.maxActiveSpeakers = value;
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateExperimentalDistanceOptions();
-      invoke('control_experimental_distance_max_active_speakers', { value });
-    });
-  }
-
-  if (experimentalDistanceErrorFloorInputEl) {
-    experimentalDistanceErrorFloorInputEl.addEventListener('change', () => {
-      const value = Math.max(0, Number(experimentalDistanceErrorFloorInputEl.value) || 0);
-      app.renderBackendState.experimentalDistance.positionErrorFloor = value;
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateExperimentalDistanceOptions();
-      invoke('control_experimental_distance_position_error_floor', { value });
-    });
-  }
-
-  if (experimentalDistanceNearestScaleInputEl) {
-    experimentalDistanceNearestScaleInputEl.addEventListener('change', () => {
-      const value = Math.max(0, Number(experimentalDistanceNearestScaleInputEl.value) || 0);
-      app.renderBackendState.experimentalDistance.positionErrorNearestScale = value;
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateExperimentalDistanceOptions();
-      invoke('control_experimental_distance_position_error_nearest_scale', { value });
-    });
-  }
-
-  if (experimentalDistanceSpanScaleInputEl) {
-    experimentalDistanceSpanScaleInputEl.addEventListener('change', () => {
-      const value = Math.max(0, Number(experimentalDistanceSpanScaleInputEl.value) || 0);
-      app.renderBackendState.experimentalDistance.positionErrorSpanScale = value;
-      app.vbapRecomputing = true;
-      renderVbapStatus();
-      updateExperimentalDistanceOptions();
-      invoke('control_experimental_distance_position_error_span_scale', { value });
     });
   }
 

--- a/omniphony-studio/src/modals.js
+++ b/omniphony-studio/src/modals.js
@@ -21,8 +21,6 @@ function getVbapPositionInterpolationInfoModalEl() { return document.getElementB
 function getEvaluationInfoModalEl() { return document.getElementById('evaluationInfoModal'); }
 function getBackendInfoModalEl() { return document.getElementById('backendInfoModal'); }
 function getDistanceModelInfoModalEl() { return document.getElementById('distanceModelInfoModal'); }
-function getBarycenterInfoModalEl() { return document.getElementById('barycenterInfoModal'); }
-function getExperimentalDistanceInfoModalEl() { return document.getElementById('experimentalDistanceInfoModal'); }
 function getInputInfoModalEl() { return document.getElementById('inputInfoModal'); }
 function getInputClockInfoModalEl() { return document.getElementById('inputClockInfoModal'); }
 function getInputLfeInfoModalEl() { return document.getElementById('inputLfeInfoModal'); }
@@ -126,18 +124,6 @@ export function setDistanceModelInfoModalOpen(open) {
   const distanceModelInfoModalEl = getDistanceModelInfoModalEl();
   if (!distanceModelInfoModalEl) return;
   distanceModelInfoModalEl.classList.toggle('open', Boolean(open));
-}
-
-export function setBarycenterInfoModalOpen(open) {
-  const barycenterInfoModalEl = getBarycenterInfoModalEl();
-  if (!barycenterInfoModalEl) return;
-  barycenterInfoModalEl.classList.toggle('open', Boolean(open));
-}
-
-export function setExperimentalDistanceInfoModalOpen(open) {
-  const experimentalDistanceInfoModalEl = getExperimentalDistanceInfoModalEl();
-  if (!experimentalDistanceInfoModalEl) return;
-  experimentalDistanceInfoModalEl.classList.toggle('open', Boolean(open));
 }
 
 export function setInputInfoModalOpen(open) {

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -199,58 +199,6 @@ export function rendererPanelMarkup() {
               </select>
             </div>
           </div>
-          <div class="info-section" id="barycenterSection" style="margin:0;padding:0;border:none;background:none;display:none">
-            <div style="display:flex;align-items:center;justify-content:space-between;gap:0.4rem">
-              <div class="title-with-info" style="margin:0;font-size:12px;font-weight:600;color:#ffffff">
-                <span data-i18n="barycenter.title">Barycenter backend</span>
-                <button id="barycenterInfoBtn" type="button" class="info-icon-btn" data-i18n-title="barycenter.infoButton" title="Barycenter backend info">i</button>
-              </div>
-            </div>
-            <div id="barycenterSectionContent" class="conditional-params open">
-              <div style="margin-top:0.2rem;margin-left:1rem;padding:0.3rem 0.4rem;background:rgba(255,255,255,0.03);border-radius:6px;display:grid;gap:0.15rem">
-                <div class="control-row" style="margin-top:0">
-                  <label style="font-size:12px;white-space:nowrap"><span>Localize</span> <span id="barycenterLocalizeVal">0.00</span></label>
-                  <input id="barycenterLocalizeInput" type="range" min="0" max="4" step="0.05" value="0" class="gain-slider" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="info-section" id="experimentalDistanceSection" style="margin:0;padding:0;border:none;background:none;display:none">
-            <div style="display:flex;align-items:center;justify-content:space-between;gap:0.4rem">
-              <div class="title-with-info" style="margin:0;font-size:12px;font-weight:600;color:#ffffff">
-                <span data-i18n="experimentalDistance.title">Distance backend</span>
-                <button id="experimentalDistanceInfoBtn" type="button" class="info-icon-btn" data-i18n-title="experimentalDistance.infoButton" title="Distance backend info">i</button>
-              </div>
-            </div>
-            <div id="experimentalDistanceSectionContent" class="conditional-params open">
-              <div style="margin-top:0.2rem;margin-left:1rem;padding:0.3rem 0.4rem;background:rgba(255,255,255,0.03);border-radius:6px;display:grid;gap:0.15rem">
-                <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
-                  <label for="experimentalDistanceFloorInput" style="font-size:12px;white-space:nowrap;color:#ffffff">Distance floor</label>
-                  <input id="experimentalDistanceFloorInput" class="delay-input" type="number" min="0" step="0.001" style="min-width:7rem" />
-                </div>
-                <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
-                  <label for="experimentalDistanceMinActiveInput" style="font-size:12px;white-space:nowrap;color:#ffffff">Min active speakers</label>
-                  <input id="experimentalDistanceMinActiveInput" class="delay-input" type="number" min="1" step="1" style="min-width:7rem" />
-                </div>
-                <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
-                  <label for="experimentalDistanceMaxActiveInput" style="font-size:12px;white-space:nowrap;color:#ffffff">Max active speakers</label>
-                  <input id="experimentalDistanceMaxActiveInput" class="delay-input" type="number" min="1" step="1" style="min-width:7rem" />
-                </div>
-                <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
-                  <label for="experimentalDistanceErrorFloorInput" style="font-size:12px;white-space:nowrap;color:#ffffff">Position error floor</label>
-                  <input id="experimentalDistanceErrorFloorInput" class="delay-input" type="number" min="0" step="0.001" style="min-width:7rem" />
-                </div>
-                <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
-                  <label for="experimentalDistanceNearestScaleInput" style="font-size:12px;white-space:nowrap;color:#ffffff">Nearest scale</label>
-                  <input id="experimentalDistanceNearestScaleInput" class="delay-input" type="number" min="0" step="0.01" style="min-width:7rem" />
-                </div>
-                <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
-                  <label for="experimentalDistanceSpanScaleInput" style="font-size:12px;white-space:nowrap;color:#ffffff">Span scale</label>
-                  <input id="experimentalDistanceSpanScaleInput" class="delay-input" type="number" min="0" step="0.01" style="min-width:7rem" />
-                </div>
-              </div>
-            </div>
-          </div>
           <div class="info-section" id="hybridSection" style="margin:0;padding:0;border:none;background:none;display:none;order:-1">
             <div style="display:flex;align-items:center;justify-content:space-between;gap:0.4rem">
               <div class="title-with-info" style="margin:0;font-size:12px;font-weight:600;color:#ffffff">


### PR DESCRIPTION
Retires the hand-written control sections for the built-in **barycenter** and **experimental-distance** backends. Their controls are now generated from the published param schema — exactly like a contributor backend — removing the last per-backend special-casing in the renderer panel.

Builds on #39 (per-backend param values + explicit-target `control_backend_param`) and #40 (per-param help tooltips).

## Frontend
- `renderGenericBackendParams(targetBackend)` drives every non-bespoke backend (barycenter, distance, contributor backends), both **standalone** and as the **active hybrid inner-backend tab**. Values are read per backend id (`backendParamValuesById`) and edits are addressed to that backend, so an inner hybrid backend is tuned independently of the active selection. The generated container lives in `backendSpecificParamsSection`, below the hybrid tab bar.
- `BESPOKE_BACKENDS` shrinks to `['vbap', 'hybrid']`.
- Deletes the bespoke render/update functions, element getters, input listeners, the two HTML sections, and the two info modals (the per-param help tooltips from #40 replace them).

## Tauri
- Removes the seven now-dead dedicated commands (`control_barycenter_localize`, `control_experimental_distance_*`); the generic `control_backend_param` with an explicit backend id covers them.

## Notes / tradeoffs
- The experimental "min ≤ max active speakers" live cross-clamp in the UI is gone; the backend still clamps `max ≥ min` server-side.
- The `/control/barycenter/*` and `/control/experimental_distance/*` OSC aliases and the bespoke snapshot fields are left in place (now unused by Studio) and can be removed in a follow-up.

## Validation
Net **−361 lines**. Frontend bundles cleanly (`vite build`), Tauri app builds, `cargo fmt --check` clean. **Visual verification pending** (renderer-panel UI is not covered by CI): backend dropdown → barycenter/distance show generated sliders + "i" tooltips; hybrid tabs show each inner backend's params and tune them independently; no layout break of the 3D view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)