### PR TITLE
cleanup(studio): remove dead bespoke barycenter/distance state plumbing

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc/recompute.rs
+++ b/omniphony-renderer/orender_engine/src/osc/recompute.rs
@@ -100,7 +100,6 @@ pub(crate) fn trigger_layout_recompute(
                             &topology,
                             scale_m,
                             control_clone.available_backends(),
-                            control_clone.backend_params_for(live.backend_id()),
                             control_clone.all_backend_params(),
                         )
                     };

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -1046,48 +1046,6 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    // Backend-specific param addresses are thin aliases over the generic param
-    // bag, keyed by the backend id. (The min/max active-speaker ordering is
-    // re-asserted at build time, so no read-modify-write is needed here.)
-    if let Some(rest) = addr.strip_prefix("/omniphony/control/experimental_distance/") {
-        let value = match rest {
-            "min_active_speakers" | "max_active_speakers" => {
-                parse_positive_u32_arg(msg.args.first())
-                    .map(|v| renderer::backend_params::ParamValue::Int(v as i64))
-            }
-            "distance_floor"
-            | "position_error_floor"
-            | "position_error_nearest_scale"
-            | "position_error_span_scale" => parse_f32_arg(msg.args.first())
-                .map(|v| renderer::backend_params::ParamValue::Float(v.max(0.0))),
-            _ => None,
-        };
-        if let Some(value) = value {
-            ctx.renderer
-                .set_backend_param("experimental_distance", rest, value);
-            effects.mark_dirty = true;
-            effects.trigger_layout_recompute = true;
-            effects.log_message = Some(format!("OSC: experimental_distance/{rest} updated"));
-        }
-        return Some(effects);
-    }
-
-    if let Some(rest) = addr.strip_prefix("/omniphony/control/barycenter/") {
-        if rest == "localize" {
-            if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.0)) {
-                ctx.renderer.set_backend_param(
-                    "barycenter",
-                    "localize",
-                    renderer::backend_params::ParamValue::Float(v),
-                );
-                effects.mark_dirty = true;
-                effects.trigger_layout_recompute = true;
-                effects.log_message = Some(format!("OSC: barycenter/localize -> {v}"));
-            }
-        }
-        return Some(effects);
-    }
-
     if let Some(rest) = addr.strip_prefix("/omniphony/control/hybrid/") {
         let mut live = ctx.renderer.live.write();
         let mut changed = false;

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -10,21 +10,6 @@ use serde_json::json;
 // without cpal/pipewire/asio.
 
 #[derive(Debug, Clone, Serialize)]
-pub struct ExperimentalDistanceOptionsSnapshot {
-    pub distance_floor: f32,
-    pub min_active_speakers: usize,
-    pub max_active_speakers: usize,
-    pub position_error_floor: f32,
-    pub position_error_nearest_scale: f32,
-    pub position_error_span_scale: f32,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct BarycenterOptionsSnapshot {
-    pub localize: f32,
-}
-
-#[derive(Debug, Clone, Serialize)]
 pub struct HybridOptionsSnapshot {
     pub external_backend: String,
     pub internal_backend: String,
@@ -41,13 +26,9 @@ pub struct RenderBackendStateSnapshot {
     /// Every selectable backend (built-in + host-registered) with its param
     /// schema, for the UI list and control generation.
     pub available_backends: Vec<renderer::backend_registry::BackendListing>,
-    /// Host-set param values for the *active* backend, keyed by param key. The
-    /// UI seeds its controls from these (falling back to the schema defaults).
-    pub backend_param_values:
-        std::collections::HashMap<String, renderer::backend_params::ParamValue>,
     /// Host-set param values for *every* backend, keyed by backend id then param
-    /// key. The UI reads an inner backend's values from here (e.g. the hybrid
-    /// barycenter tab), independent of the active selection.
+    /// key. The UI reads each backend's values from here, including an inner
+    /// backend (e.g. the hybrid barycenter tab) that is not the active selection.
     pub backend_param_values_by_id: std::collections::HashMap<
         String,
         std::collections::HashMap<String, renderer::backend_params::ParamValue>,
@@ -57,8 +38,6 @@ pub struct RenderBackendStateSnapshot {
     pub frozen_room_ratio: bool,
     pub frozen_speakers: bool,
     pub restore_backend_available: bool,
-    pub barycenter: BarycenterOptionsSnapshot,
-    pub experimental_distance: ExperimentalDistanceOptionsSnapshot,
     pub hybrid: HybridOptionsSnapshot,
 }
 
@@ -84,7 +63,6 @@ pub fn build_render_backend_state_snapshot(
     live: &LiveParams,
     active_topology: &RenderTopology,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
-    backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
     backend_param_values_by_id: std::collections::HashMap<
         String,
         std::collections::HashMap<String, renderer::backend_params::ParamValue>,
@@ -93,57 +71,17 @@ pub fn build_render_backend_state_snapshot(
     let backend = &active_topology.backend;
     let capabilities = backend.capabilities();
 
-    // The bespoke barycenter/experimental option blocks are sourced from the
-    // active backend's param bag (resolved against the model defaults). They are
-    // kept only for the current Studio UI; once Studio renders controls from the
-    // generic `available_backends` schema they can be dropped.
-    use renderer::backend_params::ParamValue;
-    let param_f32 = |key: &str, default: f32| {
-        backend_param_values
-            .get(key)
-            .and_then(ParamValue::as_f32)
-            .unwrap_or(default)
-    };
-    let param_count = |key: &str, default: usize| {
-        backend_param_values
-            .get(key)
-            .and_then(ParamValue::as_i64)
-            .map(|v| v.max(1) as usize)
-            .unwrap_or(default)
-    };
-    let exp_defaults = renderer::live_params::ExperimentalDistanceLiveParams::default();
-    let barycenter = BarycenterOptionsSnapshot {
-        localize: param_f32("localize", 0.0),
-    };
-    let experimental_distance = ExperimentalDistanceOptionsSnapshot {
-        distance_floor: param_f32("distance_floor", exp_defaults.distance_floor),
-        min_active_speakers: param_count("min_active_speakers", exp_defaults.min_active_speakers),
-        max_active_speakers: param_count("max_active_speakers", exp_defaults.max_active_speakers),
-        position_error_floor: param_f32("position_error_floor", exp_defaults.position_error_floor),
-        position_error_nearest_scale: param_f32(
-            "position_error_nearest_scale",
-            exp_defaults.position_error_nearest_scale,
-        ),
-        position_error_span_scale: param_f32(
-            "position_error_span_scale",
-            exp_defaults.position_error_span_scale,
-        ),
-    };
-
     RenderBackendStateSnapshot {
         selection: live.backend_id().to_string(),
         effective: backend.backend_id().to_string(),
         effective_label: backend.backend_label().to_string(),
         available_backends,
-        backend_param_values,
         backend_param_values_by_id,
         capabilities,
         allowed_evaluation_modes: allowed_evaluation_modes(backend, capabilities),
         frozen_room_ratio: false,
         frozen_speakers: false,
         restore_backend_available: false,
-        barycenter,
-        experimental_distance,
         hybrid: HybridOptionsSnapshot {
             external_backend: live.hybrid.external_backend_id.clone(),
             internal_backend: live.hybrid.internal_backend_id.clone(),
@@ -158,7 +96,6 @@ pub fn build_render_backend_state_json(
     live: &LiveParams,
     active_topology: &RenderTopology,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
-    backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
     backend_param_values_by_id: std::collections::HashMap<
         String,
         std::collections::HashMap<String, renderer::backend_params::ParamValue>,
@@ -168,7 +105,6 @@ pub fn build_render_backend_state_json(
         live,
         active_topology,
         available_backends,
-        backend_param_values,
         backend_param_values_by_id,
     ))
     .unwrap_or_else(|_| "{}".to_string())
@@ -179,7 +115,6 @@ pub fn build_renderer_state_json(
     active_topology: &RenderTopology,
     room_scale_m: f32,
     available_backends: Vec<renderer::backend_registry::BackendListing>,
-    backend_param_values: std::collections::HashMap<String, renderer::backend_params::ParamValue>,
     backend_param_values_by_id: std::collections::HashMap<
         String,
         std::collections::HashMap<String, renderer::backend_params::ParamValue>,
@@ -191,7 +126,6 @@ pub fn build_renderer_state_json(
         live,
         active_topology,
         available_backends,
-        backend_param_values,
         backend_param_values_by_id,
     );
     json!({
@@ -381,7 +315,6 @@ pub fn build_live_state_bundle(
         &active_topology,
         editable_layout.radius_m,
         control.available_backends(),
-        control.backend_params_for(live.backend_id()),
         control.all_backend_params(),
     );
 

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -159,30 +159,6 @@ pub struct BackendCapabilitiesState {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct ExperimentalDistanceState {
-    #[serde(rename = "distanceFloor", alias = "distance_floor")]
-    pub distance_floor: Option<f64>,
-    #[serde(rename = "minActiveSpeakers", alias = "min_active_speakers")]
-    pub min_active_speakers: Option<u32>,
-    #[serde(rename = "maxActiveSpeakers", alias = "max_active_speakers")]
-    pub max_active_speakers: Option<u32>,
-    #[serde(rename = "positionErrorFloor", alias = "position_error_floor")]
-    pub position_error_floor: Option<f64>,
-    #[serde(
-        rename = "positionErrorNearestScale",
-        alias = "position_error_nearest_scale"
-    )]
-    pub position_error_nearest_scale: Option<f64>,
-    #[serde(rename = "positionErrorSpanScale", alias = "position_error_span_scale")]
-    pub position_error_span_scale: Option<f64>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct BarycenterState {
-    pub localize: Option<f64>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct HybridState {
     #[serde(rename = "externalBackend", alias = "external_backend")]
     pub external_backend: Option<String>,
@@ -212,9 +188,6 @@ pub struct RenderBackendState {
         alias = "restore_backend_available"
     )]
     pub restore_backend_available: bool,
-    pub barycenter: BarycenterState,
-    #[serde(rename = "experimentalDistance", alias = "experimental_distance")]
-    pub experimental_distance: ExperimentalDistanceState,
     pub hybrid: HybridState,
     /// Selectable backends with their declared param schema: `[{ id, label,
     /// params: [...] }]`. Passed through verbatim so the UI can populate the
@@ -226,15 +199,6 @@ pub struct RenderBackendState {
         skip_serializing_if = "serde_json::Value::is_null"
     )]
     pub available_backends: serde_json::Value,
-    /// Host-set param values for the active backend (`{ key: value }`), used to
-    /// seed the generated controls.
-    #[serde(
-        rename = "backendParamValues",
-        alias = "backend_param_values",
-        default,
-        skip_serializing_if = "serde_json::Value::is_null"
-    )]
-    pub backend_param_values: serde_json::Value,
     /// Host-set param values for every backend (`{ backendId: { key: value } }`),
     /// used to seed generated controls for a backend that is not the active
     /// selection (e.g. a hybrid inner-backend tab).

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -213,35 +213,15 @@ export function applyInitState(payload) {
     app.renderBackendState.frozenSpeakers = payload.renderBackendState.frozenSpeakers === true;
     app.renderBackendState.restoreBackendAvailable = payload.renderBackendState.restoreBackendAvailable === true;
     // Engine-published list of selectable backends (id + label + param schema)
-    // and the active backend's current param values — drive the dynamic dropdown
-    // and the generated per-backend controls.
+    // and every backend's current param values — drive the dynamic dropdown and
+    // the generated per-backend controls (including hybrid inner-backend tabs).
     app.renderBackendState.availableBackends = Array.isArray(payload.renderBackendState.availableBackends)
       ? payload.renderBackendState.availableBackends
       : [];
-    app.renderBackendState.backendParamValues = payload.renderBackendState.backendParamValues
-      && typeof payload.renderBackendState.backendParamValues === 'object'
-      ? payload.renderBackendState.backendParamValues
+    app.renderBackendState.backendParamValuesById = payload.renderBackendState.backendParamValuesById
+      && typeof payload.renderBackendState.backendParamValuesById === 'object'
+      ? payload.renderBackendState.backendParamValuesById
       : {};
-    const barycenter = payload.renderBackendState.barycenter;
-    if (barycenter && typeof barycenter === 'object') {
-      app.renderBackendState.barycenter.localize =
-        typeof barycenter.localize === 'number' ? barycenter.localize : null;
-    }
-    const experimentalDistance = payload.renderBackendState.experimentalDistance;
-    if (experimentalDistance && typeof experimentalDistance === 'object') {
-      app.renderBackendState.experimentalDistance.distanceFloor =
-        typeof experimentalDistance.distanceFloor === 'number' ? experimentalDistance.distanceFloor : null;
-      app.renderBackendState.experimentalDistance.minActiveSpeakers =
-        typeof experimentalDistance.minActiveSpeakers === 'number' ? experimentalDistance.minActiveSpeakers : null;
-      app.renderBackendState.experimentalDistance.maxActiveSpeakers =
-        typeof experimentalDistance.maxActiveSpeakers === 'number' ? experimentalDistance.maxActiveSpeakers : null;
-      app.renderBackendState.experimentalDistance.positionErrorFloor =
-        typeof experimentalDistance.positionErrorFloor === 'number' ? experimentalDistance.positionErrorFloor : null;
-      app.renderBackendState.experimentalDistance.positionErrorNearestScale =
-        typeof experimentalDistance.positionErrorNearestScale === 'number' ? experimentalDistance.positionErrorNearestScale : null;
-      app.renderBackendState.experimentalDistance.positionErrorSpanScale =
-        typeof experimentalDistance.positionErrorSpanScale === 'number' ? experimentalDistance.positionErrorSpanScale : null;
-    }
     const hybrid = payload.renderBackendState.hybrid;
     if (hybrid && typeof hybrid === 'object') {
       const validInner = (id) =>

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -75,8 +75,6 @@ export const dirty = {
   masterMeter: false,
   roomRatio: false,
   spread: false,
-  barycenter: false,
-  experimentalDistance: false,
   hybrid: false,
   vbapMode: false,
   renderBackend: false,
@@ -130,18 +128,7 @@ export const app = {
     frozenSpeakers: false,
     restoreBackendAvailable: false,
     availableBackends: [],
-    backendParamValues: {},
-    barycenter: {
-      localize: null
-    },
-    experimentalDistance: {
-      distanceFloor: null,
-      minActiveSpeakers: null,
-      maxActiveSpeakers: null,
-      positionErrorFloor: null,
-      positionErrorNearestScale: null,
-      positionErrorSpanScale: null
-    },
+    backendParamValuesById: {},
     hybrid: {
       externalBackend: null,
       internalBackend: null,


### PR DESCRIPTION
After #41 switched the built-in barycenter and distance backends to the generic schema-driven controls, the dedicated state plumbing for them became dead. This removes it — and fixes a value-seeding gap the migration exposed.

## Renderer / runtime_control
- Drop the `/control/barycenter/*` and `/control/experimental_distance/*` OSC alias handlers (no sender remained after the dedicated Tauri commands were removed in #41).
- Drop the bespoke `BarycenterOptionsSnapshot` / `ExperimentalDistanceOptionsSnapshot` structs and the snapshot fields/construction feeding them.
- Drop the flat `backend_param_values` (active-backend) snapshot field and its threading: the generic controls read `backend_param_values_by_id`, which already covers the active backend, so the flat copy was redundant.

## Studio (Tauri)
- Remove `BarycenterState` / `ExperimentalDistanceState` and the `barycenter`, `experimental_distance`, `backend_param_values` passthrough fields.

## Studio (frontend)
- **Fix**: `init.js` now ingests `backendParamValuesById`. It previously copied only the now-unread flat `backendParamValues`, so the generated controls never reflected the engine's actual per-backend values and always fell back to schema defaults (masked in a fresh setup, where defaults *are* the current values). Same applier gotcha as before — a new state field must be wired into `init.js`.
- Drop the dead barycenter/experimentalDistance ingest and state init.

## Notes
- Unused i18n keys for the removed sections/modals are left in the 8 locale files (inert strings; not worth the cross-file churn / JSON-break risk here).

## Validation
Net **−179 lines**. Renderer workspace + Studio Tauri build, `cargo fmt --check` clean on both, renderer tests pass, frontend bundles (`vite build`). The init.js change is a strict correctness improvement (controls now reflect real values instead of defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)