### PR TITLE
feat: user-scriptable Lua render backend (registry-based)

### DIFF
--- a/omniphony-renderer/Cargo.toml
+++ b/omniphony-renderer/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["renderer", "audio_input", "audio_output", "sys", "bridge_api", "spdif", "runtime_control", "orender_engine", "orender_ffi", "host_audio", "example_backend"]
+members = ["renderer", "audio_input", "audio_output", "sys", "bridge_api", "spdif", "runtime_control", "orender_engine", "orender_ffi", "host_audio", "example_backend", "script_backend"]
 resolver = "2"
 
 [package]

--- a/omniphony-renderer/orender_engine/Cargo.toml
+++ b/omniphony-renderer/orender_engine/Cargo.toml
@@ -11,6 +11,8 @@ renderer = { version = "0.2.4", path = "../renderer" }
 # Demonstration render backend, registered at startup to prove the open backend
 # frontier end-to-end. A real deployment would register/discover backends here.
 example_backend = { path = "../example_backend" }
+# User-scriptable (Lua) render backend, registered at startup.
+script_backend = { path = "../script_backend" }
 bridge_api = { version = "0.2.0", path = "../bridge_api" }
 runtime_control = { version = "0.2.4", path = "../runtime_control" }
 sys = { version = "0.1.0", path = "../sys" }

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -408,6 +408,9 @@ pub fn build_spatial_renderer(
         let control = renderer.renderer_control();
         // Register the demonstration backend so `backend_id = "example"` resolves.
         control.register_backend(Box::new(example_backend::ExampleFactory));
+        // User-scriptable (Lua) backend; selecting `backend_id = "script"` routes
+        // a rebuild through it, reading its `.lua` path from the param store.
+        control.register_backend(Box::new(script_backend::ScriptFactory));
         // Resolve the configured backend id: built-in ids/aliases first (e.g.
         // "distance" -> experimental_distance), then any registered backend id.
         let configured_backend = configured_backend_cfg.and_then(|raw| {

--- a/omniphony-renderer/renderer/src/backend_params.rs
+++ b/omniphony-renderer/renderer/src/backend_params.rs
@@ -75,6 +75,20 @@ impl ParamSpec {
         }
     }
 
+    /// Filesystem-path control: a text field plus a file picker in the UI. The
+    /// value is carried as [`ParamValue::Text`]. Used by backends that load an
+    /// external asset (e.g. the scriptable backend's `.lua` file).
+    pub fn path(key: &'static str, label: &'static str, default: &str) -> Self {
+        Self {
+            key,
+            label,
+            kind: ParamKind::Path,
+            default: ParamValue::Text(default.to_string()),
+            requires: None,
+            help: None,
+        }
+    }
+
     /// Gate this control behind a backend capability flag.
     pub fn requires(mut self, capability: &'static str) -> Self {
         self.requires = Some(capability);
@@ -92,10 +106,22 @@ impl ParamSpec {
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ParamKind {
-    Float { min: f32, max: f32, step: f32 },
-    Int { min: i64, max: i64 },
+    Float {
+        min: f32,
+        max: f32,
+        step: f32,
+    },
+    Int {
+        min: i64,
+        max: i64,
+    },
     Bool,
-    Enum { options: Vec<ParamOption> },
+    Enum {
+        options: Vec<ParamOption>,
+    },
+    /// A filesystem path: rendered as a text field with a file picker. Value is
+    /// a [`ParamValue::Text`].
+    Path,
 }
 
 /// One choice of an [`ParamKind::Enum`] control.

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -636,6 +636,26 @@ pub trait BackendFactory: Send + Sync {
     fn param_schema(&self) -> Vec<crate::backend_params::ParamSpec> {
         Vec::new()
     }
+    /// Like [`param_schema`](BackendFactory::param_schema), but with access to the
+    /// backend's currently stored param values, so a backend whose schema depends
+    /// on its own state can report a *dynamic* schema. The scriptable backend
+    /// uses this to expose the params its currently-selected `.lua` declares.
+    /// Defaults to the static schema. Called by the host whenever it publishes
+    /// the backend list (i.e. after every param change).
+    fn param_schema_for(
+        &self,
+        params: &std::collections::HashMap<String, crate::backend_params::ParamValue>,
+    ) -> Vec<crate::backend_params::ParamSpec> {
+        let _ = params;
+        self.param_schema()
+    }
+    /// Whether this backend can run in the realtime (per-sample) evaluation mode.
+    /// A backend whose `compute_gains` is not hot-path-safe (allocates, locks,
+    /// crosses into an interpreter — e.g. the scriptable backend) returns `false`
+    /// so the host forces a precomputed mode and never calls it per sample.
+    fn realtime_capable(&self) -> bool {
+        true
+    }
     /// Build this backend's plan, or `None` if it cannot be prepared for the
     /// given context (e.g. VBAP without geometry rebuild params).
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan>;
@@ -708,6 +728,28 @@ impl BackendRegistry {
                 id: f.id(),
                 label: f.label(),
                 params: f.param_schema(),
+            })
+            .collect()
+    }
+
+    /// Like [`available`](BackendRegistry::available) but resolving each
+    /// backend's *dynamic* schema against the current param store, so a backend
+    /// whose controls depend on its own state (the scriptable backend) reports
+    /// the right schema. `params_by_backend` is keyed by backend id.
+    pub fn available_with(
+        &self,
+        params_by_backend: &std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, crate::backend_params::ParamValue>,
+        >,
+    ) -> Vec<BackendListing> {
+        let empty = std::collections::HashMap::new();
+        self.factories
+            .iter()
+            .map(|f| BackendListing {
+                id: f.id(),
+                label: f.label(),
+                params: f.param_schema_for(params_by_backend.get(f.id()).unwrap_or(&empty)),
             })
             .collect()
     }
@@ -875,7 +917,17 @@ pub fn prepare_topology_build_plan(
     };
     let backend_build = factory.build_plan(&ctx)?;
     let preferred = preferred_evaluation_mode(backend_rebuild_params);
-    let evaluation_mode = effective_live_evaluation_mode(live.evaluation.mode, preferred);
+    let mut evaluation_mode = effective_live_evaluation_mode(live.evaluation.mode, preferred);
+    // A backend that is not hot-path-safe (e.g. the scriptable backend) must
+    // never run per sample: force a precomputed mode if realtime was requested.
+    if evaluation_mode == LiveEvaluationMode::Realtime && !factory.realtime_capable() {
+        evaluation_mode = match preferred {
+            PreferredEvaluationMode::PrecomputedCartesian => {
+                LiveEvaluationMode::PrecomputedCartesian
+            }
+            PreferredEvaluationMode::PrecomputedPolar => LiveEvaluationMode::PrecomputedPolar,
+        };
+    }
     Some(TopologyBuildPlan {
         layout,
         backend_id: live.backend_id().to_string(),

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -682,7 +682,11 @@ impl RendererControl {
     /// Id + label of every registered backend, for the host to publish so the UI
     /// can list the selectable backends (built-in and contributor-registered).
     pub fn available_backends(&self) -> Vec<crate::backend_registry::BackendListing> {
-        self.backend_registry.read().available()
+        // Resolve dynamic schemas (e.g. the scriptable backend's, which depends
+        // on its selected file) against the current param store.
+        self.backend_registry
+            .read()
+            .available_with(&self.backend_params.read())
     }
 
     /// Set one backend parameter value (host/OSC). Stored generically and applied

--- a/omniphony-renderer/script_backend/Cargo.toml
+++ b/omniphony-renderer/script_backend/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "script_backend"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-only"
+description = "User-scriptable render backend (GainModel): a per-position gain function written in Lua, sampled at table-build time"
+
+[lib]
+name = "script_backend"
+
+[dependencies]
+renderer = { path = "../renderer" }
+anyhow = "1"
+parking_lot = "0.12"
+mlua = { version = "0.10", features = ["lua54", "vendored"] }

--- a/omniphony-renderer/script_backend/src/lib.rs
+++ b/omniphony-renderer/script_backend/src/lib.rs
@@ -1,0 +1,683 @@
+//! # Scriptable render backend (Lua)
+//!
+//! A [`GainModel`] whose per-position gain function is written in **Lua** and
+//! editable by the user. It depends on `renderer` through its **public API
+//! only** (like `example_backend`), so it doubles as proof that a non-trivial
+//! backend can live out-of-tree.
+//!
+//! ## Why a scripting language is viable here
+//!
+//! A backend is geometry-only and its `compute_gains` is invoked *only while the
+//! precomputed gain table is sampled* (the host runs it once per grid point on a
+//! build thread), never per audio sample. So the cost of crossing into an
+//! embedded interpreter is paid once, at table-build time. Accordingly the
+//! backend is **not** hot-path safe: [`ScriptFactory::realtime_capable`] returns
+//! `false` and [`ScriptBackend::capabilities`] sets `supports_realtime = false`,
+//! so the host forces a precomputed evaluation mode.
+//!
+//! ## The Lua contract
+//!
+//! ```lua
+//! -- REQUIRED: one gain per speaker for a position.
+//! function gains(pos, speakers, state, params)
+//!   -- pos      = { x=, y=, z= }            (raw ADM position)
+//!   -- speakers = { {x=,y=,z=}, ... }       (unit speaker directions)
+//!   -- state    = value returned by setup(), or nil
+//!   -- params   = { key = number, ... }     (resolved from the schema below)
+//!   -- return an array of #speakers finite numbers, in speaker order.
+//! end
+//!
+//! -- OPTIONAL: one-time per-VM setup; its return value is passed as `state`.
+//! function setup(speakers, params) return {} end
+//!
+//! -- OPTIONAL: declare tunable params so Studio renders controls for them.
+//! function params()
+//!   return {
+//!     { key = "falloff", label = "Falloff", min = 0.0, max = 1.0,
+//!       step = 0.01, default = 0.1, help = "Softening near a speaker" },
+//!   }
+//! end
+//! ```
+//!
+//! Distance attenuation and distance-diffuse are applied by the host *around*
+//! this model, so the script only writes the directional panning law.
+//!
+//! ## Sandbox
+//!
+//! Each VM exposes only `math`/`table`/`string` (no `io`/`os`/`require`/
+//! `debug`), is memory-capped, and each call is bounded by an instruction
+//! budget so a runaway script fails the build instead of hanging it.
+
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Result, anyhow, bail};
+use mlua::{Function, HookTriggers, Lua, LuaOptions, StdLib, Table, Value, VmState};
+
+use renderer::backend_params::{ParamSpec, ParamValue};
+use renderer::backend_registry::{
+    BackendBuildCtx, BackendBuildPlan, BackendFactory, DynamicBackendPlan,
+};
+use renderer::render_backend::{BackendCapabilities, GainModel, RenderRequest, RenderResponse};
+use renderer::spatial_vbap::{Gains, spherical_to_adm};
+use renderer::speaker_layout::SpeakerLayout;
+
+/// Per-VM heap cap: generous for honest scripts, low enough that a runaway
+/// allocation aborts the build instead of exhausting the machine.
+const MEMORY_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+/// Instruction budget per `gains` call. A normal call is a few thousand
+/// instructions; this only trips on an infinite loop.
+const INSTRUCTION_BUDGET: u64 = 5_000_000;
+/// How often the debug hook fires (VM instructions).
+const HOOK_INTERVAL: u32 = 4096;
+/// Param key holding the path to the `.lua` file.
+const PATH_KEY: &str = "path";
+
+static SCRIPT_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+fn next_generation() -> u64 {
+    SCRIPT_GENERATION.fetch_add(1, Ordering::Relaxed)
+}
+
+/// `mlua::Error` is not `Sync` without the `send` feature (the VM is kept
+/// thread-local on purpose), so it can't flow through `?` into `anyhow`.
+fn lua_err(e: mlua::Error) -> anyhow::Error {
+    anyhow!("{e}")
+}
+
+// ===========================================================================
+// The gain model
+// ===========================================================================
+
+/// A Lua-scripted gain model. `Send + Sync`: it holds only plain data; the
+/// non-`Send` [`Lua`] VM lives in a `thread_local` cache keyed by `generation`,
+/// so the host's parallel sampling gets one VM per worker with no locking.
+pub struct ScriptBackend {
+    source: Arc<str>,
+    /// Unit speaker direction vectors, one per spatializable speaker.
+    speakers: Vec<[f32; 3]>,
+    /// Resolved numeric params handed to the script as a Lua table.
+    params: Vec<(String, f64)>,
+    generation: u64,
+}
+
+impl ScriptBackend {
+    /// Build and **eagerly validate** the backend: compile the source, run
+    /// `setup`, and probe `gains` once so a broken script fails the build with a
+    /// precise message instead of mid-sampling.
+    pub fn new(
+        source: impl Into<Arc<str>>,
+        speakers: Vec<[f32; 3]>,
+        params: Vec<(String, f64)>,
+    ) -> Result<Self> {
+        let backend = Self {
+            source: source.into(),
+            speakers,
+            params,
+            generation: next_generation(),
+        };
+        // Eager smoke: compile + setup + one probe call.
+        let vm = backend.build_vm()?;
+        vm.eval_gains([0.0, 0.0, 0.0])
+            .map_err(|e| anyhow!("script `gains` failed on probe: {e}"))?;
+        Ok(backend)
+    }
+
+    fn build_vm(&self) -> Result<ScriptVm> {
+        ScriptVm::new(&self.source, &self.speakers, &self.params)
+    }
+}
+
+thread_local! {
+    static VM_CACHE: RefCell<Option<CachedVm>> = const { RefCell::new(None) };
+    static INSTRUCTIONS: Cell<u64> = const { Cell::new(0) };
+}
+
+struct CachedVm {
+    generation: u64,
+    vm: ScriptVm,
+}
+
+impl GainModel for ScriptBackend {
+    fn backend_id(&self) -> &'static str {
+        "script"
+    }
+
+    fn backend_label(&self) -> &'static str {
+        "Script"
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            // Realtime would call Lua per audio sample — forbidden.
+            supports_realtime: false,
+            supports_precomputed_polar: true,
+            supports_precomputed_cartesian: true,
+            supports_position_interpolation: true,
+            // Distance attenuation / diffuse are applied by the host decorators.
+            supports_distance_model: true,
+            supports_spread: false,
+            supports_spread_from_distance: false,
+            supports_event_size: false,
+            supports_distance_diffuse: true,
+            supports_table_export: true,
+        }
+    }
+
+    fn speaker_count(&self) -> usize {
+        self.speakers.len()
+    }
+
+    fn compute_gains(&self, req: &RenderRequest) -> RenderResponse {
+        let pos = [
+            req.adm_position[0] as f32,
+            req.adm_position[1] as f32,
+            req.adm_position[2] as f32,
+        ];
+        let result = VM_CACHE.with(|cell| -> Result<Gains> {
+            let mut slot = cell.borrow_mut();
+            if slot.as_ref().map(|c| c.generation) != Some(self.generation) {
+                *slot = Some(CachedVm {
+                    generation: self.generation,
+                    vm: self.build_vm()?,
+                });
+            }
+            let vm = &slot.as_ref().expect("vm just inserted").vm;
+            let values = vm.eval_gains(pos)?;
+            let mut gains = Gains::zeroed(self.speakers.len());
+            for (i, g) in values.into_iter().enumerate() {
+                gains.set(i, g);
+            }
+            Ok(gains)
+        });
+
+        match result {
+            Ok(gains) => RenderResponse { gains },
+            Err(_) => {
+                // A sampling-time error: emit non-finite gains so the host's
+                // build-time smoke test rejects this backend (the eager probe in
+                // `new` already caught the common cases with a precise message).
+                let mut gains = Gains::zeroed(self.speakers.len());
+                for i in 0..self.speakers.len() {
+                    gains.set(i, f32::NAN);
+                }
+                RenderResponse { gains }
+            }
+        }
+    }
+
+    fn save_to_file(&self, _path: &std::path::Path, _layout: &SpeakerLayout) -> Result<()> {
+        bail!("the scriptable backend does not support table export")
+    }
+}
+
+// ===========================================================================
+// The VM
+// ===========================================================================
+
+struct ScriptVm {
+    _lua: Lua,
+    gains_fn: Function,
+    speaker_count: usize,
+    speakers_tbl: Table,
+    state: Value,
+    params_tbl: Table,
+    pos_tbl: Table,
+}
+
+impl ScriptVm {
+    fn new(source: &str, speakers: &[[f32; 3]], params: &[(String, f64)]) -> Result<Self> {
+        let lua = sandboxed_lua()?;
+        lua.load(source)
+            .exec()
+            .map_err(|e| anyhow!("failed to load script: {e}"))?;
+        let globals = lua.globals();
+
+        let speakers_tbl = speakers_table(&lua, speakers).map_err(lua_err)?;
+        let params_tbl = params_table(&lua, params).map_err(lua_err)?;
+
+        let state = match globals.get::<Value>("setup").map_err(lua_err)? {
+            Value::Function(setup) => {
+                reset_instructions();
+                setup
+                    .call((speakers_tbl.clone(), params_tbl.clone()))
+                    .map_err(|e| anyhow!("script `setup` failed: {e}"))?
+            }
+            Value::Nil => Value::Nil,
+            other => bail!("`setup` must be a function, got {}", other.type_name()),
+        };
+
+        let gains_fn = match globals.get::<Value>("gains").map_err(lua_err)? {
+            Value::Function(f) => f,
+            Value::Nil => {
+                bail!("script must define a `gains(pos, speakers, state, params)` function")
+            }
+            other => bail!("`gains` must be a function, got {}", other.type_name()),
+        };
+
+        let pos_tbl = lua.create_table().map_err(lua_err)?;
+
+        Ok(Self {
+            _lua: lua,
+            gains_fn,
+            speaker_count: speakers.len(),
+            speakers_tbl,
+            state,
+            params_tbl,
+            pos_tbl,
+        })
+    }
+
+    fn eval_gains(&self, pos: [f32; 3]) -> Result<Vec<f32>> {
+        self.pos_tbl.set("x", pos[0]).map_err(lua_err)?;
+        self.pos_tbl.set("y", pos[1]).map_err(lua_err)?;
+        self.pos_tbl.set("z", pos[2]).map_err(lua_err)?;
+
+        reset_instructions();
+        let result: Table = self
+            .gains_fn
+            .call((
+                self.pos_tbl.clone(),
+                self.speakers_tbl.clone(),
+                self.state.clone(),
+                self.params_tbl.clone(),
+            ))
+            .map_err(lua_err)?;
+
+        let len = result.raw_len();
+        if len != self.speaker_count {
+            bail!(
+                "`gains` returned {len} values but the layout has {} speakers",
+                self.speaker_count
+            );
+        }
+        let mut out = Vec::with_capacity(self.speaker_count);
+        for i in 1..=self.speaker_count {
+            let g: f32 = result.get(i).map_err(lua_err)?;
+            if !g.is_finite() {
+                bail!("`gains[{i}]` is not finite ({g})");
+            }
+            out.push(g);
+        }
+        Ok(out)
+    }
+}
+
+fn sandboxed_lua() -> Result<Lua> {
+    let lua = Lua::new_with(
+        StdLib::MATH | StdLib::TABLE | StdLib::STRING,
+        LuaOptions::default(),
+    )
+    .map_err(|e| anyhow!("failed to create Lua VM: {e}"))?;
+    let _ = lua.set_memory_limit(MEMORY_LIMIT_BYTES);
+    lua.set_hook(
+        HookTriggers::new().every_nth_instruction(HOOK_INTERVAL),
+        |_lua, _debug| {
+            let used = INSTRUCTIONS.with(|c| {
+                let v = c.get() + HOOK_INTERVAL as u64;
+                c.set(v);
+                v
+            });
+            if used > INSTRUCTION_BUDGET {
+                Err(mlua::Error::RuntimeError(
+                    "script exceeded its instruction budget (possible infinite loop)".into(),
+                ))
+            } else {
+                Ok(VmState::Continue)
+            }
+        },
+    );
+    Ok(lua)
+}
+
+fn reset_instructions() {
+    INSTRUCTIONS.with(|c| c.set(0));
+}
+
+fn speakers_table(lua: &Lua, speakers: &[[f32; 3]]) -> mlua::Result<Table> {
+    let table = lua.create_table_with_capacity(speakers.len(), 0)?;
+    for (i, s) in speakers.iter().enumerate() {
+        let entry = lua.create_table_with_capacity(0, 3)?;
+        entry.set("x", s[0])?;
+        entry.set("y", s[1])?;
+        entry.set("z", s[2])?;
+        table.set(i + 1, entry)?;
+    }
+    Ok(table)
+}
+
+fn params_table(lua: &Lua, params: &[(String, f64)]) -> mlua::Result<Table> {
+    let table = lua.create_table_with_capacity(0, params.len())?;
+    for (key, value) in params {
+        table.set(key.as_str(), *value)?;
+    }
+    Ok(table)
+}
+
+// ===========================================================================
+// The factory
+// ===========================================================================
+
+/// Registers [`ScriptBackend`] under the id `"script"`.
+pub struct ScriptFactory;
+
+impl BackendFactory for ScriptFactory {
+    fn id(&self) -> &'static str {
+        "script"
+    }
+
+    fn label(&self) -> &'static str {
+        "Script"
+    }
+
+    fn realtime_capable(&self) -> bool {
+        false
+    }
+
+    fn param_schema(&self) -> Vec<ParamSpec> {
+        vec![
+            ParamSpec::path(PATH_KEY, "Script file", "")
+                .help("Path to a .lua file implementing gains(pos, speakers, state, params)."),
+        ]
+    }
+
+    fn param_schema_for(
+        &self,
+        params: &std::collections::HashMap<String, ParamValue>,
+    ) -> Vec<ParamSpec> {
+        let mut schema = self.param_schema();
+        // If a file is selected, ask it which params it declares and surface
+        // those controls too.
+        if let Some(path) = params.get(PATH_KEY).and_then(ParamValue::as_str) {
+            if !path.trim().is_empty() {
+                if let Ok(source) = std::fs::read_to_string(path) {
+                    schema.extend(script_declared_params(&source));
+                }
+            }
+        }
+        schema
+    }
+
+    fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+        // Unit speaker directions from the layout (captured on the build thread).
+        let (azimuth_elevation, _) = ctx.layout.spatializable_positions();
+        let speakers: Vec<[f32; 3]> = azimuth_elevation
+            .iter()
+            .map(|[az, el]| {
+                let (x, y, z) = spherical_to_adm(*az, *el, 1.0);
+                [x, y, z]
+            })
+            .collect();
+
+        let path = ctx
+            .backend_param(self.id(), PATH_KEY)
+            .and_then(ParamValue::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+
+        // Resolve the path → source, and the declared params → values, now. A
+        // missing/unreadable file produces a builder that fails with a clear
+        // message (surfaced via the recompute error banner), rather than `None`
+        // (which would silently keep the previous backend).
+        let load = (!path.is_empty())
+            .then(|| std::fs::read_to_string(&path))
+            .transpose();
+
+        let (source, params) = match load {
+            Ok(Some(source)) => {
+                let values = script_declared_params(&source)
+                    .into_iter()
+                    .filter_map(|spec| {
+                        let v = ctx
+                            .backend_param(self.id(), spec.key)
+                            .and_then(ParamValue::as_f32)
+                            .or_else(|| spec.default.as_f32())?;
+                        Some((spec.key.to_string(), v as f64))
+                    })
+                    .collect::<Vec<_>>();
+                (Some(source), values)
+            }
+            Ok(None) => (None, Vec::new()),
+            Err(e) => {
+                let msg = format!("script backend: cannot read '{path}': {e}");
+                return Some(BackendBuildPlan::Dynamic(DynamicBackendPlan::new(
+                    "script",
+                    move || bail!("{msg}"),
+                )));
+            }
+        };
+
+        let builder_msg = "script backend: no script file selected".to_string();
+        Some(BackendBuildPlan::Dynamic(DynamicBackendPlan::new(
+            "script",
+            move || match &source {
+                Some(source) => Ok(Box::new(ScriptBackend::new(
+                    source.as_str(),
+                    speakers.clone(),
+                    params.clone(),
+                )?) as Box<dyn GainModel>),
+                None => bail!("{builder_msg}"),
+            },
+        )))
+    }
+}
+
+/// Run a script's optional `params()` function in a throwaway sandboxed VM and
+/// map its descriptors to [`ParamSpec`]s. Any failure yields an empty list (the
+/// backend still works with the script's own defaults).
+fn script_declared_params(source: &str) -> Vec<ParamSpec> {
+    fn try_read(source: &str) -> Result<Vec<ParamSpec>> {
+        let lua = sandboxed_lua()?;
+        lua.load(source).exec().map_err(lua_err)?;
+        let params_fn = match lua.globals().get::<Value>("params").map_err(lua_err)? {
+            Value::Function(f) => f,
+            _ => return Ok(Vec::new()),
+        };
+        reset_instructions();
+        let list: Table = params_fn.call(()).map_err(lua_err)?;
+        let mut specs = Vec::new();
+        for entry in list.sequence_values::<Table>() {
+            let entry = entry.map_err(lua_err)?;
+            let key: String = entry.get("key").map_err(lua_err)?;
+            // `ParamSpec` needs a `&'static str` key; leak the (few, build-time)
+            // script-declared keys to satisfy that without reworking the schema.
+            let key: &'static str = Box::leak(key.into_boxed_str());
+            let label: String = entry.get("label").unwrap_or_else(|_| key.to_string());
+            let label: &'static str = Box::leak(label.into_boxed_str());
+            let min: f32 = entry.get("min").unwrap_or(0.0);
+            let max: f32 = entry.get("max").unwrap_or(1.0);
+            let step: f32 = entry.get("step").unwrap_or(0.01);
+            let default: f32 = entry.get("default").unwrap_or(0.0);
+            let mut spec = ParamSpec::float(key, label, min, max, step, default);
+            if let Ok(help) = entry.get::<String>("help") {
+                let help: &'static str = Box::leak(help.into_boxed_str());
+                spec = spec.help(help);
+            }
+            specs.push(spec);
+        }
+        Ok(specs)
+    }
+    try_read(source).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use renderer::backend_params::ParamKind;
+
+    const NEAREST: &str = r#"
+        function gains(pos, speakers, state, params)
+          local out, best, bestd = {}, 1, math.huge
+          for i = 1, #speakers do
+            out[i] = 0.0
+            local s = speakers[i]
+            local dx, dy, dz = pos.x - s.x, pos.y - s.y, pos.z - s.z
+            local d = dx*dx + dy*dy + dz*dz
+            if d < bestd then bestd, best = d, i end
+          end
+          out[best] = 1.0
+          return out
+        end
+    "#;
+
+    fn speakers() -> Vec<[f32; 3]> {
+        vec![
+            [-1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    }
+
+    fn request(pos: [f64; 3]) -> RenderRequest {
+        RenderRequest {
+            adm_position: pos,
+            event_size: [0.0; 3],
+            size_to_spread_mode: Default::default(),
+            spread_min: 0.0,
+            spread_max: 0.0,
+            spread_from_distance: false,
+            spread_distance_range: 1.0,
+            spread_distance_curve: 1.0,
+            room_ratio: [1.0, 1.0, 1.0],
+            room_ratio_rear: 1.0,
+            room_ratio_lower: 1.0,
+            room_ratio_center_blend: 0.5,
+            use_distance_diffuse: false,
+            distance_diffuse_threshold: 1.0,
+            distance_diffuse_curve: 1.0,
+            distance_model: Default::default(),
+        }
+    }
+
+    fn backend(src: &str) -> Result<ScriptBackend> {
+        ScriptBackend::new(src, speakers(), Vec::new())
+    }
+
+    #[test]
+    fn nearest_script_selects_closest() {
+        let model = backend(NEAREST).expect("valid script");
+        let gains = model.compute_gains(&request([0.9, 0.0, 0.0])).gains;
+        assert_eq!(gains.len(), 4);
+        assert_eq!(gains[1], 1.0);
+        assert!(gains.iter().all(|g| g.is_finite()));
+    }
+
+    #[test]
+    fn params_and_setup_reach_the_script() {
+        let src = r#"
+            function setup(speakers, params) return { n = #speakers } end
+            function gains(pos, speakers, state, params)
+              local out = {}
+              for i = 1, #speakers do out[i] = (params.level or 0.0) + state.n end
+              return out
+            end
+        "#;
+        let model = ScriptBackend::new(src, speakers(), vec![("level".into(), 0.25)])
+            .expect("valid script");
+        let gains = model.compute_gains(&request([0.0, 0.0, 0.0])).gains;
+        assert!(gains.iter().all(|g| (*g - 4.25).abs() < 1e-6));
+    }
+
+    #[test]
+    fn broken_scripts_fail_construction() {
+        assert!(backend("function gains( not lua").is_err(), "syntax");
+        assert!(backend("local x = 1").is_err(), "missing gains");
+        assert!(
+            backend("function gains(p,s,st,pa) return {1,2} end").is_err(),
+            "wrong length"
+        );
+        assert!(
+            backend("function gains(p,s,st,pa) local o={} for i=1,#s do o[i]=1/0 end return o end")
+                .is_err(),
+            "non-finite"
+        );
+    }
+
+    #[test]
+    fn sandbox_denies_dangerous_stdlib() {
+        assert!(backend("function gains(p,s,st,pa) return os.time() end").is_err());
+        assert!(backend("function gains(p,s,st,pa) io.write('x') return {} end").is_err());
+        assert!(backend("function gains(p,s,st,pa) require('os') return {} end").is_err());
+        assert!(backend("function gains(p,s,st,pa) return { debug.getinfo(1) } end").is_err());
+    }
+
+    #[test]
+    fn infinite_loop_and_runaway_allocation_are_bounded() {
+        assert!(backend("function gains(p,s,st,pa) while true do end end").is_err());
+        assert!(
+            backend(
+                "function gains(p,s,st,pa) local b=string.rep('x',256*1024*1024) return {#b} end"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn sampling_time_error_yields_non_finite_for_the_smoke_test() {
+        // Passes the eager probe at [0,0,0] but errors elsewhere; compute_gains
+        // then returns non-finite gains so the host smoke test rejects it.
+        let src = r#"
+            function gains(pos, speakers, state, params)
+              if pos.x < -0.5 then error("boom") end
+              local out = {}
+              for i = 1, #speakers do out[i] = 0.0 end
+              out[1] = 1.0
+              return out
+            end
+        "#;
+        let model = backend(src).expect("eager probe at origin passes");
+        let bad = model.compute_gains(&request([-1.0, 0.0, 0.0])).gains;
+        assert!(bad.iter().any(|g| !g.is_finite()));
+    }
+
+    #[test]
+    fn factory_declares_path_and_is_not_realtime() {
+        let f = ScriptFactory;
+        assert!(!f.realtime_capable());
+        let schema = f.param_schema();
+        assert!(matches!(schema[0].kind, ParamKind::Path));
+        assert_eq!(schema[0].key, "path");
+    }
+
+    #[test]
+    fn script_declared_params_are_parsed() {
+        let src = r#"
+            function params()
+              return { { key="falloff", label="Falloff", min=0.0, max=1.0, default=0.1 } }
+            end
+            function gains(p,s,st,pa) return {} end
+        "#;
+        let specs = script_declared_params(src);
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].key, "falloff");
+        assert!(matches!(specs[0].kind, ParamKind::Float { .. }));
+        // A script without params() declares none.
+        assert!(script_declared_params("function gains(p,s,st,pa) return {} end").is_empty());
+    }
+
+    #[test]
+    fn shipped_example_loads_and_declares_its_params() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../script-backends/nearest_inverse_distance.lua"
+        );
+        let source = std::fs::read_to_string(path).expect("example script readable");
+        let model =
+            ScriptBackend::new(source.clone(), speakers(), Vec::new()).expect("example is valid");
+        let gains = model.compute_gains(&request([0.7, -0.3, 0.2])).gains;
+        let energy: f32 = gains.iter().map(|g| g * g).sum();
+        assert!(
+            (energy - 1.0).abs() < 1e-4,
+            "constant-power, energy={energy}"
+        );
+
+        let keys: Vec<&str> = script_declared_params(&source)
+            .iter()
+            .map(|s| s.key)
+            .collect();
+        assert!(keys.contains(&"falloff") && keys.contains(&"sharpness"));
+    }
+}

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -387,6 +387,19 @@ function buildParamControl(spec, current, backend) {
     select.addEventListener('change', () => sendBackendParam(spec.key, select.value, backend));
     row.appendChild(select);
     row._setValue = (v) => { select.value = String(v); };
+  } else if (kind.type === 'path') {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'delay-input';
+    input.style.minWidth = '12rem';
+    input.placeholder = '/path/to/backend.lua';
+    input.value = current == null ? '' : String(current);
+    input.addEventListener('change', () => sendBackendParam(spec.key, input.value.trim(), backend));
+    row.appendChild(input);
+    // Don't clobber the field while the user is typing in it.
+    row._setValue = (v) => {
+      if (document.activeElement !== input) input.value = v == null ? '' : String(v);
+    };
   } else {
     const isInt = kind.type === 'int';
     const input = document.createElement('input');
@@ -472,7 +485,11 @@ export function renderRenderBackend() {
   const renderBackendEffectiveEl = getRenderBackendEffectiveEl();
   const selection = typeof app.renderBackendState.selection === 'string' ? app.renderBackendState.selection : 'vbap';
   const effective = typeof app.renderBackendState.effective === 'string' ? app.renderBackendState.effective : null;
-  const visibleBackend = effective || selection;
+  // Normally show the active (effective) backend's sections. The script backend
+  // is the exception: until a valid .lua is set its build fails, so `effective`
+  // lags on the previous backend — follow the selection instead so its config
+  // (the file path field) is reachable to fix the error.
+  const visibleBackend = selection === 'script' ? selection : (effective || selection);
   const frozen = app.renderBackendState.frozenSpeakers === true;
   if (renderBackendSelectEl) {
     syncBackendOptions(renderBackendSelectEl);

--- a/script-backends/README.md
+++ b/script-backends/README.md
@@ -1,0 +1,65 @@
+# Scriptable render backends (Lua)
+
+Omniphony's **Script** render backend evaluates a user-supplied Lua function to
+turn an object position into one gain per speaker. The renderer samples this
+function only while building its precomputed gain table — never per audio
+sample — so an embedded scripting language is fast enough, and you can iterate
+on a panning law without recompiling.
+
+## Selecting a script
+
+In Studio, pick **Script** as the render backend; a **Script file** field
+appears (it is a normal backend parameter). Point it at a `.lua` file. The
+parameters your script declares via `params()` then appear as sliders.
+
+In a config YAML the same lives in the generic backend-param store:
+
+```yaml
+render:
+  render_backend: script
+  backend_params:
+    script:
+      path: /path/to/your_backend.lua
+      falloff: 0.1
+```
+
+The backend runs only in a precomputed evaluation mode; a realtime request is
+forced to precomputed (calling Lua per sample is not viable).
+
+## The contract
+
+```lua
+-- REQUIRED: gains per speaker for one position.
+function gains(pos, speakers, state, params)
+  -- pos      = { x=, y=, z= }            (raw ADM position)
+  -- speakers = { {x=,y=,z=}, ... }       (unit speaker directions)
+  -- state    = value returned by setup(), or nil
+  -- params   = { key = number, ... }     (values for params() below)
+  -- return an array of #speakers finite numbers, in speaker order.
+end
+
+-- OPTIONAL: declare tunable params so Studio renders sliders.
+function params()
+  return { { key="falloff", label="Falloff", min=0, max=1, step=0.01,
+             default=0.1, help="..." } }
+end
+
+-- OPTIONAL: one-time per-VM setup; its return value is passed as `state`.
+function setup(speakers, params) return {} end
+```
+
+Distance attenuation and distance-diffuse are applied by Omniphony *around* your
+script, so you only write the directional panning law.
+
+## Sandbox & limits
+
+Scripts run sandboxed: only `math`, `table` and `string` are available (no
+`io`, `os`, `require`, …). Each VM is memory-capped and each call is bounded by
+an instruction budget, so an infinite loop fails the build instead of hanging
+the renderer. A script that errors or returns non-finite / wrong-count gains is
+rejected at build time (the engine smoke-tests every freshly built backend).
+
+## Examples
+
+- [`nearest_inverse_distance.lua`](nearest_inverse_distance.lua) — inverse-distance,
+  constant-power panning, with `falloff`/`sharpness` params. A good template.

--- a/script-backends/nearest_inverse_distance.lua
+++ b/script-backends/nearest_inverse_distance.lua
@@ -1,0 +1,55 @@
+-- Example Omniphony scriptable render backend.
+--
+-- Omniphony evaluates this only while it BUILDS the precomputed gain table (not
+-- per audio sample), so plain Lua is fast enough here.
+--
+-- Contract
+-- --------
+--   gains(pos, speakers, state, params) -> { number, ... }   (REQUIRED)
+--     pos      : { x=, y=, z= }            target position (raw ADM)
+--     speakers : { {x=,y=,z=}, ... }       unit speaker directions
+--     state    : value returned by setup(), or nil
+--     params   : { key = number, ... }     values for the params declared below
+--     return   : array of #speakers finite gains, same order as `speakers`.
+--
+--   params() -> { {key=,label=,min=,max=,step=,default=,help=}, ... }  (OPTIONAL)
+--     Declares tunable parameters so Studio renders sliders for them.
+--
+--   setup(speakers, params) -> state    (OPTIONAL, one-time per VM)
+--
+-- Sandbox: only `math`, `table`, `string` are available — no io/os/require.
+--
+-- This example: inverse-distance panning, constant-power normalised.
+
+function params()
+  return {
+    { key = "falloff", label = "Falloff", min = 0.001, max = 1.0, step = 0.001,
+      default = 0.1, help = "Softening near a speaker (smaller = sharper)." },
+    { key = "sharpness", label = "Sharpness", min = 0.5, max = 8.0, step = 0.1,
+      default = 2.0, help = "Distance falloff exponent (higher = tighter)." },
+  }
+end
+
+function gains(pos, speakers, state, params)
+  local falloff = params.falloff or 0.1
+  local sharpness = params.sharpness or 2.0
+  local out = {}
+  local energy = 0.0
+  for i = 1, #speakers do
+    local s = speakers[i]
+    local dx, dy, dz = pos.x - s.x, pos.y - s.y, pos.z - s.z
+    local d = math.sqrt(dx * dx + dy * dy + dz * dz)
+    local w = 1.0 / (d + falloff) ^ sharpness
+    out[i] = w
+    energy = energy + w * w
+  end
+
+  if energy > 1e-12 then
+    local norm = math.sqrt(energy)
+    for i = 1, #speakers do
+      out[i] = out[i] / norm
+    end
+  end
+
+  return out
+end


### PR DESCRIPTION
Adds a **Script** render backend whose per-position gain function is written in **Lua** and editable by the user, built on the new backend registry (factories + `DynamicBackendPlan`). Supersedes #27, which predated that refactor.

## Why a scripting language fits here
A backend is geometry-only and its `compute_gains` runs **only while the precomputed gain table is sampled** (once per grid point, on a build thread), never per audio sample. So an embedded interpreter is fast enough. The backend is not hot-path safe, so it declares `realtime_capable = false` / `supports_realtime = false` and the host forces a precomputed mode.

## Renderer-core extensions (commit 1, additive, built-ins unaffected)
- `ParamKind::Path` (+ `ParamSpec::path`): a filesystem-path control.
- `BackendFactory::param_schema_for(&params)`: a **dynamic** schema resolved against the backend's current params (defaults to the static schema). The script backend uses it to expose the params its selected `.lua` declares. Re-published on every param change via the normal recompute broadcast.
- `BackendFactory::realtime_capable` (default `true`): `prepare_topology_build_plan` forces a precomputed mode when a non-realtime backend is asked for realtime.

## The backend (commit 2)
- New `script_backend` crate (depends on `renderer`'s public API only, like `example_backend`); registered with one line in `renderer_build`.
- `ScriptBackend` (`GainModel`): `Send + Sync`; the non-`Send` Lua VM lives in a `thread_local` keyed by a generation (one VM per sampling worker, no locking). Sandbox = `math`/`table`/`string` only, memory cap, per-call instruction budget. Eager validation gives precise errors; a sampling-time error emits non-finite gains so the engine's build-time smoke test rejects it.
- `ScriptFactory`: dynamic schema = the `.lua` **path** + the script's `params()`-declared sliders, rendered generically by Studio (no bespoke UI). Studio renders `ParamKind::Path` and keeps the script's config reachable while its build is failing (so the file can be set).
- Docs/example in `script-backends/`.

## Tests
9 crate tests (selection, params + setup, broken-script rejection, sandbox denies `os`/`io`/`require`/`debug`, infinite loop + runaway allocation bounded, sampling-time error → non-finite, factory schema, script-declared params, shipped example). Full workspace builds; renderer (103) + crate suites pass; `fmt --check` clean.

The Lua engine core, sandbox, and behaviour were verified live in Studio + mpv on the earlier branch; this version re-expresses the wiring through the registry and the generic param system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)