### PR TITLE
feat(studio): opt-in startup update check

### DIFF
--- a/omniphony-studio/src/app.js
+++ b/omniphony-studio/src/app.js
@@ -80,6 +80,7 @@ import { renderConfigSavedUI } from './controls/config.js';
 import { renderLatencyDisplay, renderLatencyMeterUI, renderRenderTimeUI, renderResampleRatioDisplay } from './controls/latency.js';
 import { renderAudioFormatDisplay, applyAudioSampleRateNow } from './controls/audio.js';
 import { bindDrcListeners, renderDrcUI } from './controls/drc.js';
+import { initUpdateCheck, maybeCheck } from './controls/updates.js';
 import {
   updateObjectContributionUI,
   updateSpeakerContributionUI,
@@ -266,6 +267,8 @@ invoke('get_state')
     pushLog('error', tf('log.stateLoadFailed', { error: normalizeLogError(e) }));
   });
 
+initUpdateCheck();
+
 invoke('get_about_info')
   .then((info) => {
     const aboutNameEl = document.getElementById('aboutName');
@@ -281,6 +284,7 @@ invoke('get_about_info')
       aboutRepositoryLinkEl.href = info.repository;
       aboutRepositoryLinkEl.textContent = info.repository;
     }
+    maybeCheck(info.version);
   })
   .catch((e) => {
     console.error('[get_about_info]', e);

--- a/omniphony-studio/src/controls/updates.js
+++ b/omniphony-studio/src/controls/updates.js
@@ -1,0 +1,160 @@
+// Opt-in update check. When enabled (off by default), Studio queries the GitHub
+// releases API at most once per day, at startup, and shows a blue banner with a
+// link to the newer release if one is available.
+//
+// Frontend-only by design: the webview runs with `csp: null` and GitHub's REST
+// API answers with `Access-Control-Allow-Origin: *`, so a plain `fetch()` works
+// without any Rust command or new dependency. The toggle state and the
+// once-per-day throttle persist in localStorage, mirroring the pattern used by
+// diag-plot.js / room-geometry.js.
+
+import { t, tf } from '../i18n.js';
+import { pushLog, normalizeLogError } from '../log.js';
+
+const RELEASES_URL = 'https://api.github.com/repos/mgth/Omniphony/releases';
+const RELEASES_PAGE = 'https://github.com/mgth/Omniphony/releases';
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 1 day
+// Only official `vMAJOR.MINOR.PATCH` tags count: excludes the `v0.x.y.nnn`
+// dev/polish tags and the `liborender-v*` component tags.
+const OFFICIAL_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+const ENABLED_KEY = 'omniphony.updateCheck.enabled';
+const LAST_CHECK_KEY = 'omniphony.updateCheck.lastCheck';
+const RESULT_KEY = 'omniphony.updateCheck.result';
+
+let toggleEl = null;
+let bannerEl = null;
+let bannerTextEl = null;
+let bannerLinkEl = null;
+let currentVersion = '';
+
+function isEnabled() {
+  return localStorage.getItem(ENABLED_KEY) === '1';
+}
+
+function setEnabled(enabled) {
+  localStorage.setItem(ENABLED_KEY, enabled ? '1' : '0');
+}
+
+function loadCachedResult() {
+  try {
+    const raw = localStorage.getItem(RESULT_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeResult(result) {
+  if (result) localStorage.setItem(RESULT_KEY, JSON.stringify(result));
+  else localStorage.removeItem(RESULT_KEY);
+}
+
+// Parse `vX.Y.Z` (or `X.Y.Z`) into [major, minor, patch]; null if not official.
+function parseVersion(tag) {
+  if (typeof tag !== 'string') return null;
+  const m = tag.trim().match(OFFICIAL_TAG_RE);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+// Returns >0 if a is newer than b, <0 if older, 0 if equal.
+function compareVersions(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function hideBanner() {
+  if (bannerEl) bannerEl.style.display = 'none';
+}
+
+function renderBanner(result) {
+  if (!bannerEl || !result || !result.tag) {
+    hideBanner();
+    return;
+  }
+  const cur = parseVersion(currentVersion);
+  const next = parseVersion(result.tag);
+  // Only show if we can confirm the cached/fetched release is strictly newer.
+  if (!cur || !next || compareVersions(next, cur) <= 0) {
+    hideBanner();
+    return;
+  }
+  if (bannerTextEl) bannerTextEl.textContent = tf('updates.available', { version: result.tag });
+  if (bannerLinkEl) {
+    bannerLinkEl.textContent = t('updates.linkText');
+    bannerLinkEl.href = result.htmlUrl || RELEASES_PAGE;
+  }
+  bannerEl.style.display = '';
+}
+
+// Pick the highest official, non-draft, non-prerelease release from the API list.
+function pickLatestOfficial(releases) {
+  if (!Array.isArray(releases)) return null;
+  let best = null;
+  let bestVer = null;
+  for (const rel of releases) {
+    if (!rel || rel.draft || rel.prerelease) continue;
+    const ver = parseVersion(rel.tag_name);
+    if (!ver) continue;
+    if (!bestVer || compareVersions(ver, bestVer) > 0) {
+      bestVer = ver;
+      best = { tag: rel.tag_name, htmlUrl: rel.html_url || RELEASES_PAGE };
+    }
+  }
+  return best;
+}
+
+async function fetchAndRender() {
+  try {
+    const resp = await fetch(RELEASES_URL, { headers: { Accept: 'application/vnd.github+json' } });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const releases = await resp.json();
+    const result = pickLatestOfficial(releases);
+    localStorage.setItem(LAST_CHECK_KEY, String(Date.now()));
+    storeResult(result);
+    renderBanner(result);
+  } catch (e) {
+    // Network/parse failures are non-fatal: log and show nothing.
+    pushLog('warn', tf('updates.checkFailed', { error: normalizeLogError(e) }));
+  }
+}
+
+// Run a check if enabled, respecting the once-per-day throttle. Within the day,
+// render from the cached result so the banner survives restarts without refetch.
+function maybeCheck(version) {
+  if (typeof version === 'string') currentVersion = version;
+  if (!isEnabled()) {
+    hideBanner();
+    return;
+  }
+  const last = Number(localStorage.getItem(LAST_CHECK_KEY) || 0);
+  if (Number.isFinite(last) && Date.now() - last < CHECK_INTERVAL_MS) {
+    renderBanner(loadCachedResult());
+    return;
+  }
+  fetchAndRender();
+}
+
+// Bind the toggle and banner DOM. Called once at boot, before the version is
+// known; `maybeCheck(version)` is invoked later from the get_about_info handler.
+export function initUpdateCheck() {
+  toggleEl = document.getElementById('updateCheckToggle');
+  bannerEl = document.getElementById('updateAvailableBanner');
+  bannerTextEl = document.getElementById('updateAvailableText');
+  bannerLinkEl = document.getElementById('updateAvailableLink');
+
+  if (toggleEl) {
+    toggleEl.checked = isEnabled();
+    toggleEl.addEventListener('change', () => {
+      setEnabled(toggleEl.checked);
+      if (toggleEl.checked) maybeCheck(currentVersion);
+      else hideBanner();
+    });
+  }
+  hideBanner();
+}
+
+export { maybeCheck };

--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "Räumliche Steuerung",
+  "updates.checkLabel": "Beim Start nach Updates suchen",
+  "updates.available": "Update verfügbar: {version}",
+  "updates.linkText": "Auf GitHub ansehen",
+  "updates.checkFailed": "Update-Prüfung fehlgeschlagen: {error}",
   "app.language": "Sprache",
   "app.language.auto": "Automatisch",
   "app.language.en": "Englisch",

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "Spatial Control",
+  "updates.checkLabel": "Check for updates on startup",
+  "updates.available": "Update available: {version}",
+  "updates.linkText": "View on GitHub",
+  "updates.checkFailed": "Update check failed: {error}",
   "app.language": "Language",
   "app.language.auto": "Auto",
   "app.language.en": "English",

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "Control espacial",
+  "updates.checkLabel": "Buscar actualizaciones al iniciar",
+  "updates.available": "Actualización disponible: {version}",
+  "updates.linkText": "Ver en GitHub",
+  "updates.checkFailed": "Error al buscar actualizaciones: {error}",
   "app.language": "Idioma",
   "app.language.auto": "Auto",
   "app.language.en": "Inglés",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "Contrôle spatial",
+  "updates.checkLabel": "Vérifier les mises à jour au démarrage",
+  "updates.available": "Mise à jour disponible : {version}",
+  "updates.linkText": "Voir sur GitHub",
+  "updates.checkFailed": "Échec de la vérification des mises à jour : {error}",
   "app.language": "Langue",
   "app.language.auto": "Auto",
   "app.language.en": "Anglais",

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "Controllo spaziale",
+  "updates.checkLabel": "Controlla aggiornamenti all'avvio",
+  "updates.available": "Aggiornamento disponibile: {version}",
+  "updates.linkText": "Vedi su GitHub",
+  "updates.checkFailed": "Controllo aggiornamenti non riuscito: {error}",
   "app.language": "Lingua",
   "app.language.auto": "Auto",
   "app.language.en": "Inglese",

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "空間コントロール",
+  "updates.checkLabel": "起動時に更新を確認",
+  "updates.available": "更新が利用可能: {version}",
+  "updates.linkText": "GitHub で見る",
+  "updates.checkFailed": "更新の確認に失敗しました: {error}",
   "app.language": "言語",
   "app.language.auto": "自動",
   "app.language.en": "英語",

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "Controle espacial",
+  "updates.checkLabel": "Verificar atualizações ao iniciar",
+  "updates.available": "Atualização disponível: {version}",
+  "updates.linkText": "Ver no GitHub",
+  "updates.checkFailed": "Falha ao verificar atualizações: {error}",
   "app.language": "Idioma",
   "app.language.auto": "Auto",
   "app.language.en": "Inglês",

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -1,6 +1,10 @@
 {
   "app.title": "Omniphony Studio",
   "app.subtitle": "空间控制",
+  "updates.checkLabel": "启动时检查更新",
+  "updates.available": "有可用更新：{version}",
+  "updates.linkText": "在 GitHub 上查看",
+  "updates.checkFailed": "检查更新失败：{error}",
   "app.language": "语言",
   "app.language.auto": "自动",
   "app.language.en": "英语",

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -47,6 +47,16 @@
         </div>
       </div>
       <div id="overlayScroll">
+      <div id="updatePanelRoot">
+        <label class="switch-row" style="font-size:13px;cursor:pointer">
+          <span data-i18n="updates.checkLabel">Check for updates on startup</span>
+          <input id="updateCheckToggle" type="checkbox" />
+        </label>
+        <div id="updateAvailableBanner" style="display:none;margin-top:0.4rem;padding:0.55rem 0.65rem;font-size:14px;line-height:1.5;font-weight:600;color:#d9ecff;background:rgba(88,160,255,0.15);border:1px solid rgba(88,160,255,0.38);border-radius:7px">
+          <span id="updateAvailableText"></span>
+          <a id="updateAvailableLink" href="https://github.com/mgth/Omniphony/releases" target="_blank" rel="noreferrer" style="color:#9cc6ff;margin-left:0.5rem;text-decoration:underline"></a>
+        </div>
+      </div>
       <div id="oscPanelRoot">
       <div style="display:flex;align-items:center;justify-content:space-between">
         <div><span class="osc-status-dot" id="oscStatusDot"></span><span data-i18n="osc.label">OSC</span>: <span id="status">Initializing...</span></div>


### PR DESCRIPTION
Add an opt-in "check for updates on startup" toggle to Studio. When enabled (off by default), the webview queries the GitHub releases API at most once per day at startup and shows a banner linking to the newer release when one is available.

Frontend-only: relies on `csp: null` and GitHub's permissive CORS, so no Rust command or new dependency is needed. Toggle state, the once-per-day throttle, and the last result persist in localStorage, mirroring the diag-plot/room-geometry pattern. Only official vMAJOR.MINOR.PATCH tags count (dev `v0.x.y.nnn` and `liborender-v*` component tags are ignored). Adds the four `updates.*` strings to all eight locales.