### PR TITLE
feat(hybrid): allow any registered backend as an inner model

### DIFF
--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -374,36 +374,6 @@ pub fn build_spatial_renderer(
     let configured_evaluation = render_cfg
         .and_then(|cfg| cfg.render_evaluation_mode.as_deref())
         .and_then(LiveEvaluationMode::from_str);
-    let hybrid_cfg = render_cfg.map(|cfg| {
-        let defaults = renderer::live_params::HybridLiveParams::default();
-        let valid_inner = |id: &str| matches!(id, "vbap" | "barycenter" | "experimental_distance");
-        renderer::live_params::HybridLiveParams {
-            external_backend_id: cfg
-                .hybrid_external_backend
-                .clone()
-                .filter(|id| valid_inner(id))
-                .unwrap_or(defaults.external_backend_id),
-            internal_backend_id: cfg
-                .hybrid_internal_backend
-                .clone()
-                .filter(|id| valid_inner(id))
-                .unwrap_or(defaults.internal_backend_id),
-            curve: cfg
-                .hybrid_curve
-                .clone()
-                .filter(|points| points.len() >= 2)
-                .unwrap_or(defaults.curve),
-            curve_smoothing: cfg
-                .hybrid_curve_smoothing
-                .map(|v| v.clamp(0.0, 1.0))
-                .unwrap_or(defaults.curve_smoothing),
-            metric: cfg
-                .hybrid_metric
-                .as_deref()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(defaults.metric),
-        }
-    });
     {
         let control = renderer.renderer_control();
         // Register the demonstration backend so `backend_id = "example"` resolves.
@@ -411,6 +381,39 @@ pub fn build_spatial_renderer(
         // User-scriptable (Lua) backend; selecting `backend_id = "script"` routes
         // a rebuild through it, reading its `.lua` path from the param store.
         control.register_backend(Box::new(script_backend::ScriptFactory));
+        // Resolved after registration so any registered backend (not just the
+        // historical concrete ones) is accepted as a hybrid inner model; a nested
+        // hybrid or an unregistered id falls back to the default.
+        let hybrid_cfg = render_cfg.map(|cfg| {
+            let defaults = renderer::live_params::HybridLiveParams::default();
+            let valid_inner = |id: &str| id != "hybrid" && control.has_backend(id);
+            renderer::live_params::HybridLiveParams {
+                external_backend_id: cfg
+                    .hybrid_external_backend
+                    .clone()
+                    .filter(|id| valid_inner(id))
+                    .unwrap_or(defaults.external_backend_id),
+                internal_backend_id: cfg
+                    .hybrid_internal_backend
+                    .clone()
+                    .filter(|id| valid_inner(id))
+                    .unwrap_or(defaults.internal_backend_id),
+                curve: cfg
+                    .hybrid_curve
+                    .clone()
+                    .filter(|points| points.len() >= 2)
+                    .unwrap_or(defaults.curve),
+                curve_smoothing: cfg
+                    .hybrid_curve_smoothing
+                    .map(|v| v.clamp(0.0, 1.0))
+                    .unwrap_or(defaults.curve_smoothing),
+                metric: cfg
+                    .hybrid_metric
+                    .as_deref()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(defaults.metric),
+            }
+        });
         // Resolve the configured backend id: built-in ids/aliases first (e.g.
         // "distance" -> experimental_distance), then any registered backend id.
         let configured_backend = configured_backend_cfg.and_then(|raw| {

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -600,9 +600,13 @@ fn experimental_params(
 }
 
 /// Build a `BackendBuildPlan` for one of the concrete (non-hybrid) backends.
-/// Used by the top-level barycenter/experimental_distance/vbap factories and by
-/// the hybrid backend for each of its inner models. Tuning params come from the
-/// bag keyed by `backend_id`. Returns `None` for an unknown id or `"hybrid"`.
+/// Used by the top-level barycenter/experimental_distance/vbap factories. Tuning
+/// params come from the bag keyed by `backend_id`. Returns `None` for an unknown
+/// id or `"hybrid"`.
+///
+/// This deliberately does NOT dispatch through the registry: it is called from
+/// the concrete factories' own `build_plan`, so routing back through the registry
+/// would recurse. Composite backends use [`resolve_hybrid_inner_plan`] instead.
 fn build_inner_backend_plan(
     ctx: &BackendBuildCtx<'_>,
     backend_id: &str,
@@ -628,6 +632,40 @@ fn build_inner_backend_plan(
     }
 }
 
+/// Resolve an inner model of the hybrid backend by id, dispatching through the
+/// registry so *any* registered backend (built-in, scriptable, or contributor)
+/// can be composed — not just the historical concrete ones. The inner factory's
+/// own `build_plan` runs, so e.g. the scriptable backend yields a `Dynamic` plan.
+///
+/// Nested hybrid is rejected to keep this from recursing indefinitely.
+fn resolve_hybrid_inner_plan(
+    ctx: &BackendBuildCtx<'_>,
+    backend_id: &str,
+) -> Option<BackendBuildPlan> {
+    if backend_id == "hybrid" {
+        return None;
+    }
+    ctx.registry.get(backend_id)?.build_plan(ctx)
+}
+
+/// Whether both named backends are hot-path-safe per the registry. An
+/// unregistered id is treated as realtime-capable (it will fail to build
+/// elsewhere). Used to force a precomputed evaluation mode when a hybrid inner
+/// backend (e.g. the scriptable backend) cannot run per sample.
+fn inners_realtime_capable(
+    registry: &BackendRegistry,
+    external_id: &str,
+    internal_id: &str,
+) -> bool {
+    let realtime = |id: &str| {
+        registry
+            .get(id)
+            .map(|factory| factory.realtime_capable())
+            .unwrap_or(true)
+    };
+    realtime(external_id) && realtime(internal_id)
+}
+
 fn preferred_evaluation_mode(
     backend_rebuild_params: Option<BackendRebuildParams>,
 ) -> PreferredEvaluationMode {
@@ -643,6 +681,10 @@ pub struct BackendBuildCtx<'a> {
     pub layout: &'a SpeakerLayout,
     pub live: &'a LiveParams,
     pub backend_rebuild_params: Option<BackendRebuildParams>,
+    /// The registry the active backend was looked up in. A composite backend
+    /// (hybrid) resolves its inner models through this so any registered backend
+    /// can be composed, not just a hard-coded set. See [`resolve_hybrid_inner_plan`].
+    pub registry: &'a BackendRegistry,
     /// All host-set backend param values, keyed by backend id then param key
     /// (see [`crate::backend_params`]). Read at build time only — never on the
     /// audio hot path. A backend reads its own entry via [`backend_param`]; a
@@ -993,11 +1035,12 @@ impl BackendFactory for HybridFactory {
         "Hybrid"
     }
     fn build_plan(&self, ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
-        // The hybrid backend composes two inner backends. Each inner model reads
-        // its own params from the bag keyed by the inner backend id, so a nested
-        // barycenter/experimental_distance is tuned exactly like the standalone one.
-        let external = build_inner_backend_plan(ctx, &ctx.live.hybrid.external_backend_id)?;
-        let internal = build_inner_backend_plan(ctx, &ctx.live.hybrid.internal_backend_id)?;
+        // The hybrid backend composes two inner backends, resolved through the
+        // registry so any registered backend can be an inner model (nested hybrid
+        // excepted). Each inner model reads its own params from the bag keyed by
+        // the inner backend id, so it is tuned exactly like the standalone one.
+        let external = resolve_hybrid_inner_plan(ctx, &ctx.live.hybrid.external_backend_id)?;
+        let internal = resolve_hybrid_inner_plan(ctx, &ctx.live.hybrid.internal_backend_id)?;
         Some(BackendBuildPlan::Hybrid(HybridBuildPlan {
             external: Box::new(external),
             internal: Box::new(internal),
@@ -1027,13 +1070,22 @@ pub fn prepare_topology_build_plan(
         live,
         backend_rebuild_params,
         backend_params,
+        registry,
     };
     let backend_build = factory.build_plan(&ctx)?;
     let preferred = preferred_evaluation_mode(backend_rebuild_params);
     let mut evaluation_mode = effective_live_evaluation_mode(live.evaluation.mode, preferred);
     // A backend that is not hot-path-safe (e.g. the scriptable backend) must
     // never run per sample: force a precomputed mode if realtime was requested.
-    if evaluation_mode == LiveEvaluationMode::Realtime && !factory.realtime_capable() {
+    // For hybrid this is recursive — a non-realtime *inner* backend forces it too.
+    let realtime_capable = factory.realtime_capable()
+        && (live.backend_id() != "hybrid"
+            || inners_realtime_capable(
+                registry,
+                &live.hybrid.external_backend_id,
+                &live.hybrid.internal_backend_id,
+            ));
+    if evaluation_mode == LiveEvaluationMode::Realtime && !realtime_capable {
         evaluation_mode = match preferred {
             PreferredEvaluationMode::PrecomputedCartesian => {
                 LiveEvaluationMode::PrecomputedCartesian
@@ -1283,6 +1335,41 @@ mod tests {
         assert_eq!(vbap.label, "VBAP");
         // Every builtin reports a non-empty label.
         assert!(listings.iter().all(|l| !l.label.is_empty()));
+    }
+
+    /// A registered factory that is not hot-path-safe (mirrors the scriptable
+    /// backend), used to check the recursive realtime gate for hybrid inners.
+    struct NonRealtimeFactory;
+    impl BackendFactory for NonRealtimeFactory {
+        fn id(&self) -> &'static str {
+            "non_realtime"
+        }
+        fn realtime_capable(&self) -> bool {
+            false
+        }
+        fn build_plan(&self, _ctx: &BackendBuildCtx<'_>) -> Option<BackendBuildPlan> {
+            Some(BackendBuildPlan::Dynamic(DynamicBackendPlan::new(
+                "non_realtime",
+                || Ok(Box::new(GoodBackend)),
+            )))
+        }
+    }
+
+    #[test]
+    fn inners_realtime_capable_reflects_registry() {
+        let mut registry = BackendRegistry::builtin();
+        registry.register(Box::new(NonRealtimeFactory));
+        // Two realtime-capable builtins: hybrid can stay realtime.
+        assert!(inners_realtime_capable(&registry, "vbap", "barycenter"));
+        // A non-realtime inner forces the composite to be non-realtime.
+        assert!(!inners_realtime_capable(
+            &registry,
+            "non_realtime",
+            "barycenter"
+        ));
+        assert!(!inners_realtime_capable(&registry, "vbap", "non_realtime"));
+        // An unregistered id is treated as realtime-capable (fails to build later).
+        assert!(inners_realtime_capable(&registry, "vbap", "does_not_exist"));
     }
 
     #[test]

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -1071,11 +1071,9 @@ pub fn apply_simple_osc_control(
             "external_backend" | "internal_backend" => {
                 if let Some(value) = parse_string_arg(msg.args.first()) {
                     let normalized = value.trim().to_ascii_lowercase();
-                    // Only concrete backends are valid inner models (no nested hybrid).
-                    if matches!(
-                        normalized.as_str(),
-                        "vbap" | "barycenter" | "experimental_distance"
-                    ) {
+                    // Any registered backend is a valid inner model, except a
+                    // nested hybrid (which would recurse).
+                    if normalized != "hybrid" && ctx.renderer.has_backend(&normalized) {
                         let slot = if rest == "external_backend" {
                             &mut live.hybrid.external_backend_id
                         } else {

--- a/omniphony-studio/src-tauri/src/commands/render.rs
+++ b/omniphony-studio/src-tauri/src/commands/render.rs
@@ -115,38 +115,36 @@ pub fn control_distance_diffuse_metric(state: State<SharedState>, value: String)
 
 #[tauri::command]
 pub fn control_hybrid_external_backend(state: State<SharedState>, value: String) {
-    let normalized = value.trim().to_ascii_lowercase();
-    if !matches!(
-        normalized.as_str(),
-        "vbap" | "barycenter" | "experimental_distance"
-    ) {
-        return;
+    if let Some(normalized) = valid_hybrid_inner_id(&value) {
+        send_control(
+            &state.osc_tx,
+            OscControlMsg::SendString {
+                address: "/omniphony/control/hybrid/external_backend".to_string(),
+                value: normalized,
+            },
+        );
     }
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendString {
-            address: "/omniphony/control/hybrid/external_backend".to_string(),
-            value: normalized,
-        },
-    );
 }
 
 #[tauri::command]
 pub fn control_hybrid_internal_backend(state: State<SharedState>, value: String) {
-    let normalized = value.trim().to_ascii_lowercase();
-    if !matches!(
-        normalized.as_str(),
-        "vbap" | "barycenter" | "experimental_distance"
-    ) {
-        return;
+    if let Some(normalized) = valid_hybrid_inner_id(&value) {
+        send_control(
+            &state.osc_tx,
+            OscControlMsg::SendString {
+                address: "/omniphony/control/hybrid/internal_backend".to_string(),
+                value: normalized,
+            },
+        );
     }
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendString {
-            address: "/omniphony/control/hybrid/internal_backend".to_string(),
-            value: normalized,
-        },
-    );
+}
+
+/// Normalise a hybrid inner-backend id and reject the only structurally invalid
+/// choices (empty, or a nested `hybrid`). Any other id is forwarded; the renderer
+/// validates it against its backend registry authoritatively.
+fn valid_hybrid_inner_id(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    (!normalized.is_empty() && normalized != "hybrid").then_some(normalized)
 }
 
 #[tauri::command]

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -282,15 +282,19 @@ export function updateEvaluationMode() {
 // Populate the backend dropdown from the engine-published list of selectable
 // backends (built-in + contributor-registered). Falls back to the static HTML
 // options when the engine doesn't send a list (older builds).
-function syncBackendOptions(selectEl) {
+function syncBackendOptions(selectEl, excludeIds) {
   const available = app.renderBackendState && Array.isArray(app.renderBackendState.availableBackends)
     ? app.renderBackendState.availableBackends
     : null;
   if (!selectEl || !available || available.length === 0) return;
-  const desired = available.map((b) => ({
-    value: String(b.id),
-    label: String(b.label || b.id),
-  }));
+  const exclude = excludeIds instanceof Set ? excludeIds : new Set(excludeIds || []);
+  const desired = available
+    .filter((b) => !exclude.has(String(b.id)))
+    .map((b) => ({
+      value: String(b.id),
+      label: String(b.label || b.id),
+    }));
+  if (desired.length === 0) return;
   const current = Array.from(selectEl.options).map((o) => `${o.value}=${o.textContent}`).join('|');
   const next = desired.map((d) => `${d.value}=${d.label}`).join('|');
   if (current === next) return;
@@ -513,6 +517,10 @@ export function renderHybridOptions() {
   const hybridExternalBackendSelectEl = getHybridExternalBackendSelectEl();
   const hybridInternalBackendSelectEl = getHybridInternalBackendSelectEl();
   const state = app.renderBackendState.hybrid || {};
+  // Inner models can be any registered backend except a nested hybrid.
+  const innerExclude = new Set(['hybrid']);
+  syncBackendOptions(hybridExternalBackendSelectEl, innerExclude);
+  syncBackendOptions(hybridInternalBackendSelectEl, innerExclude);
   if (hybridExternalBackendSelectEl && typeof state.externalBackend === 'string') {
     hybridExternalBackendSelectEl.value = state.externalBackend;
   }

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -199,8 +199,17 @@ export function applyInitState(payload) {
       : {};
     const hybrid = payload.renderBackendState.hybrid;
     if (hybrid && typeof hybrid === 'object') {
+      // Any registered backend can be a hybrid inner model, except a nested
+      // hybrid. The dropdown is populated from `availableBackends`; accept an id
+      // present in that list (or any non-hybrid id if the list isn't published).
+      const available = app.renderBackendState.availableBackends;
       const validInner = (id) =>
-        id === 'vbap' || id === 'barycenter' || id === 'experimental_distance';
+        typeof id === 'string'
+        && id.length > 0
+        && id !== 'hybrid'
+        && (!Array.isArray(available)
+          || available.length === 0
+          || available.some((b) => String(b.id) === id));
       const external = typeof hybrid.externalBackend === 'string'
         ? hybrid.externalBackend.trim().toLowerCase()
         : null;

--- a/omniphony-studio/src/listeners/renderer-panel-listeners.js
+++ b/omniphony-studio/src/listeners/renderer-panel-listeners.js
@@ -143,10 +143,20 @@ export function setupRendererPanelListeners() {
     });
   }
 
+  // A valid hybrid inner model is any registered backend except a nested hybrid.
+  const isValidHybridInner = (value) => {
+    if (!value || value === 'hybrid') return false;
+    const available = Array.isArray(app.renderBackendState.availableBackends)
+      ? app.renderBackendState.availableBackends
+      : null;
+    // If the engine hasn't published a list yet, accept any non-hybrid id.
+    return !available || available.some((b) => String(b.id) === value);
+  };
+
   if (hybridExternalBackendSelectEl) {
     hybridExternalBackendSelectEl.addEventListener('change', () => {
       const value = String(hybridExternalBackendSelectEl.value || '').trim().toLowerCase();
-      if (!['vbap', 'barycenter', 'experimental_distance'].includes(value)) return;
+      if (!isValidHybridInner(value)) return;
       app.renderBackendState.hybrid.externalBackend = value;
       app.vbapRecomputing = true;
       renderVbapStatus();
@@ -158,7 +168,7 @@ export function setupRendererPanelListeners() {
   if (hybridInternalBackendSelectEl) {
     hybridInternalBackendSelectEl.addEventListener('change', () => {
       const value = String(hybridInternalBackendSelectEl.value || '').trim().toLowerCase();
-      if (!['vbap', 'barycenter', 'experimental_distance'].includes(value)) return;
+      if (!isValidHybridInner(value)) return;
       app.renderBackendState.hybrid.internalBackend = value;
       app.vbapRecomputing = true;
       renderVbapStatus();

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -167,19 +167,11 @@ export function rendererPanelMarkup() {
                 <div style="margin-top:0.2rem;margin-left:1rem;padding:0.3rem 0.4rem;background:rgba(255,255,255,0.03);border-radius:6px;display:grid;gap:0.3rem">
                   <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
                     <label for="hybridExternalBackendSelect" style="font-size:12px;white-space:nowrap;color:#ffffff" data-i18n="hybrid.external">External backend (ratio = 1)</label>
-                    <select id="hybridExternalBackendSelect" class="delay-input" style="min-width:9rem">
-                      <option value="vbap">VBAP</option>
-                      <option value="barycenter">Barycenter</option>
-                      <option value="experimental_distance">Distance</option>
-                    </select>
+                    <select id="hybridExternalBackendSelect" class="delay-input" style="min-width:9rem"></select>
                   </div>
                   <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
                     <label for="hybridInternalBackendSelect" style="font-size:12px;white-space:nowrap;color:#ffffff" data-i18n="hybrid.internal">Internal backend (ratio = 0)</label>
-                    <select id="hybridInternalBackendSelect" class="delay-input" style="min-width:9rem">
-                      <option value="vbap">VBAP</option>
-                      <option value="barycenter">Barycenter</option>
-                      <option value="experimental_distance">Distance</option>
-                    </select>
+                    <select id="hybridInternalBackendSelect" class="delay-input" style="min-width:9rem"></select>
                   </div>
                   <div class="control-row" style="margin-top:0;grid-template-columns:1fr auto;align-items:center">
                     <label for="hybridMetricSelect" style="font-size:12px;white-space:nowrap;color:#ffffff" data-i18n="distance.metric">Distance metric</label>


### PR DESCRIPTION
## Context

The `hybrid` render backend blends two inner backends ("external"/"internal") selected by id, but only the three historical built-ins (`vbap`/`barycenter`/`experimental_distance`) could be chosen — even though the renderer already hosts arbitrary backends through `BackendRegistry` (the `example` and scriptable Lua backends are registered at startup).

The restriction was **not** a single gate: it was duplicated across **six** independent hardcoded whitelists spanning the renderer, the OSC layer, the config loader, and both sides of the Studio round-trip. The symptom was that the inner-backend dropdowns listed every backend (they're registry-driven) but selecting anything past the 3 historical ones silently reverted.

## Changes

Widen every gate to consult the registry, so any registered backend **except a nested `hybrid`** can be an inner model:

- **`renderer/backend_registry.rs`** — `BackendBuildCtx` now carries the `registry`; `HybridFactory` resolves inner models through it via the new `resolve_hybrid_inner_plan` (rejecting nested hybrid). Realtime capability is now **recursive** (`inners_realtime_capable`): a non-realtime inner (e.g. the scriptable backend) forces the composite into a precomputed evaluation mode, so the interpreter never runs per sample.
- **`runtime_control/osc.rs`** — the `hybrid/{external,internal}_backend` handler validates against `has_backend` instead of a literal id match.
- **`orender_engine/renderer_build.rs`** — config-load validation resolves inner ids against the registry (moved after backend registration; falls back to the default for unregistered ids).
- **Studio host** — the Tauri commands (send side) and `init.js` state ingest (receive side) no longer drop non-historical ids; the inner-backend dropdowns are populated dynamically from `availableBackends` (minus `hybrid`).

## Tests

- New unit test `inners_realtime_capable_reflects_registry` for the recursive realtime gate.
- Full affected suite green (`renderer` / `orender_engine` / `runtime_control`), `cargo fmt --check` clean across both workspaces, JS syntax-checked.

## Out of scope

`evaluation_artifact.rs::build_backend_restore_snapshot` still only snapshots the 3 historical backends — that's the table export/restore path, unrelated to inner-backend selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)