### PR TITLE
feat(renderer): precompute object size as N+1 interval tables

### DIFF
--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -531,6 +531,12 @@ pub fn build_spatial_renderer(
                     requires_rebuild = true;
                 }
             }
+            if let Some(intervals) = render_cfg.and_then(|c| c.evaluation_object_size_intervals) {
+                if live.evaluation.object_size_intervals != intervals {
+                    live.evaluation.object_size_intervals = intervals;
+                    requires_rebuild = true;
+                }
+            }
             if let Some(hybrid) = hybrid_cfg {
                 if live.hybrid.external_backend_id != hybrid.external_backend_id
                     || live.hybrid.internal_backend_id != hybrid.internal_backend_id

--- a/omniphony-renderer/renderer/src/backend_registry.rs
+++ b/omniphony-renderer/renderer/src/backend_registry.rs
@@ -1159,6 +1159,8 @@ mod tests {
             },
             distance_model_metric: DistanceMetric::default(),
             distance_diffuse_metric: DistanceMetric::default(),
+            object_size_intervals: 0,
+            object_size_mode: crate::render_backend::SizeToSpreadMode::default(),
         }
     }
 

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -86,6 +86,10 @@ pub struct RenderConfig {
     pub evaluation_cartesian_z_size: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evaluation_cartesian_z_neg_size: Option<usize>,
+    /// Number of object-size intervals to precompute (0 = single table). Applies
+    /// to both precomputed evaluation modes; see `EvaluationLiveParams`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluation_object_size_intervals: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vbap_allow_negative_z: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -164,6 +164,10 @@ pub struct EvaluationLiveParams {
     pub position_interpolation: bool,
     pub cartesian: CartesianEvaluationParams,
     pub polar: PolarEvaluationParams,
+    /// Number of object-size intervals to precompute (0 = single table, the
+    /// default; `N` ⇒ `N + 1` size tables interpolated at read time). Applies to
+    /// both precomputed modes; ignored for backends without `supports_event_size`.
+    pub object_size_intervals: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -434,6 +438,8 @@ fn evaluation_build_config_from_live(
         },
         distance_model_metric: live.distance_model_metric,
         distance_diffuse_metric: live.distance_diffuse_metric,
+        object_size_intervals: live.evaluation.object_size_intervals,
+        object_size_mode: live.size_to_spread_mode,
     }
 }
 

--- a/omniphony-renderer/renderer/src/render_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend.rs
@@ -134,6 +134,16 @@ pub struct EvaluationBuildConfig {
     /// model and distance diffuse output stages (Spherical / Chebyshev).
     pub distance_model_metric: crate::spatial_vbap::DistanceMetric,
     pub distance_diffuse_metric: crate::spatial_vbap::DistanceMetric,
+    /// Number of object-size *intervals* to precompute. `0` (default) bakes a
+    /// single table at the build-time `event_size` (object size honoured only in
+    /// realtime). `N >= 1` builds `N + 1` tables at isotropic sizes `s_i = i / N`
+    /// and interpolates between them at read time, so the precomputed modes
+    /// honour object size. Only meaningful for backends whose capabilities report
+    /// `supports_event_size`. See [`SizeInterpolatingEvaluator`].
+    pub object_size_intervals: usize,
+    /// Policy used to reduce a `(w, d, h)` object-size triplet to the scalar that
+    /// indexes the size tables at read time (see [`reduce_size_to_spread`]).
+    pub object_size_mode: SizeToSpreadMode,
 }
 
 /// A gain model maps an object position (plus live render parameters) to a
@@ -556,6 +566,109 @@ impl PreparedEvaluator for SampledPolarEvaluator {
     }
 }
 
+/// Wraps `N + 1` position tables, each baked at a fixed isotropic object size
+/// `s_i = i / N`, and interpolates between the two bracketing tables at read time
+/// on the object's reduced size scalar. This is how the precomputed modes honour
+/// object size: a single table freezes it, so when `object_size_intervals > 0`
+/// the strategy builds several tables and wraps them here.
+///
+/// `cartesian_parts`/`polar_parts` return `None`, so a crossover layout with this
+/// evaluator does not build the unified multi-band table and falls back to the
+/// per-band `compute_gains` path (see `build_unified_table`). Table export is
+/// likewise unsupported here.
+pub struct SizeInterpolatingEvaluator {
+    model: Arc<dyn GainModel>,
+    /// Sorted ascending in `[0, 1]`; `sizes[i] = i / N`. `len() == inners.len()`,
+    /// always `>= 2` (built only when `intervals >= 1`).
+    sizes: Vec<f32>,
+    inners: Vec<Box<dyn PreparedEvaluator>>,
+    /// Policy reducing the request's `(w, d, h)` to the scalar that indexes `sizes`.
+    mode: SizeToSpreadMode,
+    speaker_count: usize,
+}
+
+impl SizeInterpolatingEvaluator {
+    /// Build `intervals + 1` inner evaluators at isotropic sizes `s_i = i /
+    /// intervals`, each via `build_inner` with a per-size config (object size
+    /// frozen to `[s_i; 3]`, its own interval count reset to 0 so the inner bakes
+    /// a single table).
+    fn new(
+        model: Arc<dyn GainModel>,
+        config: &EvaluationBuildConfig,
+        intervals: usize,
+        build_inner: impl Fn(Arc<dyn GainModel>, &EvaluationBuildConfig) -> Box<dyn PreparedEvaluator>,
+    ) -> Self {
+        let n = intervals.max(1);
+        let speaker_count = model.speaker_count();
+        let mut sizes = Vec::with_capacity(n + 1);
+        let mut inners = Vec::with_capacity(n + 1);
+        for i in 0..=n {
+            let s = i as f32 / n as f32;
+            let mut inner_config = *config;
+            inner_config.object_size_intervals = 0;
+            inner_config.request_template.event_size = [s, s, s];
+            sizes.push(s);
+            inners.push(build_inner(Arc::clone(&model), &inner_config));
+        }
+        Self {
+            model,
+            sizes,
+            inners,
+            mode: config.object_size_mode,
+            speaker_count,
+        }
+    }
+}
+
+impl PreparedEvaluator for SizeInterpolatingEvaluator {
+    fn speaker_count(&self) -> usize {
+        self.speaker_count
+    }
+
+    fn model_arc(&self) -> Option<Arc<dyn GainModel>> {
+        Some(Arc::clone(&self.model))
+    }
+
+    fn set_position_interpolation(&self, interpolate: bool) {
+        for inner in &self.inners {
+            inner.set_position_interpolation(interpolate);
+        }
+    }
+
+    fn compute_gains(&self, req: &RenderRequest) -> RenderResponse {
+        let pos = req.adm_position.map(|value| value as f32);
+        let query = reduce_size_to_spread(req.event_size, pos, self.mode).clamp(0.0, 1.0);
+        // Bracket the query size. `sizes` is sorted ascending and has >= 2 entries.
+        let last = self.sizes.len() - 1;
+        let mut hi = 1;
+        while hi < last && self.sizes[hi] < query {
+            hi += 1;
+        }
+        let lo = hi - 1;
+        let span = (self.sizes[hi] - self.sizes[lo]).max(1e-6);
+        let fraction = ((query - self.sizes[lo]) / span).clamp(0.0, 1.0);
+        let gains_lo = self.inners[lo].compute_gains(req).gains;
+        let gains_hi = self.inners[hi].compute_gains(req).gains;
+        let mut gains = Gains::zeroed(self.speaker_count);
+        for index in 0..self.speaker_count {
+            gains.set(
+                index,
+                gains_lo[index] * (1.0 - fraction) + gains_hi[index] * fraction,
+            );
+        }
+        RenderResponse { gains }
+    }
+
+    fn save_to_file(&self, path: &std::path::Path, speaker_layout: &SpeakerLayout) -> Result<()> {
+        std::fs::write(path, self.artifact_bytes(speaker_layout)?)?;
+        Ok(())
+    }
+
+    fn artifact_bytes(&self, _speaker_layout: &SpeakerLayout) -> Result<Vec<u8>> {
+        anyhow::bail!("object-size interval tables are not serializable yet")
+    }
+}
+
 pub struct RealtimeStrategy;
 
 impl EvaluationStrategy for RealtimeStrategy {
@@ -584,7 +697,18 @@ impl EvaluationStrategy for PrecomputedCartesianStrategy {
         model: Arc<dyn GainModel>,
         config: &EvaluationBuildConfig,
     ) -> Result<Box<dyn PreparedEvaluator>> {
-        Ok(Box::new(SampledCartesianEvaluator::new(model, config)))
+        if config.object_size_intervals > 0 && model.capabilities().supports_event_size {
+            Ok(Box::new(SizeInterpolatingEvaluator::new(
+                model,
+                config,
+                config.object_size_intervals,
+                |inner_model, inner_config| {
+                    Box::new(SampledCartesianEvaluator::new(inner_model, inner_config))
+                },
+            )))
+        } else {
+            Ok(Box::new(SampledCartesianEvaluator::new(model, config)))
+        }
     }
 }
 
@@ -600,7 +724,18 @@ impl EvaluationStrategy for PrecomputedPolarStrategy {
         model: Arc<dyn GainModel>,
         config: &EvaluationBuildConfig,
     ) -> Result<Box<dyn PreparedEvaluator>> {
-        Ok(Box::new(SampledPolarEvaluator::new(model, config)))
+        if config.object_size_intervals > 0 && model.capabilities().supports_event_size {
+            Ok(Box::new(SizeInterpolatingEvaluator::new(
+                model,
+                config,
+                config.object_size_intervals,
+                |inner_model, inner_config| {
+                    Box::new(SampledPolarEvaluator::new(inner_model, inner_config))
+                },
+            )))
+        } else {
+            Ok(Box::new(SampledPolarEvaluator::new(model, config)))
+        }
     }
 }
 
@@ -1783,5 +1918,155 @@ mod polar_lut_tests {
                 "azimuth seam mismatch at {pos}: want {want} got {got}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod size_interval_tests {
+    //! Object-size interval precompute: a `SizeInterpolatingEvaluator` built with
+    //! `object_size_intervals = N` bakes `N + 1` position tables at isotropic
+    //! sizes and interpolates between them at read time, so the precomputed modes
+    //! honour object size (a single table freezes it).
+    use super::*;
+    use crate::spatial_vbap::{DistanceMetric, DistanceModel, VbapPanner};
+
+    /// 4-speaker horizontal VBAP backend. `supports_event_size` is true and the
+    /// default spread range is [0, 1], so a non-zero `event_size` widens the pan.
+    fn make_model() -> Box<dyn GainModel> {
+        let positions = [[-30.0, 0.0], [30.0, 0.0], [-110.0, 0.0], [110.0, 0.0]];
+        let panner = VbapPanner::new(&positions, 5, 5, 0.0)
+            .expect("panner")
+            .with_negative_z(true);
+        Box::new(VbapBackend::new(panner, VbapSpreadParams::default()))
+    }
+
+    fn config(intervals: usize, event_size: [f32; 3]) -> EvaluationBuildConfig {
+        EvaluationBuildConfig {
+            request_template: RenderRequest {
+                adm_position: [0.0, 0.0, 0.0],
+                event_size,
+                room_ratio: [1.0, 1.0, 1.0],
+                room_ratio_rear: 1.0,
+                room_ratio_lower: 1.0,
+                room_ratio_center_blend: 0.0,
+                use_distance_diffuse: false,
+                distance_diffuse_threshold: 1.0,
+                distance_diffuse_curve: 1.0,
+                distance_model: DistanceModel::None,
+            },
+            position_interpolation: true,
+            cartesian: CartesianEvaluationConfig {
+                x_size: 9,
+                y_size: 9,
+                z_size: 5,
+                z_neg_size: 0,
+            },
+            polar: PolarEvaluationConfig {
+                azimuth_values: 16,
+                elevation_values: 7,
+                distance_values: 4,
+                distance_max: 1.0,
+                allow_negative_z: false,
+            },
+            distance_model_metric: DistanceMetric::default(),
+            distance_diffuse_metric: DistanceMetric::default(),
+            object_size_intervals: intervals,
+            object_size_mode: SizeToSpreadMode::Max,
+        }
+    }
+
+    fn request(pos: [f64; 3], size: [f32; 3]) -> RenderRequest {
+        let mut req = config(0, [0.0; 3]).request_template;
+        req.adm_position = pos;
+        req.event_size = size;
+        req
+    }
+
+    fn engine(
+        mode: EffectiveEvaluationMode,
+        intervals: usize,
+        frozen_size: [f32; 3],
+    ) -> PreparedRenderEngine {
+        build_prepared_render_engine(make_model(), mode, &config(intervals, frozen_size))
+            .expect("engine builds")
+    }
+
+    fn assert_close(a: &Gains, b: &Gains, eps: f32) {
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert!((x - y).abs() < eps, "{x} vs {y}");
+        }
+    }
+
+    /// At the sampled endpoints (size 0 and size 1) the interval engine reproduces
+    /// the single tables frozen at those sizes, and object size visibly matters.
+    fn endpoints_match_frozen_tables(mode: EffectiveEvaluationMode) {
+        let pos = [0.3, 0.1, 0.2];
+        let intervals = engine(mode, 1, [0.0; 3]);
+        let small = engine(mode, 0, [0.0; 3]);
+        let large = engine(mode, 0, [1.0; 3]);
+
+        let at_small = intervals.compute_gains(&request(pos, [0.0; 3])).gains;
+        let at_large = intervals.compute_gains(&request(pos, [1.0; 3])).gains;
+        assert_close(
+            &at_small,
+            &small.compute_gains(&request(pos, [0.0; 3])).gains,
+            1e-6,
+        );
+        assert_close(
+            &at_large,
+            &large.compute_gains(&request(pos, [1.0; 3])).gains,
+            1e-6,
+        );
+
+        let max_diff = at_small
+            .iter()
+            .zip(at_large.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert!(max_diff > 1e-3, "object size had no effect: {max_diff}");
+    }
+
+    #[test]
+    fn cartesian_endpoints_match_frozen_tables() {
+        endpoints_match_frozen_tables(EffectiveEvaluationMode::PrecomputedCartesian);
+    }
+
+    #[test]
+    fn polar_endpoints_match_frozen_tables() {
+        endpoints_match_frozen_tables(EffectiveEvaluationMode::PrecomputedPolar);
+    }
+
+    /// At a size between two sampled sizes the result is their linear blend
+    /// (N = 1 ⇒ sizes {0, 1}, query 0.5 ⇒ equal weights).
+    #[test]
+    fn cartesian_midpoint_is_blend_of_endpoints() {
+        let pos = [0.3, 0.1, 0.2];
+        let intervals = engine(EffectiveEvaluationMode::PrecomputedCartesian, 1, [0.0; 3]);
+        let small = engine(EffectiveEvaluationMode::PrecomputedCartesian, 0, [0.0; 3]);
+        let large = engine(EffectiveEvaluationMode::PrecomputedCartesian, 0, [1.0; 3]);
+
+        let mid = intervals.compute_gains(&request(pos, [0.5; 3])).gains;
+        let s = small.compute_gains(&request(pos, [0.0; 3])).gains;
+        let l = large.compute_gains(&request(pos, [1.0; 3])).gains;
+        for i in 0..mid.len() {
+            let expected = 0.5 * s[i] + 0.5 * l[i];
+            assert!(
+                (mid[i] - expected).abs() < 1e-6,
+                "i={i}: {} vs {expected}",
+                mid[i]
+            );
+        }
+    }
+
+    /// With intervals = 0 (the default) the single table freezes object size: the
+    /// request's `event_size` is ignored, matching the pre-feature behaviour.
+    #[test]
+    fn intervals_zero_freezes_object_size() {
+        let pos = [0.3, 0.1, 0.2];
+        let engine = engine(EffectiveEvaluationMode::PrecomputedCartesian, 0, [0.0; 3]);
+        let g0 = engine.compute_gains(&request(pos, [0.0; 3])).gains;
+        let g1 = engine.compute_gains(&request(pos, [1.0; 3])).gains;
+        assert_close(&g0, &g1, 1e-9);
     }
 }

--- a/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
@@ -443,6 +443,8 @@ mod tests {
             },
             distance_model_metric: crate::spatial_vbap::DistanceMetric::default(),
             distance_diffuse_metric: crate::spatial_vbap::DistanceMetric::default(),
+            object_size_intervals: 0,
+            object_size_mode: crate::render_backend::SizeToSpreadMode::default(),
         };
 
         let engine = build_prepared_render_engine(

--- a/omniphony-renderer/renderer/src/spatial_renderer/components.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/components.rs
@@ -83,6 +83,10 @@ pub(super) fn evaluation_build_config(
         // evaluation_build_config_from_live.
         distance_model_metric: crate::spatial_vbap::DistanceMetric::default(),
         distance_diffuse_metric: crate::spatial_vbap::DistanceMetric::default(),
+        // Single table on the initial build; a configured interval count is
+        // applied via live params (evaluation_build_config_from_live) on rebuild.
+        object_size_intervals: 0,
+        object_size_mode: crate::render_backend::SizeToSpreadMode::default(),
     }
 }
 

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -359,6 +359,7 @@ impl SpatialRenderer {
                     distance_res: (distance_max / distance_res.max(0.01)).round() as i32,
                     distance_max: distance_max.max(0.01),
                 },
+                object_size_intervals: 0,
             },
             use_loudness,
             auto_gain,

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -963,6 +963,27 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
+    if addr == "/omniphony/control/render_evaluation/object_size_intervals" {
+        let intervals = match msg.args.first() {
+            Some(OscType::Int(i)) => Some((*i).max(0) as usize),
+            Some(OscType::Float(f)) => Some(f.round().max(0.0) as usize),
+            _ => None,
+        };
+        if let Some(intervals) = intervals {
+            ctx.renderer.live.write().evaluation.object_size_intervals = intervals;
+            effects.mark_dirty = true;
+            effects.trigger_layout_recompute = true;
+            // Object-size interval count is evaluation-layer only: re-sample the
+            // tables, reuse the backend geometry.
+            effects.evaluation_only = true;
+            effects.broadcasts.push(BroadcastUpdate {
+                addr: "/omniphony/state/render_evaluation/object_size_intervals".to_string(),
+                value: BroadcastValue::Int(intervals as i32),
+            });
+        }
+        return Some(effects);
+    }
+
     if let Some(rest) = addr.strip_prefix("/omniphony/control/render_evaluation/polar/") {
         match rest {
             "azimuth_resolution" | "elevation_resolution" => {

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -107,6 +107,10 @@ pub fn save_live_config(
         render.evaluation_cartesian_z_size = None;
         render.evaluation_cartesian_z_neg_size = None;
     }
+    // Object-size interval count applies to both precomputed modes; persist it
+    // only when enabled (0 is the default and stays out of the file).
+    render.evaluation_object_size_intervals = (live.evaluation.object_size_intervals > 0)
+        .then_some(live.evaluation.object_size_intervals);
     // VBAP spread tuning (min/max, from_distance, distance range/curve, size
     // policy) now lives in the generic param bag (`render.backend_params`,
     // written above via `all_backend_params`). Drop the legacy dedicated keys on

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -133,6 +133,7 @@ pub fn build_renderer_state_json(
         "renderBackendEffective": effective_backend,
         "renderEvaluationMode": live.requested_evaluation_mode().as_str(),
         "renderEvaluationModeEffective": effective_evaluation_mode,
+        "objectSizeIntervals": live.evaluation.object_size_intervals,
         "masterGain": live.master_gain,
         "autoGain": live.auto_gain,
         "autoGainCeilingDb": live.auto_gain_ceiling_db,
@@ -383,6 +384,10 @@ pub fn build_live_state_bundle(
             } else {
                 0
             })],
+        }),
+        OscPacket::Message(OscMessage {
+            addr: "/omniphony/state/render_evaluation/object_size_intervals".to_string(),
+            args: vec![OscType::Int(live.evaluation.object_size_intervals as i32)],
         }),
         OscPacket::Message(OscMessage {
             addr: "/omniphony/state/log_level".to_string(),

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -340,6 +340,9 @@ pub struct AppState {
     pub render_backend_state: RenderBackendState,
     #[serde(rename = "renderEvaluationModeState")]
     pub render_evaluation_mode_state: RenderEvaluationModeState,
+    /// Number of object-size intervals precomputed (0 = single table).
+    #[serde(rename = "objectSizeIntervals")]
+    pub object_size_intervals: u32,
     #[serde(rename = "vbapAllowNegativeZ")]
     pub vbap_allow_negative_z: Option<bool>,
     #[serde(rename = "adaptiveResampling")]
@@ -643,6 +646,7 @@ impl Default for AppState {
             vbap_polar: VbapPolar::default(),
             render_backend_state: RenderBackendState::default(),
             render_evaluation_mode_state: RenderEvaluationModeState::default(),
+            object_size_intervals: 0,
             vbap_allow_negative_z: None,
             adaptive_resampling: Some(0),
             adaptive_resampling_enable_far_mode: Some(1),

--- a/omniphony-studio/src-tauri/src/commands/render.rs
+++ b/omniphony-studio/src-tauri/src/commands/render.rs
@@ -185,6 +185,17 @@ pub fn control_hybrid_curve(state: State<SharedState>, points: Vec<[f32; 2]>) {
 }
 
 #[tauri::command]
+pub fn control_render_evaluation_object_size_intervals(state: State<SharedState>, value: i32) {
+    send_control(
+        &state.osc_tx,
+        OscControlMsg::SendInt {
+            address: "/omniphony/control/render_evaluation/object_size_intervals".to_string(),
+            value: value.max(0),
+        },
+    );
+}
+
+#[tauri::command]
 pub fn control_render_evaluation_cartesian_x_size(state: State<SharedState>, value: i32) {
     send_control(
         &state.osc_tx,

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -213,6 +213,7 @@ fn main() {
             control_hybrid_curve,
             control_hybrid_metric,
             control_hybrid_curve_smoothing,
+            control_render_evaluation_object_size_intervals,
             control_render_evaluation_cartesian_x_size,
             control_render_evaluation_cartesian_y_size,
             control_render_evaluation_cartesian_z_size,

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -108,6 +108,7 @@ struct RendererDomainState {
     render_backend_effective: Option<String>,
     render_evaluation_mode: Option<String>,
     render_evaluation_mode_effective: Option<String>,
+    object_size_intervals: Option<u32>,
     master_gain: Option<f64>,
     auto_gain: Option<bool>,
     auto_gain_ceiling_db: Option<f64>,
@@ -567,6 +568,9 @@ fn apply_renderer_domain_state(s: &mut AppState, value: &str) -> bool {
     }
     if let Some(render_evaluation_mode_effective) = parsed.render_evaluation_mode_effective {
         s.render_evaluation_mode_state.effective = Some(render_evaluation_mode_effective);
+    }
+    if let Some(object_size_intervals) = parsed.object_size_intervals {
+        s.object_size_intervals = object_size_intervals;
     }
     if let Some(master_gain) = parsed.master_gain {
         s.master_gain = Some(master_gain);

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -272,6 +272,24 @@ export function renderEvaluationMode() {
     : nextValue;
   applyEvaluationModeVisibility(visibleMode);
   renderVbapPositionInterpolation();
+  renderObjectSizeIntervals();
+}
+
+// Sync the object-size interval count input, and hide it for backends that do
+// not consume object size (the precomputed size tables would have no effect).
+function renderObjectSizeIntervals() {
+  const rowEl = inRendererPanel('objectSizeIntervalsRow');
+  const inputEl = inRendererPanel('objectSizeIntervalsInput');
+  if (inputEl && document.activeElement !== inputEl) {
+    inputEl.value = String(app.objectSizeIntervals ?? 0);
+  }
+  if (rowEl) {
+    const caps = backendCapabilities();
+    // Show unless the active backend explicitly reports no event-size support.
+    const supportsSize = !caps
+      || (caps.supports_event_size !== false && caps.supportsEventSize !== false);
+    rowEl.style.display = supportsSize ? '' : 'none';
+  }
 }
 
 export function updateEvaluationMode() {

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -201,6 +201,7 @@
   "config.import": "Import layout",
   "config.export": "Export layout",
   "evaluation.title": "Evaluation",
+  "evaluation.objectSizeIntervals": "Object size intervals",
   "evaluation.infoButton": "Evaluation mode info",
   "evaluation.infoTitle": "Evaluation mode",
   "evaluation.infoBody": "Evaluation mode controls how speaker gains are computed for each object position.<br><br><strong>Realtime</strong> computes directly at runtime. <strong>Precomputed polar</strong> and <strong>precomputed cartesian</strong> trade memory for faster lookups and more stable cost. <strong>Auto</strong> lets the renderer choose the best available path for the current backend and tables.",

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -238,6 +238,9 @@ export function applyInitState(payload) {
       }
     }
   }
+  if (typeof payload.objectSizeIntervals === 'number' && payload.objectSizeIntervals >= 0) {
+    app.objectSizeIntervals = Math.round(payload.objectSizeIntervals);
+  }
   if (payload.renderEvaluationModeState && typeof payload.renderEvaluationModeState === 'object') {
     if (typeof payload.renderEvaluationModeState.selection === 'string') {
       const selection = payload.renderEvaluationModeState.selection.trim().toLowerCase();

--- a/omniphony-studio/src/listeners/renderer-panel-listeners.js
+++ b/omniphony-studio/src/listeners/renderer-panel-listeners.js
@@ -31,6 +31,7 @@ export function setupRendererPanelListeners() {
   const vbapPolarDistanceResInputEl = document.getElementById('vbapPolarDistanceResInput');
   const vbapPolarDistanceMaxInputEl = document.getElementById('vbapPolarDistanceMaxInput');
   const vbapPositionInterpolationToggleEl = document.getElementById('vbapPositionInterpolationToggleEl');
+  const objectSizeIntervalsInputEl = document.getElementById('objectSizeIntervalsInput');
   const distanceDiffuseToggleEl = document.getElementById('distanceDiffuseToggle');
   const distanceDiffuseThresholdSliderEl = document.getElementById('distanceDiffuseThresholdSlider');
   const distanceDiffuseThresholdValEl = document.getElementById('distanceDiffuseThresholdVal');
@@ -86,6 +87,18 @@ export function setupRendererPanelListeners() {
       renderVbapStatus();
       updateVbapCartesian();
       invoke('control_render_evaluation_cartesian_x_size', { value });
+    });
+  }
+
+  if (objectSizeIntervalsInputEl) {
+    objectSizeIntervalsInputEl.addEventListener('change', () => {
+      const value = Math.max(0, Math.round(Number(objectSizeIntervalsInputEl.value) || 0));
+      app.objectSizeIntervals = value;
+      objectSizeIntervalsInputEl.value = String(value);
+      app.vbapRecomputing = true;
+      renderVbapStatus();
+      updateEvaluationMode();
+      invoke('control_render_evaluation_object_size_intervals', { value });
     });
   }
 

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -117,6 +117,8 @@ export const app = {
   vbapCartesianState: { xSize: null, ySize: null, zSize: null, zNegSize: 0 },
   vbapPolarState: { azimuthResolution: null, elevationResolution: null, distanceRes: null, distanceMax: null },
   evaluationModeState: { selection: null, effective: null },
+  // Number of object-size intervals precomputed (0 = single table).
+  objectSizeIntervals: 0,
   renderBackendState: {
     selection: null,
     effective: null,

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -109,6 +109,12 @@ export function rendererPanelMarkup() {
               </div>
               <input id="vbapPositionInterpolationToggleEl" type="checkbox" />
             </div>
+            <div class="control-row" id="objectSizeIntervalsRow" style="margin-top:0.25rem;grid-template-columns:1fr auto;align-items:center">
+              <div class="title-with-info" style="min-width:0">
+                <span style="font-size:12px;white-space:nowrap;color:#ffffff" data-i18n="evaluation.objectSizeIntervals" title="Object-size intervals to precompute: 0 = single table (size honoured only in realtime); N = N+1 tables interpolated at read time.">Object size intervals</span>
+              </div>
+              <input id="objectSizeIntervalsInput" class="delay-input" type="number" min="0" step="1" style="width:5rem" />
+            </div>
             </div>
           </div>
           <div class="info-section renderer-subpanel" id="rampSection" style="margin:0;padding:0.4rem 0.5rem;border:1px solid rgba(255,255,255,0.08);border-radius:8px;background:rgba(255,255,255,0.03)">


### PR DESCRIPTION
## Context

The sampled (precomputed) evaluators baked a **single table** with `event_size` frozen at the build-time value, so object-size spread was honoured **only in realtime** evaluation. (A multi-spread-table file format once existed but is now dead code; its generator was removed in `e45cddc`.)

This adds an opt-in **evaluation field = number of object-size intervals `N`**:

- `N = 0` (default): one table — unchanged, no extra cost.
- `N = 1`: 2 tables (sizes 0 and 1); `N = 2`: 3 tables (0, 0.5, 1) … general `N+1` tables at `s_i = i/N`, interpolated at read time, so the precomputed modes finally honour object size at `(N+1)×` table memory.

## Implementation

- **`SizeInterpolatingEvaluator`** (`render_backend.rs`) wraps `N+1` ordinary sampled evaluators, each built at a fixed isotropic `event_size = [s_i; 3]`, and blends the two bracketing tables at read time on the request's reduced size scalar (`reduce_size_to_spread` with the configured `SizeToSpreadMode`). Wired into the precomputed cartesian/polar strategies, guarded by `model.capabilities().supports_event_size`.
- Its `cartesian_parts`/`polar_parts` return `None`, so a crossover layout with sizes on skips the unified multi-band table and uses the **correct per-band path** (`build_unified_table` already falls back via `?`). Table export is unsupported while `N>0`. Both documented in code.
- `object_size_intervals` threads through `EvaluationBuildConfig` + `EvaluationLiveParams` + `evaluation_build_config_from_live`, OSC (`/omniphony/control/render_evaluation/object_size_intervals`, evaluation-only rebuild), config load (`evaluation_object_size_intervals`), persistence, the state snapshot, and the Studio UI (evaluation-section numeric input, shown only for event-size-capable backends).

## Tests

New renderer unit tests (cartesian + polar): endpoints reproduce the frozen size-0 / size-1 tables, the midpoint is their linear blend, object size visibly changes the output, and `N = 0` still freezes object size. Existing `unified_crossover_matches_per_band` / `unified_polar_matches_per_band` still pass. `cargo fmt --check`, full build, and `cargo test -p renderer -p runtime_control -p orender_engine` all green.

## Notes / limits (v1)

- Memory scales `×(N+1)`; default `N=0` adds nothing.
- While `N>0`: unified crossover table disabled (per-band path) and table export unsupported — both acceptable for an opt-in feature, flagged for follow-up.
- Read-time reduction uses the configured `SizeToSpreadMode`; exact at sampled sizes for isotropic objects, a reduction-based approximation otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)