### PR TITLE
feat(studio): pin the speaker editor so it stays visible while editing

### DIFF
--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -454,6 +454,8 @@
         </div>
         <div id="speakersList" class="info-list">No speakers.</div>
       </div>
+      </div>
+      <!-- Speaker editor pinned below the scroll so it stays visible while editing. -->
       <div class="info-section" id="speakerEditSection" style="display:none">
         <div class="info-title" id="speakerEditTitle" data-i18n="section.speakerEditor">Speaker Editor</div>
         <div class="editor-row" style="margin-bottom:0.35rem">
@@ -527,7 +529,6 @@
             <input id="speakerEditFreqHighInput" class="delay-input" type="number" min="0" step="10" placeholder="full range" />
           </div>
         </div>
-      </div>
       </div>
     </div>
 

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -159,6 +159,20 @@
         min-height: auto;
       }
 
+      /* Speaker editor pinned below the right-overlay scroll: the rest (audio,
+         renderer, speaker list) keeps scrolling in #speakersOverlayScroll, while
+         this temporary editing panel stays visible at the bottom. Bounded height
+         with internal scroll so a tall editor never starves the scroll above. */
+      #speakersOverlay > #speakerEditSection {
+        flex: 0 0 auto;
+        width: 100%;
+        min-height: auto;
+        box-sizing: border-box;
+        padding-right: 0.85rem;
+        max-height: 45vh;
+        overflow-y: auto;
+      }
+
       .app-brand {
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Summary

The temporary **Speaker Editor** panel lived inside the right overlay's global scroll, so it scrolled away while you were editing a speaker. Pin **only that panel** at the bottom of the overlay, outside the scroll; everything else (audio, renderer, speakers list) keeps scrolling together in its **original order**.

## Changes

- **index.html** — `#speakersOverlayScroll` now closes right after the speakers list, so the scroll holds audio + renderer + the speakers list (unchanged order). `#speakerEditSection` is moved just below the scroll as a fixed child of `#speakersOverlay`, so it stays visible while editing. Collapse still hides it (the existing `#speakersOverlay.panel-collapsed > *:not(...)` rule covers direct children).
- **app.css** — pin `#speakerEditSection` (`flex: 0 0 auto`) with a `45vh` max-height + internal `overflow-y:auto`, so a tall editor never starves the scroll area above (fixed overlay extents, bounded height, internal overflow).
- `speakers.js` unchanged — the speakers list stays in the scroll, so its existing flex proportioning is kept.

The overlay is `position: fixed` with unchanged extents → 3D viewport geometry is unaffected. The editor is `display:none` until a speaker is selected, so it only occupies space while editing.

## Testing

Frontend only; the moved markup is a balanced relocation (div open/close count unchanged). Reload Studio, select a speaker: the editor stays pinned at the bottom while the audio/renderer/speaker-list content scrolls above it; collapsing the overlay still hides everything.