### PR TITLE
feat(studio): move the 3D Edit buttons beside the coord tables

### DIFF
--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -476,42 +476,46 @@
                 <input id="speakerEditCartesianMode" type="radio" name="speakerCoordMode" value="cartesian" />
                 <strong data-i18n="common.cartesian">Cartesian:</strong>
               </label>
-              <button id="speakerEditCartesianGizmoBtn" type="button" class="toggle-btn" data-i18n="speaker.edit3d">3D Edit</button>
             </div>
-            <div class="cart-coord-table">
-              <span class="cart-coord-corner" aria-hidden="true"></span>
-              <span class="cart-coord-head" title="Omniphony X (left/right)">X</span>
-              <span class="cart-coord-head" title="Omniphony Y (rear/front)">Y</span>
-              <span class="cart-coord-head" title="Omniphony Z (down/up)">Z</span>
-              <span class="cart-coord-rowlabel" data-i18n="speaker.normalizedCoords">Norm.</span>
-              <input id="speakerEditXInput" type="number" step="0.001" title="Omniphony X (left/right)" />
-              <input id="speakerEditYInput" type="number" step="0.001" title="Omniphony Y (rear/front)" />
-              <input id="speakerEditZInput" type="number" step="0.001" title="Omniphony Z (down/up)" />
-              <span class="cart-coord-rowlabel" data-i18n="speaker.metersCoords" data-help-i18n="help.speaker.positionMeters" data-help-anchor=".editor-meta">Real (m)</span>
-              <input id="speakerEditXMetersInput" type="number" step="0.01" title="Omniphony X in meters (left/right)" />
-              <input id="speakerEditYMetersInput" type="number" step="0.01" title="Omniphony Y in meters (rear/front)" />
-              <input id="speakerEditZMetersInput" type="number" step="0.01" title="Omniphony Z in meters (down/up)" />
+            <div class="coord-table-row">
+              <div class="cart-coord-table">
+                <span class="cart-coord-corner" aria-hidden="true"></span>
+                <span class="cart-coord-head" title="Omniphony X (left/right)">X</span>
+                <span class="cart-coord-head" title="Omniphony Y (rear/front)">Y</span>
+                <span class="cart-coord-head" title="Omniphony Z (down/up)">Z</span>
+                <span class="cart-coord-rowlabel" data-i18n="speaker.normalizedCoords">Norm.</span>
+                <input id="speakerEditXInput" type="number" step="0.001" title="Omniphony X (left/right)" />
+                <input id="speakerEditYInput" type="number" step="0.001" title="Omniphony Y (rear/front)" />
+                <input id="speakerEditZInput" type="number" step="0.001" title="Omniphony Z (down/up)" />
+                <span class="cart-coord-rowlabel" data-i18n="speaker.metersCoords" data-help-i18n="help.speaker.positionMeters" data-help-anchor=".editor-meta">Real (m)</span>
+                <input id="speakerEditXMetersInput" type="number" step="0.01" title="Omniphony X in meters (left/right)" />
+                <input id="speakerEditYMetersInput" type="number" step="0.01" title="Omniphony Y in meters (rear/front)" />
+                <input id="speakerEditZMetersInput" type="number" step="0.01" title="Omniphony Z in meters (down/up)" />
+              </div>
+              <button id="speakerEditCartesianGizmoBtn" type="button" class="toggle-btn" data-i18n="speaker.edit3d">3D Edit</button>
             </div>
             <div class="coord-mode-row">
               <label class="coord-mode-label" for="speakerEditPolarMode">
                 <input id="speakerEditPolarMode" type="radio" name="speakerCoordMode" value="polar" />
                 <strong data-i18n="common.polar">Polar:</strong>
               </label>
-              <button id="speakerEditPolarGizmoBtn" type="button" class="toggle-btn" data-i18n="speaker.edit3d">3D Edit</button>
             </div>
-            <div class="cart-coord-table">
-              <span class="cart-coord-corner" aria-hidden="true"></span>
-              <span class="cart-coord-head" title="Azimuth (degrees)">Az°</span>
-              <span class="cart-coord-head" title="Elevation (degrees)">El°</span>
-              <span class="cart-coord-head" title="Distance">Dist</span>
-              <span class="cart-coord-rowlabel" data-i18n="speaker.normalizedCoords">Norm.</span>
-              <input id="speakerEditAzInput" type="number" step="0.1" title="Azimuth (degrees)" />
-              <input id="speakerEditElInput" type="number" step="0.1" title="Elevation (degrees)" />
-              <input id="speakerEditRInput" type="number" step="0.001" min="0.01" title="Distance" />
-              <span class="cart-coord-rowlabel" data-i18n="speaker.metersCoords" data-help-i18n="help.speaker.positionMeters" data-help-anchor=".editor-meta">Real (m)</span>
-              <span aria-hidden="true"></span>
-              <span aria-hidden="true"></span>
-              <input id="speakerEditRMetersInput" type="number" step="0.01" min="0.01" title="Distance in meters" />
+            <div class="coord-table-row">
+              <div class="cart-coord-table">
+                <span class="cart-coord-corner" aria-hidden="true"></span>
+                <span class="cart-coord-head" title="Azimuth (degrees)">Az°</span>
+                <span class="cart-coord-head" title="Elevation (degrees)">El°</span>
+                <span class="cart-coord-head" title="Distance">Dist</span>
+                <span class="cart-coord-rowlabel" data-i18n="speaker.normalizedCoords">Norm.</span>
+                <input id="speakerEditAzInput" type="number" step="0.1" title="Azimuth (degrees)" />
+                <input id="speakerEditElInput" type="number" step="0.1" title="Elevation (degrees)" />
+                <input id="speakerEditRInput" type="number" step="0.001" min="0.01" title="Distance" />
+                <span class="cart-coord-rowlabel" data-i18n="speaker.metersCoords" data-help-i18n="help.speaker.positionMeters" data-help-anchor=".editor-meta">Real (m)</span>
+                <span aria-hidden="true"></span>
+                <span aria-hidden="true"></span>
+                <input id="speakerEditRMetersInput" type="number" step="0.01" min="0.01" title="Distance in meters" />
+              </div>
+              <button id="speakerEditPolarGizmoBtn" type="button" class="toggle-btn" data-i18n="speaker.edit3d">3D Edit</button>
             </div>
           </div>
           <div class="editor-row gain-row">

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -2154,6 +2154,21 @@
         border-color: rgba(255, 255, 255, 0.45);
       }
 
+      .coord-table-row {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+      }
+
+      .coord-table-row .cart-coord-table {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      .coord-table-row .toggle-btn {
+        flex: 0 0 auto;
+      }
+
       .cart-coord-table {
         display: grid;
         grid-template-columns: auto repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
Moves each **3D Edit** button out of its Cartesian/Polar mode row and places it **to the right of its coordinate table**, vertically centred.

- New `.coord-table-row` flex wrapper holds the table (`flex: 1`) and the button (`flex: 0 0 auto`) side by side.
- The mode row now carries only the `Cartesian:` / `Polar:` radio + label.
- Button ids are unchanged, so the existing gizmo listeners keep working.

Frontend only — `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)