### PR TITLE
feat(studio): re-enable overlay backdrop blur with a canvas DnD guard

### DIFF
--- a/docs/webgl-compositor-aliasing.md
+++ b/docs/webgl-compositor-aliasing.md
@@ -2,6 +2,29 @@
 
 Note interne sur une classe de bug récurrente dans Omniphony Studio sous Tauri Linux. À lire avant d'ajouter quoi que ce soit qui chevauche le canvas WebGL ou de proposer une solution dynamique de blur, glow, ou snapshot du viewport 3D.
 
+> ## Resolution (2026-06, WebKitGTK 2.52.4) — backdrop blur re-enabled
+>
+> The overlay backdrop blur is back on the left/right panels and the expanded
+> log overlay. Re-tested on WebKitGTK **2.52.4** (webkit2gtk-4.1): the broad
+> triggers from the historical record (panel resize, visibility transitions) no
+> longer reproduce on this version. The **one remaining trigger** was a native
+> HTML5 drag accidentally started by an orbit-drag on the WebGL canvas — the OS
+> drag ghost is a compositor snapshot, and dropping it aliases the sprite
+> textures (the classic corruption).
+>
+> Fix / guard: a `dragstart` `preventDefault` scoped to `#omniphony-renderer-mount`
+> (in `scene/setup.js`, on the persistent mount) plus `-webkit-user-drag: none`
+> on the canvas. This blocks only native drag *originating in the 3D canvas* — the
+> speaker list's own drag-to-reorder and all pointer/slider/text input are
+> untouched. With that guard in place, native `backdrop-filter: blur()` is safe
+> again. Defense-in-depth kept from the earlier mitigation: blur is still reset to
+> `none` while a panel is collapsed or being resized.
+>
+> The historical analysis below stays as the decision record — and the hard rule
+> still holds for **other** compositor-promoting properties (`filter`, extra
+> stacked canvases, `will-change`, etc.); only the orbit-drag DnD trigger has been
+> understood and neutralised.
+
 ## Symptôme
 
 Des sprites Three.js (typiquement les labels de sources et de HP, mais aussi les graduations du gizmo) affichent un contenu qui n'est pas le leur :
@@ -50,6 +73,11 @@ Commit `3a243fa`, annulé par `d4ca167`. Hypothèse : si on insère un `<canvas>
 Test rapide non commité (`#omniphony-renderer-mount { isolation: isolate; contain: paint; transform: translateZ(0); }`). Réfuté empiriquement : promouvoir explicitement le canvas WebGL en couche compositeur casse les labels dès le boot. La promotion crée le contexte exact qui produit l'aliasing.
 
 ## Options pour récupérer un effet de blur sur les panneaux
+
+> **Superseded — see "Resolution (2026-06)" at the top.** On WebKitGTK 2.52.4
+> native `backdrop-filter` is viable once the orbit-drag native-DnD trigger is
+> neutralised; the fallbacks below were written when no dynamic solution was
+> known and are kept for context.
 
 Aucune solution dynamique connue à ce jour ne tient sous WebKitGTK. Les pistes restantes sont :
 

--- a/omniphony-studio/README.md
+++ b/omniphony-studio/README.md
@@ -96,7 +96,8 @@ Ce script applique `NO_STRIP=true` et permet de générer les trois formats, y c
   Raison : l’overlay peut remonter, remplacer ou réinitialiser des sous-arbres. Une ref capturée hors timing casse facilement la synchro UI et empêche d’isoler proprement le viewport 3D du reste du DOM.
   En review, considérer comme odeur d’architecture tout accès DOM persistant à un panneau monté dynamiquement.
 - Couches compositeur au-dessus du canvas WebGL :
-  aucun élément promu en couche compositeur GPU ne doit chevaucher `#omniphony-renderer-mount`. Ça inclut `backdrop-filter`, `filter`, et l'ajout d'un canvas supplémentaire au-dessus du canvas WebGL. Sinon : aliasing avec les `CanvasTexture` des sprites, labels qui affichent une copie du viewport ou une autre texture. Voir `../docs/webgl-compositor-aliasing.md` pour le mécanisme, les tentatives ratées, et les options encore ouvertes pour récupérer un effet de blur.
+  aucun élément promu en couche compositeur GPU ne doit chevaucher `#omniphony-renderer-mount`. Ça inclut `filter`, et l'ajout d'un canvas supplémentaire au-dessus du canvas WebGL. Sinon : aliasing avec les `CanvasTexture` des sprites, labels qui affichent une copie du viewport ou une autre texture.
+  Update (2026-06, WebKitGTK 2.52.4): `backdrop-filter: blur()` on the side/log overlays is allowed again, guarded by a canvas-scoped native-DnD block (the orbit-drag trigger). See `../docs/webgl-compositor-aliasing.md` → "Resolution" before touching it. The rule above still applies to every other compositor-promoting property.
 
 ## Messages envoyés par le studio vers le renderer
 

--- a/omniphony-studio/src/scene/setup.js
+++ b/omniphony-studio/src/scene/setup.js
@@ -46,6 +46,14 @@ function getRendererMount() {
   mount.style.zIndex = '0';
   mount.style.pointerEvents = 'auto';
   mount.style.overflow = 'hidden';
+  // Block native HTML5 drag starting inside the 3D canvas. On WebKitGTK an
+  // orbit-drag could otherwise kick off a native drag-and-drop whose drag
+  // image is a compositor snapshot; dropping it aliases the sprite textures
+  // with the backdrop and corrupts the labels (see
+  // docs/webgl-compositor-aliasing.md). Scoped to the mount, so the speaker
+  // list's own drag-to-reorder is unaffected; the mount persists across canvas
+  // rebuilds so one listener is enough.
+  mount.addEventListener('dragstart', (event) => event.preventDefault());
   document.body.prepend(mount);
   return mount;
 }

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -13,11 +13,24 @@
         background: #0a0b10;
       }
 
+      /* Stop the WebGL canvas from being picked up as a native drag source.
+         An orbit-drag could otherwise start a native drag-and-drop whose drag
+         image is a compositor snapshot; dropping it aliases the sprite textures
+         (see docs/webgl-compositor-aliasing.md). This is the guard that lets the
+         overlay backdrop blur below stay enabled safely. */
+      #omniphony-renderer-mount,
+      #omniphony-renderer-mount canvas {
+        -webkit-user-drag: none;
+        user-select: none;
+      }
+
       #overlay {
         position: fixed;
         top: 1rem;
         left: 1rem;
         background: rgba(0, 0, 0, 0.5);
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
         border: 1px solid rgba(255, 255, 255, 0.2);
         border-radius: 12px;
         padding: 0.75rem 1rem;
@@ -38,6 +51,7 @@
         overflow: visible;
         background: transparent;
         border: none;
+        -webkit-backdrop-filter: none;
         backdrop-filter: none;
         height: auto;
       }
@@ -124,6 +138,7 @@
       body.overlay-layout-resizing #overlay,
       body.overlay-layout-resizing #speakersOverlay,
       body.overlay-layout-resizing #logOverlay.expanded {
+        -webkit-backdrop-filter: none;
         backdrop-filter: none;
         transition: none !important;
       }
@@ -410,6 +425,8 @@
         top: 1rem;
         right: 1rem;
         background: rgba(0, 0, 0, 0.5);
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
         border: 1px solid rgba(255, 255, 255, 0.2);
         border-radius: 12px;
         padding: 0.75rem 1rem;
@@ -458,6 +475,7 @@
         background: transparent;
         border: 0;
         border-radius: 0;
+        -webkit-backdrop-filter: none;
         backdrop-filter: none;
         box-shadow: none;
         padding: 0;
@@ -465,6 +483,8 @@
 
       #logOverlay.expanded {
         background: rgba(8, 11, 18, 0.42);
+        -webkit-backdrop-filter: blur(10px);
+        backdrop-filter: blur(10px);
         border: 1px solid rgba(255, 255, 255, 0.14);
         border-radius: 14px;
         box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## What

Restores `backdrop-filter: blur()` on the **left** (`#overlay`) and **right** (`#speakersOverlay`) panels and the **expanded log overlay** (`#logOverlay.expanded`).

## Why it's safe now

Re-tested on **WebKitGTK 2.52.4** (webkit2gtk-4.1). The historical compositor texture-aliasing bug (`docs/webgl-compositor-aliasing.md`) no longer fires on the broad triggers (panel resize, visibility transitions). The **only** remaining trigger was a native HTML5 drag accidentally started by an **orbit-drag on the WebGL canvas** — the OS drag ghost is a compositor snapshot, and dropping it aliased the Three.js sprite textures (labels showing a copy of the viewport).

## Guard

- `dragstart` `preventDefault` **scoped to `#omniphony-renderer-mount`** (registered once on the persistent mount in `scene/setup.js`) + `-webkit-user-drag: none` on the canvas.
- Blocks only native drag *originating in the 3D canvas*. The speaker list's own native drag-to-reorder, sliders, and text input are untouched.
- Both `-webkit-` and unprefixed `backdrop-filter` are set (WebKitGTK honours the prefixed one); the collapsed/resizing guards reset **both** so blur stays off in those states (defense-in-depth).

## Docs

`docs/webgl-compositor-aliasing.md` moves from "unsolved" to a "Resolution" section; the studio README rule is updated. The hard rule still holds for every **other** compositor-promoting property (`filter`, extra stacked canvases, `will-change`, …).

Frontend only — `vite build` passes. Validated interactively on WebKitGTK 2.52.4 (orbit-drag stress + speaker reorder still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)