### PR TITLE
feat(studio): make the overlay panels a bit more opaque

### DIFF
--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -28,7 +28,7 @@
         position: fixed;
         top: 1rem;
         left: 1rem;
-        background: rgba(0, 0, 0, 0.5);
+        background: rgba(0, 0, 0, 0.65);
         -webkit-backdrop-filter: blur(8px);
         backdrop-filter: blur(8px);
         border: 1px solid rgba(255, 255, 255, 0.2);
@@ -424,7 +424,7 @@
         position: fixed;
         top: 1rem;
         right: 1rem;
-        background: rgba(0, 0, 0, 0.5);
+        background: rgba(0, 0, 0, 0.65);
         -webkit-backdrop-filter: blur(8px);
         backdrop-filter: blur(8px);
         border: 1px solid rgba(255, 255, 255, 0.2);
@@ -482,7 +482,7 @@
       }
 
       #logOverlay.expanded {
-        background: rgba(8, 11, 18, 0.42);
+        background: rgba(8, 11, 18, 0.58);
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
         border: 1px solid rgba(255, 255, 255, 0.14);


### PR DESCRIPTION
Raises the panel background alpha so they're a little less see-through, keeping the backdrop blur:

- `#overlay` / `#speakersOverlay`: `rgba(0,0,0,0.5)` → `rgba(0,0,0,0.65)`
- `#logOverlay.expanded`: `rgba(8,11,18,0.42)` → `rgba(8,11,18,0.58)`

Frontend only — `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)