### PR TITLE
fix(studio): don't let speaker-row text selection block selecting the speaker

### DIFF
--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -1854,6 +1854,12 @@
         gap: 0.45rem;
         align-items: stretch;
         position: relative;
+        /* The row is a click target (select the speaker); its labels (name, dB,
+           cutoffs) aren't meant to be selected as text — a click-drag on the dB
+           value would otherwise start a text selection instead of selecting the
+           speaker. No text inputs live in this row, so this is safe. */
+        -webkit-user-select: none;
+        user-select: none;
       }
 
       /* Clip indicator: flash just the speaker's name chip, not the whole row. */


### PR DESCRIPTION
The dB value (and the other labels) in a speaker-list row were selectable, so a click-drag on the dB text started a **text selection** instead of selecting the speaker.

The row is a click target and contains no text inputs, so disable text selection on `.speaker-item` (`user-select: none`, plus the `-webkit-` prefix for WebKitGTK). Clicks now always select the speaker.

Frontend only — `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)