### PR TITLE
fix(studio): let clicks on the speaker dB/filter readouts select the speaker

### DIFF
--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -1862,6 +1862,16 @@
         user-select: none;
       }
 
+      /* The dB value and the filter glyph are readouts, not controls — let clicks
+         fall through to the row so clicking them selects the speaker. The dB value
+         in particular is rewritten continuously by the meter loop, so making it a
+         hit target also dropped clicks when its text node churned mid-click. The
+         M/S buttons and the drag-handle name chip keep their own pointer events. */
+      .speaker-item .fixed-metric,
+      .speaker-item .speaker-filter-icon {
+        pointer-events: none;
+      }
+
       /* Clip indicator: flash just the speaker's name chip, not the whole row. */
       .speaker-item .id-strip.clip-flash {
         animation: speaker-clip-flash 1s ease-out;


### PR DESCRIPTION
Clicking the **dB value** (or the filter glyph) didn't select the speaker, while clicking anywhere else on the row did.

Root cause: the dB value is a readout rewritten continuously by the meter loop (~10–20 Hz). As a hit target, a click landing on it got dropped when its text node was replaced mid-click. (Removing text selection in #74 exposed this — the click never reached the row's handler.)

Fix: mark the readouts (`.fixed-metric` dB value + `.speaker-filter-icon`) `pointer-events: none` so clicks fall through to the row and select the speaker. The M/S buttons and the drag-handle name chip keep their own pointer events.

Frontend only — `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)