### PR TITLE
feat(studio): collapsible auto-gain under Master, gauge beside the title

### DIFF
--- a/omniphony-studio/src/app.js
+++ b/omniphony-studio/src/app.js
@@ -49,7 +49,8 @@ import {
   setInputSectionOpen,
   setRendererSectionOpen,
   setDisplaySectionOpen,
-  setDrcSectionOpen
+  setDrcSectionOpen,
+  setAutoGainSectionOpen
 } from './modals.js';
 
 // ── Initialization & wiring ─────────────────────────────────────────────────
@@ -230,6 +231,7 @@ setInputSectionOpen(false);
 setRendererSectionOpen(false);
 setDisplaySectionOpen(false);
 setDrcSectionOpen(false);
+setAutoGainSectionOpen(false);
 
 // Register UI event listeners
 initRenderSurfaceController({

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -457,6 +457,7 @@
   "distance.title": "Distance Diffuse",
   "autoGain.title": "Auto-gain (anti-clip)",
   "autoGain.ceiling": "Ceiling",
+  "autoGain.toggle": "Auto-gain settings",
   "distance.model": "Distance model",
   "distance.metric": "Distance metric",
   "distance.metric.spherical": "Spherical",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -383,6 +383,7 @@
   "distance.title": "Distance Diffuse",
   "autoGain.title": "Gain auto (anti-clip)",
   "autoGain.ceiling": "Plafond",
+  "autoGain.toggle": "Réglages du gain auto",
   "distance.model": "Modèle de distance",
   "distance.metric": "Métrique de distance",
   "distance.metric.spherical": "Sphérique",

--- a/omniphony-studio/src/listeners/modal-and-toggle-listeners.js
+++ b/omniphony-studio/src/listeners/modal-and-toggle-listeners.js
@@ -10,7 +10,8 @@ import {
   setInputClockInfoModalOpen, setInputLfeInfoModalOpen,
   setDrcInfoModalOpen, setHeatmapInfoModalOpen,
   setTelemetryGaugesOpen,
-  setDisplaySectionOpen, setDrcSectionOpen, setAudioOutputSectionOpen, setInputSectionOpen, setRendererSectionOpen
+  setDisplaySectionOpen, setDrcSectionOpen, setAudioOutputSectionOpen, setInputSectionOpen, setRendererSectionOpen,
+  setAutoGainSectionOpen
 } from '../modals.js';
 import { closeAutoTuneWizardOnEscape } from '../auto-tune/wizard-ui.js';
 
@@ -269,6 +270,7 @@ export function setupModalAndToggleListeners() {
   const audioOutputSectionToggleBtnEl = document.getElementById('audioOutputSectionToggleBtn');
   const inputSectionToggleBtnEl = document.getElementById('inputSectionToggleBtn');
   const rendererSectionToggleBtnEl = document.getElementById('rendererSectionToggleBtn');
+  const autoGainSectionToggleBtnEl = document.getElementById('autoGainSectionToggleBtn');
 
   if (telemetryGaugesToggleBtnEl) {
     telemetryGaugesToggleBtnEl.addEventListener('click', () => {
@@ -297,6 +299,12 @@ export function setupModalAndToggleListeners() {
   if (inputSectionToggleBtnEl) {
     inputSectionToggleBtnEl.addEventListener('click', () => {
       setInputSectionOpen(!app.inputSectionOpen);
+    });
+  }
+
+  if (autoGainSectionToggleBtnEl) {
+    autoGainSectionToggleBtnEl.addEventListener('click', () => {
+      setAutoGainSectionOpen(!app.autoGainSectionOpen);
     });
   }
 

--- a/omniphony-studio/src/modals.js
+++ b/omniphony-studio/src/modals.js
@@ -244,6 +244,19 @@ export function setAudioOutputSectionOpen(open) {
   emitOverlayLayoutChanged('audio-output-section-toggle');
 }
 
+export function setAutoGainSectionOpen(open) {
+  app.autoGainSectionOpen = Boolean(open);
+  const content = document.getElementById('autoGainSection');
+  const toggleBtn = document.getElementById('autoGainSectionToggleBtn');
+  if (content) {
+    content.classList.toggle('open', app.autoGainSectionOpen);
+  }
+  if (toggleBtn) {
+    toggleBtn.textContent = app.autoGainSectionOpen ? '▾' : '▸';
+  }
+  emitOverlayLayoutChanged('auto-gain-section-toggle');
+}
+
 export function setInputSectionOpen(open) {
   const inputSectionContentEl = getInputSectionContentEl();
   const inputSummaryEl = getInputSummaryEl();

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -329,6 +329,7 @@ export const app = {
   rendererSectionOpen: false,
   displaySectionOpen: false,
   drcSectionOpen: false,
+  autoGainSectionOpen: false,
 
   // Selection & drag
   selectedSourceId: null,

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -1355,6 +1355,15 @@
         gap: 0.4rem;
       }
 
+      /* Master section header: title + level gauge on one line, with the
+         auto-gain collapse toggle on the right. The gain slider below and this
+         gauge stay visible when the auto-gain block is collapsed. */
+      .master-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
       .fixed-metric {
         width: 8ch;
         min-width: 8ch;

--- a/omniphony-studio/src/ui/audio-panel.js
+++ b/omniphony-studio/src/ui/audio-panel.js
@@ -255,28 +255,31 @@ export function audioPanelMarkup() {
         </div>
       </div>
       <div class="info-section" id="masterSection">
-        <div class="info-title" data-i18n="master.title">Master</div>
-        <div class="meter-row">
-          <div id="masterMeterText" class="fixed-metric">— dB</div>
-          <div class="meter-bar level-meter">
+        <div class="master-header">
+          <div class="info-title" style="margin:0;white-space:nowrap" data-i18n="master.title">Master</div>
+          <div class="meter-bar level-meter" style="flex:1 1 auto;min-width:0">
             <div id="masterMeterFill" class="meter-fill"></div>
             <div id="masterMeterPeak" class="meter-peak"></div>
           </div>
+          <div id="masterMeterText" class="fixed-metric" style="text-align:right">— dB</div>
+          <button id="autoGainSectionToggleBtn" type="button" class="panel-toggle-btn" data-i18n-title="autoGain.toggle" title="Auto-gain settings">▸</button>
         </div>
         <div class="control-row">
           <input id="masterGainSlider" class="gain-slider" type="range" min="0" max="2" step="0.01" value="1" />
           <div id="masterGainBox" class="gain-box">0.0 dB</div>
         </div>
-        <div class="switch-row">
-          <span style="display:flex;align-items:center;gap:0.4rem;font-size:12px;color:#ffffff">
-            <span id="clipIndicator" class="clip-indicator" title="Clip" aria-label="Clip indicator"></span>
-            <span data-i18n="autoGain.title">Auto-gain (anti-clip)</span>
-          </span>
-          <input id="autoGainToggle" type="checkbox" />
-        </div>
-        <div class="control-row" id="autoGainCeilingRow">
-          <label style="font-size:12px;white-space:nowrap;color:#ffffff" for="autoGainCeilingSlider"><span data-i18n="autoGain.ceiling">Ceiling</span> <span id="autoGainCeilingVal">-1.0 dB</span></label>
-          <input id="autoGainCeilingSlider" class="gain-slider" type="range" min="-12" max="0" step="0.1" value="-1" />
+        <div id="autoGainSection" class="conditional-params">
+          <div class="switch-row">
+            <span style="display:flex;align-items:center;gap:0.4rem;font-size:12px;color:#ffffff">
+              <span id="clipIndicator" class="clip-indicator" title="Clip" aria-label="Clip indicator"></span>
+              <span data-i18n="autoGain.title">Auto-gain (anti-clip)</span>
+            </span>
+            <input id="autoGainToggle" type="checkbox" />
+          </div>
+          <div class="control-row" id="autoGainCeilingRow">
+            <label style="font-size:12px;white-space:nowrap;color:#ffffff" for="autoGainCeilingSlider"><span data-i18n="autoGain.ceiling">Ceiling</span> <span id="autoGainCeilingVal">-1.0 dB</span></label>
+            <input id="autoGainCeilingSlider" class="gain-slider" type="range" min="-12" max="0" step="0.1" value="-1" />
+          </div>
         </div>
       </div>
       </div>`;


### PR DESCRIPTION
Restructures the **Master** section of the audio panel:

- The **level gauge** moves onto the title line, right next to "Master".
- A collapse toggle (▸/▾) on the right folds the **auto-gain (anti-clip) + ceiling** controls into a collapsible block (`#autoGainSection`, `.conditional-params`), default collapsed — consistent with the other sections.
- The **master gain slider** and the gauge stay visible when collapsed.

Plumbing mirrors the existing section toggles: `app.autoGainSectionOpen` state, `setAutoGainSectionOpen` in `modals.js`, toggle wiring in the listeners, init in `app.js`, and the `autoGain.toggle` label (en + fr).

Note: the clip indicator lives with the auto-gain row, so it folds away when collapsed; the gauge's own over-level peak marker stays visible.

Frontend only — `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)