### PR TITLE
studio: theme picker for the script editor (dark-mode friendly)

### DIFF
--- a/omniphony-studio/package-lock.json
+++ b/omniphony-studio/package-lock.json
@@ -11,9 +11,11 @@
         "@codemirror/language": "^6",
         "@codemirror/legacy-modes": "^6",
         "@codemirror/state": "^6",
+        "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6",
         "@tauri-apps/api": "^2",
         "codemirror": "^6",
+        "thememirror": "^2.0.1",
         "three": "^0.165.0"
       },
       "devDependencies": {
@@ -97,6 +99,18 @@
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
@@ -1306,6 +1320,17 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/thememirror": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/thememirror/-/thememirror-2.0.1.tgz",
+      "integrity": "sha512-d5i6FVvWWPkwrm4cHLI3t9AT1OrkAt7Ig8dtdYSofgF7C/eiyNuq6zQzSTusWTde3jpW9WLvA9J/fzNKMUsd0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
     },
     "node_modules/three": {
       "version": "0.165.0",

--- a/omniphony-studio/package.json
+++ b/omniphony-studio/package.json
@@ -13,9 +13,11 @@
     "@codemirror/language": "^6",
     "@codemirror/legacy-modes": "^6",
     "@codemirror/state": "^6",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6",
     "@tauri-apps/api": "^2",
     "codemirror": "^6",
+    "thememirror": "^2.0.1",
     "three": "^0.165.0"
   },
   "devDependencies": {

--- a/omniphony-studio/src/controls/script-editor.js
+++ b/omniphony-studio/src/controls/script-editor.js
@@ -13,15 +13,52 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { EditorView, basicSetup } from 'codemirror';
-import { EditorState } from '@codemirror/state';
+import { Compartment, EditorState } from '@codemirror/state';
 import { StreamLanguage } from '@codemirror/language';
 import { lua } from '@codemirror/legacy-modes/mode/lua';
+import { oneDark } from '@codemirror/theme-one-dark';
+import {
+  amy, ayuLight, cobalt, coolGlow, dracula, espresso,
+  rosePineDawn, solarizedLight, tomorrow,
+} from 'thememirror';
 import { t } from '../i18n.js';
+
+// Selectable editor colour themes. `ext: null` keeps CodeMirror's built-in light
+// theme. Dark themes come first since the Studio panel is dark; the default is
+// One Dark. Each theme extension carries both the editor chrome and the syntax
+// highlight colours, so applying one is a single extension.
+const THEMES = [
+  { id: 'one-dark', label: 'One Dark', ext: oneDark },
+  { id: 'dracula', label: 'Dracula', ext: dracula },
+  { id: 'cobalt', label: 'Cobalt', ext: cobalt },
+  { id: 'cool-glow', label: 'Cool Glow', ext: coolGlow },
+  { id: 'espresso', label: 'Espresso', ext: espresso },
+  { id: 'amy', label: 'Amy', ext: amy },
+  { id: 'tomorrow', label: 'Tomorrow (light)', ext: tomorrow },
+  { id: 'solarized-light', label: 'Solarized Light', ext: solarizedLight },
+  { id: 'ayu-light', label: 'Ayu Light', ext: ayuLight },
+  { id: 'rose-pine-dawn', label: 'Rosé Pine Dawn', ext: rosePineDawn },
+  { id: 'default', label: 'Default (light)', ext: null },
+];
+const THEME_KEY = 'omniphony.scriptEditor.theme';
+const DEFAULT_THEME = 'one-dark';
+const themeCompartment = new Compartment();
+
+function selectedThemeId() {
+  const id = localStorage.getItem(THEME_KEY);
+  return THEMES.some((entry) => entry.id === id) ? id : DEFAULT_THEME;
+}
+
+function themeExtensionFor(id) {
+  const entry = THEMES.find((e) => e.id === id);
+  return entry && entry.ext ? entry.ext : [];
+}
 
 let modalEl = null;
 let view = null;
 let filenameEl = null;
 let pickerEl = null;
+let themeEl = null;
 let browseBtn = null;
 let statusEl = null;
 // The file currently open: { backend, key, language, extensions, rendererIsLocal }.
@@ -38,13 +75,17 @@ function langExtensions(language) {
   return language === 'lua' ? [StreamLanguage.define(lua)] : [];
 }
 
-// Replace the whole document, keeping the language for the active session. Used
-// on load and New so the editor stays consistent.
+// Replace the whole document, keeping the language + theme for the active session.
+// Used on load and New so the editor stays consistent.
 function resetEditor(text) {
   if (!view) return;
   view.setState(EditorState.create({
     doc: text || '',
-    extensions: [basicSetup, ...langExtensions(session && session.language)],
+    extensions: [
+      basicSetup,
+      ...langExtensions(session && session.language),
+      themeCompartment.of(themeExtensionFor(selectedThemeId())),
+    ],
   }));
 }
 
@@ -122,9 +163,31 @@ function buildModal() {
   header.style.cssText = 'display:flex;align-items:center;justify-content:space-between';
   const title = document.createElement('strong');
   title.textContent = t('backend.file.editor.title');
+  // Colour-theme picker (persisted): the Studio panel is dark, so a dark editor
+  // theme reads far better than CodeMirror's default light one.
+  themeEl = document.createElement('select');
+  themeEl.title = t('backend.file.editor.theme');
+  themeEl.style.fontSize = '12px';
+  for (const entry of THEMES) {
+    const opt = document.createElement('option');
+    opt.value = entry.id;
+    opt.textContent = entry.label;
+    themeEl.appendChild(opt);
+  }
+  themeEl.value = selectedThemeId();
+  themeEl.addEventListener('change', () => {
+    localStorage.setItem(THEME_KEY, themeEl.value);
+    if (view) {
+      view.dispatch({ effects: themeCompartment.reconfigure(themeExtensionFor(themeEl.value)) });
+    }
+  });
+
   const closeBtn = button(t('backend.file.editor.close'));
   closeBtn.addEventListener('click', closeEditor);
-  header.append(title, closeBtn);
+  const headerRight = document.createElement('div');
+  headerRight.style.cssText = 'display:flex;gap:0.4rem;align-items:center';
+  headerRight.append(themeEl, closeBtn);
+  header.append(title, headerRight);
 
   // Toolbar: managed-file picker, filename, Browse, New, Reload, Save.
   const toolbar = document.createElement('div');
@@ -185,7 +248,11 @@ function buildModal() {
   modalEl.addEventListener('mousedown', (e) => { if (e.target === modalEl) closeEditor(); });
   document.body.appendChild(modalEl);
 
-  view = new EditorView({ parent: host, doc: '', extensions: [basicSetup] });
+  view = new EditorView({
+    parent: host,
+    doc: '',
+    extensions: [basicSetup, themeCompartment.of(themeExtensionFor(selectedThemeId()))],
+  });
 }
 
 // Ask the renderer for content: an explicit `name` previews a managed file;

--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -349,6 +349,7 @@
   "backend.file.browse": "Durchsuchen…",
   "backend.file.edit": "Bearbeiten",
   "backend.file.editor.title": "Backend-Datei bearbeiten",
+  "backend.file.editor.theme": "Editor-Thema",
   "backend.file.editor.close": "Schließen",
   "backend.file.editor.new": "Neu",
   "backend.file.editor.reload": "Neu laden",

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -273,6 +273,7 @@
   "backend.file.browse": "Browse…",
   "backend.file.edit": "Edit",
   "backend.file.editor.title": "Edit backend file",
+  "backend.file.editor.theme": "Editor theme",
   "backend.file.editor.close": "Close",
   "backend.file.editor.new": "New",
   "backend.file.editor.reload": "Reload",

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -350,6 +350,7 @@
   "backend.file.browse": "Examinar…",
   "backend.file.edit": "Editar",
   "backend.file.editor.title": "Editar archivo del backend",
+  "backend.file.editor.theme": "Tema del editor",
   "backend.file.editor.close": "Cerrar",
   "backend.file.editor.new": "Nuevo",
   "backend.file.editor.reload": "Recargar",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -209,6 +209,7 @@
   "backend.file.browse": "Parcourir…",
   "backend.file.edit": "Éditer",
   "backend.file.editor.title": "Éditer le fichier du backend",
+  "backend.file.editor.theme": "Thème de l’éditeur",
   "backend.file.editor.close": "Fermer",
   "backend.file.editor.new": "Nouveau",
   "backend.file.editor.reload": "Recharger",

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -345,6 +345,7 @@
   "backend.file.browse": "Sfoglia…",
   "backend.file.edit": "Modifica",
   "backend.file.editor.title": "Modifica file del backend",
+  "backend.file.editor.theme": "Tema dell’editor",
   "backend.file.editor.close": "Chiudi",
   "backend.file.editor.new": "Nuovo",
   "backend.file.editor.reload": "Ricarica",

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -340,6 +340,7 @@
   "backend.file.browse": "参照…",
   "backend.file.edit": "編集",
   "backend.file.editor.title": "バックエンドファイルを編集",
+  "backend.file.editor.theme": "エディターのテーマ",
   "backend.file.editor.close": "閉じる",
   "backend.file.editor.new": "新規",
   "backend.file.editor.reload": "再読み込み",

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -350,6 +350,7 @@
   "backend.file.browse": "Procurar…",
   "backend.file.edit": "Editar",
   "backend.file.editor.title": "Editar arquivo do backend",
+  "backend.file.editor.theme": "Tema do editor",
   "backend.file.editor.close": "Fechar",
   "backend.file.editor.new": "Novo",
   "backend.file.editor.reload": "Recarregar",

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -345,6 +345,7 @@
   "backend.file.browse": "浏览…",
   "backend.file.edit": "编辑",
   "backend.file.editor.title": "编辑后端文件",
+  "backend.file.editor.theme": "编辑器主题",
   "backend.file.editor.close": "关闭",
   "backend.file.editor.new": "新建",
   "backend.file.editor.reload": "重新加载",


### PR DESCRIPTION
The script editor used CodeMirror's default light theme, which reads poorly on Studio's dark panel.

- Adds a **theme combo** to the editor header (top-right), persisted in `localStorage`.
- Options (dark first, since the panel is dark): One Dark (default), Dracula, Cobalt, Cool Glow, Espresso, Amy, Tomorrow, Solarized Light, Ayu Light, Rosé Pine Dawn, and the original Default (light).
- The selection lives in a CodeMirror `Compartment`, so switching themes reconfigures the editor **live** without losing edits.
- New deps: `@codemirror/theme-one-dark`, `thememirror`. Adds `backend.file.editor.theme` in all eight locales.

`npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)