### PR TITLE
ci(integration): publish freshly built bundles, not stale cached ones

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -113,6 +113,16 @@ jobs:
         working-directory: omniphony-studio
         run: npm install
 
+      # The cargo cache restores src-tauri/target, which still holds bundle
+      # artifacts from earlier runs (older versions). The staging step below
+      # globs the bundle dir and picks matches[0] — the lowest version present —
+      # so a fresh 0.3.3 build was being published as a stale 0.3.2 bundle. Wipe
+      # stale bundles before rebuilding; compiled deps in target/ are kept, so
+      # this does not force a full recompile.
+      - name: Remove stale bundles restored from cache
+        shell: bash
+        run: rm -rf omniphony-studio/src-tauri/target/release/bundle
+
       # No tagName → tauri-action only builds (runs beforeBuildCommand: frontend
       # build + prepare-sidecar), leaving bundles under src-tauri/target/.../bundle/.
       - name: Build Studio bundles


### PR DESCRIPTION
## Problem

Testers downloading the rolling `integration` release got **Omniphony Studio 0.3.2** with no per-user/per-machine install choice, even though `main` is at **0.3.3** with NSIS `installMode: "both"`.

The build is not behind — the run logs show tauri-action **does** produce fresh 0.3.3 bundles:

```
Running light    → bundle/msi/Omniphony Studio_0.3.3_x64_en-US.msi
Running makensis → bundle/nsis/Omniphony Studio_0.3.3_x64-setup.exe
```

…but the *Stage renamed bundles* step publishes the stale 0.3.2 ones:

```
staged …windows…msi        ←  bundle/msi/Omniphony Studio_0.3.2_x64_en-US.msi
staged …windows…setup.exe  ←  bundle/nsis/Omniphony Studio_0.3.2_x64-setup.exe
```

## Root cause

The cargo cache restores `omniphony-studio/src-tauri/target`, which still contains bundle artifacts from earlier runs. The cache key only changes when the `Cargo.lock` files change, so those older-versioned bundles linger across runs. `copy_one` then globs the bundle dir and takes `matches[0]` — the lowest version present alphanumerically — i.e. the stale 0.3.2 (built before `installMode: "both"` was added).

## Fix

Remove `target/release/bundle` before invoking tauri-action, so only the freshly built artifacts exist when staging globs them. Compiled deps in `target/` are kept, so this does not force a full recompile.

## After merge

Re-run the **Integration Build** workflow (workflow_dispatch) to regenerate the `integration` release as 0.3.3. Note: the admin/per-user choice only appears in the `-setup.exe` (NSIS); the `.msi` (WiX) installs per-machine by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)