### PR TITLE
studio: bundle layouts into resources/layouts (no _up_) + seed import picker

### DIFF
--- a/omniphony-studio/src-tauri/src/commands/app.rs
+++ b/omniphony-studio/src-tauri/src/commands/app.rs
@@ -64,7 +64,10 @@ pub fn get_about_info() -> AboutInfo {
 }
 
 #[tauri::command]
-pub fn save_osc_config(state: State<SharedState>, config: OscConfig) -> Result<(), String> {
+pub fn save_osc_config(state: State<SharedState>, mut config: OscConfig) -> Result<(), String> {
+    // The JS config form doesn't carry server-only fields; preserve them from
+    // the persisted copy so a save doesn't wipe the remembered import dir.
+    config.last_layout_import_dir = load_config(&state.config_dir).last_layout_import_dir;
     save_config(&state.config_dir, &config)?;
     // A config change re-arms the auto-start watchdog after a failure streak.
     state.watchdog.lock().unwrap().rearm();

--- a/omniphony-studio/src-tauri/src/commands/layout_io.rs
+++ b/omniphony-studio/src-tauri/src/commands/layout_io.rs
@@ -6,11 +6,12 @@
 //!
 //! [`AppState`]: crate::app_state::AppState
 
+use crate::config::{load_config, save_config};
 use crate::layouts::{self, Layout};
 use crate::SharedState;
 use rfd::FileDialog;
 use std::path::Path;
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 
 #[tauri::command]
 pub fn select_layout(state: State<SharedState>, key: String) -> bool {
@@ -52,12 +53,39 @@ pub fn import_layout_from_path(
     }))
 }
 
+/// Directory the import picker should open in: the user's last import dir if
+/// known, otherwise the bundled layouts dir (so a first-time user lands right
+/// on the shipped presets).
+fn import_start_dir(app: &AppHandle, state: &State<SharedState>) -> Option<std::path::PathBuf> {
+    if let Some(dir) = load_config(&state.config_dir).last_layout_import_dir {
+        let p = std::path::PathBuf::from(dir);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    app.path()
+        .resource_dir()
+        .ok()
+        .map(|d| d.join("layouts"))
+        .filter(|p| p.is_dir())
+}
+
 #[tauri::command]
-pub fn pick_import_layout_path() -> Option<String> {
-    FileDialog::new()
-        .add_filter("Layout", &["json", "yaml", "yml"])
-        .pick_file()
-        .map(|path| path.to_string_lossy().to_string())
+pub fn pick_import_layout_path(app: AppHandle, state: State<SharedState>) -> Option<String> {
+    let mut dialog = FileDialog::new().add_filter("Layout", &["json", "yaml", "yml"]);
+    if let Some(dir) = import_start_dir(&app, &state) {
+        dialog = dialog.set_directory(dir);
+    }
+    let picked = dialog.pick_file()?;
+
+    // Remember where the user imported from for next time.
+    if let Some(parent) = picked.parent() {
+        let mut cfg = load_config(&state.config_dir);
+        cfg.last_layout_import_dir = Some(parent.to_string_lossy().to_string());
+        let _ = save_config(&state.config_dir, &cfg);
+    }
+
+    Some(picked.to_string_lossy().to_string())
 }
 
 #[tauri::command]

--- a/omniphony-studio/src-tauri/src/config.rs
+++ b/omniphony-studio/src-tauri/src/config.rs
@@ -15,6 +15,11 @@ pub struct OscConfig {
     /// Leave the Studio-launched standby renderer running when Studio quits.
     #[serde(default)]
     pub keep_renderer_alive_on_quit: bool,
+    /// Directory the layout-import picker last opened in. Server-only (never
+    /// sent by the JS config form); seeded with the bundled layouts dir on the
+    /// first import so users can find the presets, then tracks their last pick.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_layout_import_dir: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -30,6 +35,7 @@ impl Default for OscConfig {
             osc_metering_enabled: false,
             auto_start_renderer: true,
             keep_renderer_alive_on_quit: false,
+            last_layout_import_dir: None,
         }
     }
 }

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
     "active": true,
     "icon": ["icons/icon.ico", "icons/icon.png"],
     "externalBin": ["binaries/orender"],
-    "resources": ["../../layouts/*"],
+    "resources": { "../../layouts/*": "layouts/" },
     "windows": {
       "nsis": {
         "installMode": "both"


### PR DESCRIPTION
## Problem

On installed builds, the shipped speaker-layout presets land in a bizarre path — `C:\Program Files\Omniphony Studio\_up_\_up_\layouts` on Windows (reported by a user). The resource glob `"../../layouts/*"` makes Tauri mirror the *source* path into the bundle, encoding each `..` as `_up_`.

Worse: `main.rs` and `orender.rs` resolve the layouts dir as `resource_dir/layouts`, so with the files actually sitting in `resource_dir/_up_/_up_/layouts`, **the built-in presets were never loaded from the bundle at all** — users only saw them because they dug up the `_up_` folder manually.

## Fix

- Map the resource to a flat destination — `"resources": { "../../layouts/*": "layouts/" }` — so files land in `resource_dir/layouts`, exactly where the loader looks. **Verified with a real deb bundle**: presets now at `/usr/lib/Omniphony Studio/layouts/*.yaml`, no `_up_` anywhere. This also restores built-in preset auto-loading on installed builds.
- Seed the layout-import file picker: it opens in the user's last import directory if known, otherwise in the bundled layouts dir, so a first-time user lands right on the presets instead of an empty home dir. The directory is remembered (`last_layout_import_dir` in `osc_config.json`, server-only and preserved across config saves since the JS form doesn't carry it).

No frontend change: `pick_import_layout_path` gains `AppHandle`/`State`, both Tauri-injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)