### PR TITLE
studio: presets dropdown left of Import for bundled layouts

### DIFF
--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -257,6 +257,7 @@
   "edit.cartesian": "Cartesian",
   "config.save": "Save",
   "config.reload": "Reload",
+  "config.presets": "Presets — bundled speaker layouts",
   "config.import": "Import layout",
   "config.export": "Export layout",
   "evaluation.title": "Evaluation",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -202,6 +202,7 @@
   "edit.cartesian": "Cartésien",
   "config.save": "Sauvegarder",
   "config.reload": "Relire",
+  "config.presets": "Préréglages — layouts d'enceintes fournis",
   "config.import": "Importer layout",
   "config.export": "Exporter layout",
   "evaluation.title": "Évaluation",

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -468,6 +468,7 @@
           <div class="info-title panel-title speakers-title-binaural">Headphones</div>
           </div>
           <div class="speakers-layout-actions" style="display:flex;align-items:center;gap:0.35rem">
+            <select id="layoutSelect" data-i18n-title="config.presets" data-i18n-aria-label="config.presets" style="font-size:11px;background:rgba(255,255,255,0.06);color:#d9ecff;border:1px solid rgba(255,255,255,0.18);border-radius:4px;padding:0.1rem 0.25rem;max-width:150px"></select>
             <button id="importLayoutBtn" class="ui-btn ui-btn-primary" data-i18n="config.import">Import layout</button>
             <button id="exportLayoutBtn" class="ui-btn ui-btn-primary" data-i18n="config.export">Export layout</button>
             <button id="speakerAddBtn" type="button" class="toggle-btn">+ Add</button>


### PR DESCRIPTION
## What

Adds a **Presets** combo to the left of the *Import layout* button, listing the bundled speaker-layout YAMLs so they're selectable from the UI.

## Why it was missing

The `layoutSelect` plumbing (populate, change-listener that applies the pick to the renderer, `select_layout`) is still fully wired in JS — but the `<select>` element itself was dropped from `index.html` in the big DOM refactor (`504075f`, −2100 lines). So the bundled presets loaded silently and only the first was auto-applied; there was no way to switch.

## Change

- Re-add `<select id="layoutSelect">` with a *Presets* tooltip/aria-label (new i18n key `config.presets`, en + fr).
- It lists the layouts loaded from the bundled layouts dir at startup — exactly the folder's YAML presets — and picking one applies it to the renderer via the existing listener.
- Session-imported layouts also appear (in-memory only; reset to presets on next launch).

Frontend-only. Pairs with #92: presets now actually ship to `resource_dir/layouts` and load, so the combo has content on installed builds.

Validated: `npm run build` clean, i18n JSON valid, select present in dist with the listener wired via `setupLayoutListeners()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)