### PR TITLE
windows: store the renderer config machine-wide in %ProgramData%

### DIFF
--- a/omniphony-renderer/QUICKSTART.md
+++ b/omniphony-renderer/QUICKSTART.md
@@ -136,7 +136,7 @@ Windows / ASIO:
 Default config path:
 
 - Linux: `~/.config/omniphony/config.yaml`
-- Windows: `%APPDATA%\omniphony\config.yaml`
+- Windows: `%ProgramData%\omniphony\config.yaml` (machine-wide; shared by user-mode and the service)
 
 Save the current effective configuration:
 

--- a/omniphony-renderer/README.md
+++ b/omniphony-renderer/README.md
@@ -142,7 +142,7 @@ Global and render settings are loaded from a YAML config file.
 Default path:
 
 - Linux: `~/.config/omniphony/config.yaml`
-- Windows: `%APPDATA%\\omniphony\\config.yaml`
+- Windows: `%ProgramData%\\omniphony\\config.yaml` (machine-wide, so the user-mode renderer and a service share one file)
 
 You can point to another file with `--config`, and persist the current effective settings with `--save-config`.
 

--- a/omniphony-renderer/orender_engine/src/lib.rs
+++ b/omniphony-renderer/orender_engine/src/lib.rs
@@ -29,7 +29,9 @@ pub use osc::{ObjectMeta, OscSender};
 /// The shared omniphony config (`~/.config/omniphony/config.yaml`) + its path,
 /// re-exported so hosts default to the SAME config as the `orender` CLI + studio
 /// (bridge path, layout, OSC settings, render params).
-pub use renderer::config::{Config, RenderConfig, default_config_path};
+pub use renderer::config::{
+    Config, RenderConfig, default_config_path, migrate_legacy_windows_config,
+};
 pub use virtual_bed::{build_virtual_bed_events, build_virtual_bed_objects};
 
 /// Install the shared live-log logger used by the engine.

--- a/omniphony-renderer/orender_ffi/src/lib.rs
+++ b/omniphony-renderer/orender_ffi/src/lib.rs
@@ -173,10 +173,14 @@ fn host_launch_diagnostics() -> String {
 }
 
 fn build_engine(cfg: &OrenderConfig) -> Result<Engine> {
+    // Seed the machine-wide Windows config from the legacy per-user location
+    // once (no-op on Linux/macOS), before resolving the default path.
+    orender_engine::migrate_legacy_windows_config();
+
     // Optional override; NULL → taken from the config YAML's render.bridge_path.
     let bridge_path = unsafe { opt_str(cfg.bridge_path) };
-    // NULL config → the shared omniphony config (same as the CLI + studio:
-    // ~/.config/omniphony/config.yaml), so one config drives all hosts.
+    // NULL config → the shared omniphony config (same as the CLI + studio),
+    // so one config drives all hosts.
     let config_path = unsafe { opt_str(cfg.config_yaml_path) }
         .map(PathBuf::from)
         .or_else(orender_engine::default_config_path);

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -645,13 +645,17 @@ pub fn clear_live_overlay_cache() {
 /// Returns the platform default config path without external dependencies.
 ///
 /// - Linux:   `$XDG_CONFIG_HOME/omniphony/config.yaml`  (fallback: `~/.config/omniphony/config.yaml`)
-/// - Windows: `%APPDATA%\omniphony\config.yaml`
+/// - Windows: `%ProgramData%\omniphony\config.yaml`  (fallback: `C:\ProgramData\omniphony\config.yaml`)
+///
+/// On Windows the config is machine-wide so that the user-mode renderer and a
+/// LocalSystem service resolve the *same* file — `%ProgramData%` is account
+/// independent, unlike `%APPDATA%` which differs between the logged-in user and
+/// the service's system profile.
 pub fn default_config_path() -> Option<PathBuf> {
     #[cfg(windows)]
     {
-        return std::env::var("APPDATA")
-            .ok()
-            .map(|p| PathBuf::from(p).join("omniphony").join("config.yaml"));
+        let dir = windows_program_data_dir().join("omniphony");
+        return Some(dir.join("config.yaml"));
     }
 
     // Unix / Linux
@@ -668,6 +672,61 @@ pub fn default_config_path() -> Option<PathBuf> {
         Some(base.join("omniphony").join("config.yaml"))
     }
 }
+
+/// Machine-wide `%ProgramData%` directory (same for every account), with the
+/// canonical `C:\ProgramData` fallback when the env var is somehow unset.
+#[cfg(windows)]
+fn windows_program_data_dir() -> PathBuf {
+    std::env::var("ProgramData")
+        .ok()
+        .filter(|p| !p.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+}
+
+/// One-shot migration of the pre-machine-wide config: older builds stored it in
+/// the per-user `%APPDATA%\omniphony\`. If the new `%ProgramData%` location has
+/// no `config.yaml` yet but the legacy one exists, copy it (and its live
+/// sidecar) over so upgrades keep the user's settings. Best-effort and guarded
+/// by a process `Once`; never panics. Runs in whatever account the renderer
+/// starts as — for a user-context launch this seeds ProgramData from the user's
+/// config; the service (SYSTEM) at worst migrates its own old system-profile
+/// config, which is harmless.
+#[cfg(windows)]
+pub fn migrate_legacy_windows_config() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let Some(appdata) = std::env::var("APPDATA").ok().filter(|p| !p.is_empty()) else {
+            return;
+        };
+        let legacy_dir = PathBuf::from(appdata).join("omniphony");
+        let legacy = legacy_dir.join("config.yaml");
+        if !legacy.is_file() {
+            return;
+        }
+        let dest_dir = windows_program_data_dir().join("omniphony");
+        let dest = dest_dir.join("config.yaml");
+        if dest.exists() {
+            return; // already migrated / machine config present
+        }
+        if std::fs::create_dir_all(&dest_dir).is_err() {
+            return;
+        }
+        if std::fs::copy(&legacy, &dest).is_err() {
+            return;
+        }
+        // Carry the unsaved-live sidecar across too, if present.
+        let legacy_live = live_sidecar_path(&legacy);
+        if legacy_live.is_file() {
+            let _ = std::fs::copy(&legacy_live, live_sidecar_path(&dest));
+        }
+    });
+}
+
+/// No-op on non-Windows: the Linux/macOS config path never moved.
+#[cfg(not(windows))]
+pub fn migrate_legacy_windows_config() {}
 
 #[cfg(test)]
 mod tests {

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -23,7 +23,8 @@ pub const VERSION_INFO: &str = concat!(
     after_help = "If no command is given, orender runs the default render flow.",
 )]
 pub struct Cli {
-    /// Path to config file (default: ~/.config/omniphony/config.yaml)
+    /// Path to config file (default: ~/.config/omniphony/config.yaml on Linux,
+    /// %ProgramData%\omniphony\config.yaml on Windows)
     #[arg(long, global = true, value_name = "FILE")]
     pub config: Option<PathBuf>,
 

--- a/omniphony-renderer/src/main.rs
+++ b/omniphony-renderer/src/main.rs
@@ -83,6 +83,11 @@ fn run_as_service() -> anyhow::Result<()> {
 }
 
 fn main() -> Result<()> {
+    // Seed the machine-wide Windows config from the legacy per-user location
+    // once, before any path resolution and before the service dispatch loop so
+    // both the console and service flows are covered. No-op on Linux/macOS.
+    renderer::config::migrate_legacy_windows_config();
+
     // When started by the Windows Service Control Manager, enter the SCM
     // dispatch loop and run to completion; otherwise fall through to the
     // normal console CLI flow.

--- a/omniphony-studio/src-tauri/src/commands/orender.rs
+++ b/omniphony-studio/src-tauri/src/commands/orender.rs
@@ -466,6 +466,9 @@ pub fn install_orender_service(
         };
         let script = format!(
             "try {{\r\n\
+             $cfgDir = Join-Path $env:ProgramData 'omniphony'\r\n\
+             New-Item -ItemType Directory -Force -Path $cfgDir | Out-Null\r\n\
+             icacls $cfgDir /grant '*S-1-5-32-545:(OI)(CI)M' /T | Out-Null\r\n\
              New-Service -Name {name} -BinaryPathName {bin} \
              -DisplayName {display} -StartupType Manual -ErrorAction Stop\r\n\
              & sc.exe description {name} {desc}\r\n\


### PR DESCRIPTION
## Problem

On Windows the orender service is created via `New-Service` with no `-Credential`, so it runs as **LocalSystem**. With no `--config`, the renderer resolved `%APPDATA%\omniphony\config.yaml` — under LocalSystem that's the *system profile* (`C:\Windows\System32\config\systemprofile\…`): invisible to the user **and** a different file from the user-mode config. Switching between service and user mode silently swapped configs.

(Linux is unaffected: its service is a `systemctl --user` unit running as the user, already sharing the XDG config.)

## Fix

Move the Windows default to `%ProgramData%\omniphony\config.yaml`. `%ProgramData%` is **account-independent**, so the user-mode renderer (logged-in user) and the service (LocalSystem) resolve the **same** file — no `--config` plumbing needed.

- `config.rs`: `default_config_path()` Windows branch → `%ProgramData%` (fallback `C:\ProgramData`); new `migrate_legacy_windows_config()` — `Once`-guarded, best-effort copy of the old `%APPDATA%` config (+ live sidecar) into ProgramData when the machine config doesn't exist yet.
- Migration called at both entry points: CLI `main()` (before the service dispatch loop) and FFI `build_engine()` (mpv host). No-op on Linux/macOS.
- Service install (already elevated) creates `%ProgramData%\omniphony` and `icacls /grant *S-1-5-32-545:(OI)(CI)M /T` (BUILTIN\Users, Modify, inherited) so a config written by SYSTEM stays user-writable and vice versa.
- Docs: README / QUICKSTART / `--config` help.

## Validation

- `renderer`, `orender_engine`, `orender_ffi` cross-compile for `x86_64-pc-windows-gnu` (the `cfg(windows)` code paths); host `cargo test` green; `cargo fmt --check` clean on the renderer workspace.
- Manual Windows check (to do on a box): user-mode → config at `C:\ProgramData\omniphony`; install service → same file; user can still save after a SYSTEM write; migration seeds ProgramData once from an existing `%APPDATA%` config.

Follow-up (separate repo): the `ad_orender.c` error hint in the mpv fork still cites `%APPDATA%\omniphony` — align to ProgramData in `mgth/mpv` and regenerate the mpv-omniphony patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)