### PR TITLE
studio: tidy service-mode UX (disable auto-start on install, label 'service')

### DIFF
--- a/omniphony-studio/src-tauri/src/commands/orender.rs
+++ b/omniphony-studio/src-tauri/src/commands/orender.rs
@@ -397,6 +397,18 @@ pub fn get_orender_service_status() -> Result<OrenderServiceStatus, String> {
     Err("service management is not supported on this platform".to_string())
 }
 
+/// Installing the service makes it the owner of the renderer, so turn off the
+/// auto-start watchdog — otherwise it would spawn a competing CLI standby — and
+/// suppress any in-flight check. The user can re-enable auto-start afterwards.
+fn disable_autostart_for_service(state: &SharedState) {
+    let mut cfg = load_config(&state.config_dir);
+    if cfg.auto_start_renderer {
+        cfg.auto_start_renderer = false;
+        let _ = save_config(&state.config_dir, &cfg);
+    }
+    state.watchdog.lock().unwrap().suppressed = true;
+}
+
 #[tauri::command]
 pub fn install_orender_service(
     app: tauri::AppHandle,
@@ -444,6 +456,7 @@ pub fn install_orender_service(
         })?;
         run_user_systemctl(&["daemon-reload"], "install service")?;
         run_user_systemctl(&["enable", &service_name], "install service")?;
+        disable_autostart_for_service(&state);
         return Ok(serde_json::json!({
             "command": format!("systemctl --user enable {service_name}")
         }));
@@ -499,6 +512,7 @@ pub fn install_orender_service(
         let _ = std::fs::remove_file(&script_path);
         result?;
 
+        disable_autostart_for_service(&state);
         return Ok(serde_json::json!({
             "command": format!("sc create {} binPath= {}", ORENDER_SERVICE_NAME, bin_path)
         }));

--- a/omniphony-studio/src/controls/osc.js
+++ b/omniphony-studio/src/controls/osc.js
@@ -59,10 +59,18 @@ export function renderOscStatus() {
   applyProducerCapabilityVisibility();
   if (statusEl) {
     let statusText = t(`status.${app.oscStatusState}`);
-    // Label the connected renderer flavour (e.g. "connected · mpv" for the
-    // embedded variant vs "connected · cli" for the standalone service).
+    // Label the connected renderer flavour so the user can tell what they are
+    // talking to: "mpv" for the embedded player, "service" for the OS-managed
+    // instance, or "cli" for a standalone/Studio-launched one.
     if (app.oscStatusState === 'connected' && app.producerCapabilities) {
-      const flavour = producerHost() || producerVariant();
+      let flavour;
+      if (isEmbeddedProducer()) {
+        flavour = producerHost() || producerVariant(); // "mpv"
+      } else if (app.orenderServiceRunning) {
+        flavour = 'service';
+      } else {
+        flavour = producerHost() || producerVariant(); // "cli"
+      }
       if (flavour) statusText += ` · ${flavour}`;
     }
     statusEl.textContent = statusText;
@@ -381,6 +389,9 @@ export function installOrenderServiceFromPanel() {
       } else {
         pushLog('info', 'orender service installed.');
       }
+      // Installing the service disables auto-start backend-side; reload the
+      // panel so the toggle reflects it.
+      loadOscConfigIntoPanel();
       return refreshOrenderServiceStatus();
     })
     .finally(() => {


### PR DESCRIPTION
Two papercuts when running the renderer as an OS service (reported on Windows):

1. **Installing the service now disables auto-start.** The service owns the renderer, so the auto-start watchdog must not also spawn a competing CLI standby. `install_orender_service` turns `auto_start_renderer` off and suppresses any in-flight watchdog check; the OSC panel reloads after install so the toggle reflects it.

2. **The status now distinguishes `service` from `cli`/`mpv`.** It could only show `connected · cli` or `connected · mpv`, so a service instance looked identical to a Studio/CLI standby — confusing e.g. after mpv exits and you reconnect to a plain standby rather than the service. Now shows `connected · service` when the OS service is running (mpv still wins when the embedded producer is connected).

Frontend-side inference (service-running ⇒ `service`); no renderer/protocol change.

Validated: `cargo build` + `cargo fmt --check` clean on the new code, `npm run build` clean, the `service` flavour is in the bundle.

Note: the deeper Windows race (a non-yieldable service vs an mpv-embedded renderer both wanting port 9000) is separate and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)