### PR TITLE
renderer: standby/resume instead of shutdown on yield (service ↔ mpv coexistence)

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -39,7 +39,18 @@ const YIELD_REBIND_BUDGET: Duration = Duration::from_secs(5);
 /// Poll interval while waiting for the RX port to free up after a yield request.
 const YIELD_REBIND_POLL: Duration = Duration::from_millis(50);
 
-/// Fire-and-forget `/omniphony/control/yield_port` to the local holder of `rx_port`.
+/// Dynamic resume port advertised by a standby instance we displaced. When this
+/// (port-taking) instance later releases the RX port — at `OscSender::Drop`,
+/// e.g. mpv quitting — we send `/omniphony/control/resume` here so the standby
+/// comes back. `None` until a `yield_port` reply carries it.
+static RESUME_TARGET: Mutex<Option<u16>> = Mutex::new(None);
+
+/// Send `/omniphony/control/yield_port` to the local holder of `rx_port` and,
+/// briefly, listen for its reply advertising a dynamic resume port. A
+/// standby-capable holder replies with [`STANDBY_RESUME_REPLY`] carrying the
+/// port on which it will accept a later `resume`; we stash it in
+/// [`RESUME_TARGET`]. A holder that just shuts down (older, or non-standby)
+/// sends no reply — harmless.
 fn send_yield_request(rx_port: u16) {
     let Ok(socket) = UdpSocket::bind("127.0.0.1:0") else {
         return;
@@ -51,6 +62,61 @@ fn send_yield_request(rx_port: u16) {
     if let Ok(bytes) = rosc::encoder::encode(&OscPacket::Message(msg)) {
         let _ = socket.send_to(&bytes, ("127.0.0.1", rx_port));
     }
+    // Wait briefly for the standby's resume-port reply (point-to-point).
+    let _ = socket.set_read_timeout(Some(Duration::from_millis(500)));
+    let mut buf = [0u8; 256];
+    if let Ok((len, _)) = socket.recv_from(&mut buf) {
+        if let Ok((_, OscPacket::Message(reply))) = rosc::decoder::decode_udp(&buf[..len]) {
+            if reply.addr == STANDBY_RESUME_REPLY {
+                if let Some(rosc::OscType::Int(port)) = reply.args.first() {
+                    if let Ok(port) = u16::try_from(*port) {
+                        *RESUME_TARGET.lock().unwrap() = Some(port);
+                        log::info!("standby holder will resume on port {port}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Send `/omniphony/control/resume` to the standby port we recorded when we took
+/// the RX port over, so the displaced standby re-acquires it. Called as this
+/// instance releases the port (mpv quit / `orender_destroy`).
+fn send_resume_to_standby() {
+    let target = RESUME_TARGET.lock().unwrap().take();
+    let Some(port) = target else { return };
+    let Ok(socket) = UdpSocket::bind("127.0.0.1:0") else {
+        return;
+    };
+    let msg = OscMessage {
+        addr: runtime_control::osc_contract::CONTROL_RESUME.to_string(),
+        args: vec![],
+    };
+    if let Ok(bytes) = rosc::encoder::encode(&OscPacket::Message(msg)) {
+        let _ = socket.send_to(&bytes, ("127.0.0.1", port));
+        log::info!("resume sent to standby on port {port}");
+    }
+}
+
+/// Point-to-point reply address: a standby-capable instance answers a
+/// `yield_port` with this, carrying the dynamic UDP port (Int) on which it will
+/// listen for `/omniphony/control/resume`. Both sides live in this crate.
+pub(crate) const STANDBY_RESUME_REPLY: &str = "/omniphony/yield/resume_port";
+
+/// Dynamic resume socket allocated by the yield handler when this instance is
+/// asked to stand by. The render loop's standby path takes it to listen for
+/// `CONTROL_RESUME` (and it is what frees once we re-acquire the RX port).
+static RESUME_SOCKET: Mutex<Option<UdpSocket>> = Mutex::new(None);
+
+/// Allocate the dynamic resume port for a standby handoff and stash its socket.
+/// Returns the chosen port so the yield handler can advertise it to the
+/// requester (mpv). The socket is non-blocking so the standby listener can poll.
+pub(crate) fn prepare_standby_resume_port() -> Option<u16> {
+    let sock = UdpSocket::bind("127.0.0.1:0").ok()?;
+    sock.set_nonblocking(true).ok()?;
+    let port = sock.local_addr().ok()?.port();
+    *RESUME_SOCKET.lock().unwrap() = Some(sock);
+    Some(port)
 }
 
 /// Reservation socket from [`negotiate_rx_port`]: keeps the RX port HELD
@@ -222,6 +288,12 @@ pub struct OscSender {
     listener_stop: Arc<AtomicBool>,
     /// Join handle for the background OSC listener thread.
     listener_thread: Mutex<Option<JoinHandle<()>>>,
+    /// RX port the listener last bound, so `resume` re-acquires the same one.
+    rx_port: u16,
+    /// Stop flag + handle for the standby resume-listener thread (active only
+    /// while this instance is standing by, waiting for `resume`).
+    standby_stop: Arc<AtomicBool>,
+    standby_thread: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl OscSender {
@@ -239,6 +311,9 @@ impl OscSender {
             content_generation: 0,
             listener_stop: Arc::new(AtomicBool::new(false)),
             listener_thread: Mutex::new(None),
+            rx_port: 0,
+            standby_stop: Arc::new(AtomicBool::new(false)),
+            standby_thread: Mutex::new(None),
         })
     }
 
@@ -268,6 +343,7 @@ impl OscSender {
     /// (loud error, no audio regression) — a port squatter must never cost the
     /// listener spatial audio.
     pub fn start_listener(&mut self, rx_port: u16, request_yield: bool) -> Result<()> {
+        self.rx_port = rx_port;
         let socket = Arc::clone(&self.socket);
         let clients = Arc::clone(&self.clients);
         let control = self.control.clone();
@@ -460,6 +536,77 @@ impl OscSender {
         Ok(())
     }
 
+    /// Enter standby: stop the OSC RX listener (freeing `rx_port` for an
+    /// mpv-embedded renderer) and start a tiny resume-watch thread on the
+    /// dynamic socket the yield handler advertised. It resumes this instance
+    /// when `/omniphony/control/resume` arrives there, or — as a crash safety
+    /// net — when `rx_port` becomes bindable again. The process stays alive; the
+    /// render loop releases its audio output in parallel.
+    pub fn enter_standby(&mut self) {
+        // Release the RX port: stop + join the listener thread.
+        self.listener_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.listener_thread.lock().unwrap().take() {
+            let _ = handle.join();
+        }
+        self.listener_stop.store(false, Ordering::Relaxed);
+
+        let resume_socket = RESUME_SOCKET.lock().unwrap().take();
+        let rx_port = self.rx_port;
+        let stop = Arc::clone(&self.standby_stop);
+        stop.store(false, Ordering::Relaxed);
+        let handle = std::thread::Builder::new()
+            .name("osc-standby".into())
+            .spawn(move || {
+                let mut buf = [0u8; 1024];
+                let mut last_probe = std::time::Instant::now();
+                loop {
+                    if stop.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    // Primary path: a `resume` on the advertised dynamic port.
+                    if let Some(ref sock) = resume_socket {
+                        if let Ok((len, _)) = sock.recv_from(&mut buf) {
+                            if let Ok((_, OscPacket::Message(msg))) =
+                                rosc::decoder::decode_udp(&buf[..len])
+                            {
+                                if msg.addr == runtime_control::osc_contract::CONTROL_RESUME {
+                                    sys::shutdown::request_resume();
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                    // Safety net: if mpv crashed without sending `resume`, the RX
+                    // port simply frees up. Probe it occasionally (test-bind,
+                    // release immediately so `resume` can re-bind cleanly).
+                    if last_probe.elapsed() >= Duration::from_secs(2) {
+                        last_probe = std::time::Instant::now();
+                        if let Ok(probe) = UdpSocket::bind(("0.0.0.0", rx_port)) {
+                            drop(probe);
+                            sys::shutdown::request_resume();
+                            return;
+                        }
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            })
+            .ok();
+        *self.standby_thread.lock().unwrap() = handle;
+    }
+
+    /// Resume from standby: stop the resume-watch thread and re-acquire the RX
+    /// port (re-binding `rx_port`, asking any lingering holder to yield).
+    pub fn resume(&mut self) -> Result<()> {
+        self.standby_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.standby_thread.lock().unwrap().take() {
+            let _ = handle.join();
+        }
+        self.standby_stop.store(false, Ordering::Relaxed);
+        *RESUME_SOCKET.lock().unwrap() = None;
+        let rx_port = self.rx_port;
+        self.start_listener(rx_port, true)
+    }
+
     /// Send bytes to every live client.
     ///
     /// Clients with a timed entry (`Some(t)`) are dropped if `t.elapsed() >= CLIENT_TIMEOUT`.
@@ -502,6 +649,11 @@ impl OscSender {
 
 impl Drop for OscSender {
     fn drop(&mut self) {
+        // If we took the RX port over from a standby instance, wake it back up
+        // as we release the port (e.g. mpv quitting). Done first, while the port
+        // is still ours, so the standby's re-bind races nothing.
+        send_resume_to_standby();
+
         // Graceful-shutdown handoff, done while the RX port is still held so a
         // successor polling for the port is guaranteed to see the sidecar by
         // the time the port frees up. Skipped on reload_config, whose contract
@@ -656,6 +808,54 @@ mod yield_tests {
     fn free_port() -> u16 {
         let s = UdpSocket::bind("127.0.0.1:0").unwrap();
         s.local_addr().unwrap().port()
+    }
+
+    /// A standby holder that replies to a `yield_port` with a dynamic resume
+    /// port must have that port captured by the taker, which then delivers
+    /// `resume` there as it releases the port.
+    #[test]
+    fn standby_resume_port_is_captured_and_resume_delivered() {
+        let holder = UdpSocket::bind("127.0.0.1:0").unwrap();
+        holder
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let rx_port = holder.local_addr().unwrap().port();
+        let resume = UdpSocket::bind("127.0.0.1:0").unwrap();
+        resume
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let resume_port = resume.local_addr().unwrap().port();
+
+        // Holder side: on yield, advertise the resume port to the sender.
+        let h = std::thread::spawn(move || {
+            let mut buf = [0u8; 256];
+            if let Ok((_, src)) = holder.recv_from(&mut buf) {
+                let reply = OscMessage {
+                    addr: STANDBY_RESUME_REPLY.to_string(),
+                    args: vec![rosc::OscType::Int(resume_port as i32)],
+                };
+                let bytes = rosc::encoder::encode(&OscPacket::Message(reply)).unwrap();
+                let _ = holder.send_to(&bytes, src);
+            }
+        });
+
+        *RESUME_TARGET.lock().unwrap() = None;
+        send_yield_request(rx_port);
+        assert_eq!(*RESUME_TARGET.lock().unwrap(), Some(resume_port));
+
+        send_resume_to_standby();
+        let mut buf = [0u8; 256];
+        let (len, _) = resume.recv_from(&mut buf).expect("resume delivered");
+        let (_, pkt) = rosc::decoder::decode_udp(&buf[..len]).unwrap();
+        match pkt {
+            OscPacket::Message(m) => {
+                assert_eq!(m.addr, runtime_control::osc_contract::CONTROL_RESUME)
+            }
+            _ => panic!("expected a resume message"),
+        }
+        // Taking it cleared the target.
+        assert!(RESUME_TARGET.lock().unwrap().is_none());
+        h.join().unwrap();
     }
 
     #[test]

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -506,11 +506,40 @@ pub(crate) fn handle_control_message(
             }
             RuntimeCommand::YieldPort => {
                 if sys::shutdown::is_yieldable() {
-                    log::info!("OSC yield_port requested; shutting down to free the port");
-                    sys::shutdown::request_shutdown();
+                    // Instead of shutting down, allocate a dynamic resume port,
+                    // tell the requester (mpv) about it, and enter standby: the
+                    // render loop releases the RX port + audio output and idles
+                    // until a `resume` arrives on that port (mpv exit).
+                    match crate::osc::prepare_standby_resume_port() {
+                        Some(resume_port) => {
+                            let reply = OscMessage {
+                                addr: crate::osc::STANDBY_RESUME_REPLY.to_string(),
+                                args: vec![OscType::Int(resume_port as i32)],
+                            };
+                            if let Ok(bytes) =
+                                rosc::encoder::encode(&rosc::OscPacket::Message(reply))
+                            {
+                                let _ = socket.send_to(&bytes, src);
+                            }
+                            log::info!(
+                                "OSC yield_port: entering standby; resume port {resume_port}"
+                            );
+                            sys::shutdown::request_standby();
+                        }
+                        None => {
+                            log::warn!(
+                                "OSC yield_port: could not allocate a resume port; shutting down"
+                            );
+                            sys::shutdown::request_shutdown();
+                        }
+                    }
                 } else {
                     log::info!("OSC yield_port ignored (instance not yieldable)");
                 }
+            }
+            RuntimeCommand::Resume => {
+                log::info!("OSC resume requested");
+                sys::shutdown::request_resume();
             }
             RuntimeCommand::SetLogLevel(requested) => {
                 sys::live_log::set_runtime_level(requested);

--- a/omniphony-renderer/runtime_control/src/command.rs
+++ b/omniphony-renderer/runtime_control/src/command.rs
@@ -9,6 +9,9 @@ pub enum RuntimeCommand {
     /// Another local instance wants the OSC RX port; only honoured by
     /// instances started with `--osc-yield` (see `sys::shutdown::is_yieldable`).
     YieldPort,
+    /// Sent to a standing-by instance (on its advertised dynamic resume port) to
+    /// re-acquire the OSC port + audio and resume rendering.
+    Resume,
     SetLogLevel(LevelFilter),
 }
 
@@ -30,6 +33,7 @@ pub fn parse_process_command(msg: &OscMessage) -> Option<RuntimeCommand> {
         "/omniphony/control/reload_config" => Some(RuntimeCommand::ReloadConfig),
         "/omniphony/control/quit" => Some(RuntimeCommand::Quit),
         "/omniphony/control/yield_port" => Some(RuntimeCommand::YieldPort),
+        "/omniphony/control/resume" => Some(RuntimeCommand::Resume),
         "/omniphony/control/log_level" => msg.args.first().and_then(|arg| match arg {
             OscType::String(s) => parse_runtime_log_level(s).map(RuntimeCommand::SetLogLevel),
             _ => None,

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -155,6 +155,9 @@ pub const CONTROL_SPREAD_MIN: &str = "/omniphony/control/spread/min";
 pub const CONTROL_SPREAD_SIZE_TO_SPREAD_MODE: &str =
     "/omniphony/control/spread/size_to_spread_mode";
 pub const CONTROL_YIELD_PORT: &str = "/omniphony/control/yield_port";
+/// Sent to a standing-by instance (on the dynamic resume port it advertised in
+/// reply to a yield) to ask it to re-acquire the OSC port + audio and resume.
+pub const CONTROL_RESUME: &str = "/omniphony/control/resume";
 
 /// Prefix for the per-object mute address. Append `"{id}/mute"`.
 pub const CONTROL_OBJECT_PREFIX: &str = "/omniphony/control/object/";
@@ -324,6 +327,7 @@ pub const ALL_CONTROL: &[&str] = &[
     CONTROL_RENDER_EVALUATION_MODE_FROM_FILE,
     CONTROL_RENDER_EVALUATION_POSITION_INTERPOLATION,
     CONTROL_RENDER_INPUT_PIPE,
+    CONTROL_RESUME,
     CONTROL_ROOM_RATIO,
     CONTROL_ROOM_RATIO_CENTER_BLEND,
     CONTROL_ROOM_RATIO_LOWER,

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -457,12 +457,53 @@ fn handle_audio_message(
     handler.handle_decoded_frame(decoded.source, frame, &ctx)
 }
 
+/// Standby handoff: an mpv-embedded renderer asked for the OSC port. Release the
+/// audio output (so an exclusive backend like ASIO frees the device for mpv) and
+/// the OSC RX port, then idle — keeping the engine + VBAP table warm — until a
+/// `resume` arrives (mpv exited) or the process is asked to quit. The audio
+/// writer rebuilds itself lazily on the first decoded frame after resume.
+fn run_standby_until_resume(
+    rx: &mpsc::Receiver<Result<DecoderMessage>>,
+    handler: &mut DecodeHandler,
+) {
+    sys::shutdown::take_standby_request();
+    log::info!("Entering standby: releasing audio output + OSC port for mpv");
+    handler.output.audio_writer = None;
+    if let Some(osc) = handler.telemetry.osc_sender.as_mut() {
+        osc.enter_standby();
+    }
+    loop {
+        if sys::ShutdownHandle::is_requested()
+            || sys::ShutdownHandle::is_restart_from_config_requested()
+        {
+            return;
+        }
+        if sys::shutdown::take_resume_request() {
+            break;
+        }
+        // Discard any frames the decoder rendered while standing by so the
+        // decoder thread never blocks on a full channel and no stale audio is
+        // played on resume.
+        while rx.try_recv().is_ok() {}
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    log::info!("Resuming from standby: re-acquiring OSC port + audio output");
+    if let Some(osc) = handler.telemetry.osc_sender.as_mut() {
+        if let Err(e) = osc.resume() {
+            log::error!("standby resume: failed to re-bind the OSC port: {e}");
+        }
+    }
+}
+
 fn process_decoder_messages(
     rx: &mpsc::Receiver<Result<DecoderMessage>>,
     handler: &mut DecodeHandler,
     ctx: &DecodeRunContext<'_>,
 ) -> Result<()> {
     loop {
+        if sys::shutdown::is_standby_requested() {
+            run_standby_until_resume(rx, handler);
+        }
         let result = match rx.recv_timeout(std::time::Duration::from_millis(50)) {
             Ok(result) => result,
             Err(mpsc::RecvTimeoutError::Timeout) => {

--- a/omniphony-renderer/sys/src/shutdown.rs
+++ b/omniphony-renderer/sys/src/shutdown.rs
@@ -18,6 +18,13 @@ static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 static RELOAD_REQUESTED: AtomicBool = AtomicBool::new(false);
 static RESTART_FROM_CONFIG_REQUESTED: AtomicBool = AtomicBool::new(false);
 static YIELDABLE: AtomicBool = AtomicBool::new(false);
+/// Set by the yield handler on a `--osc-yield` instance: the render loop should
+/// drop its OSC port + audio output and idle in **standby** (without exiting),
+/// so an mpv-embedded renderer can take the port over. See `request_standby`.
+static STANDBY_REQUESTED: AtomicBool = AtomicBool::new(false);
+/// Set when a standing-by instance is asked to come back (mpv released the
+/// port): the standby wait loop re-acquires the OSC port + audio output.
+static RESUME_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 /// Mark this process as willing to shut down when another local instance
 /// requests the OSC port via `/omniphony/control/yield_port`. Set by the CLI
@@ -30,6 +37,29 @@ pub fn set_yieldable(yieldable: bool) {
 /// Whether this instance honours `/omniphony/control/yield_port`.
 pub fn is_yieldable() -> bool {
     YIELDABLE.load(Ordering::Relaxed)
+}
+
+/// Take (and clear) a pending standby request. The render loop checks this and,
+/// when set, releases its OSC port + audio writer and idles until resumed.
+pub fn take_standby_request() -> bool {
+    STANDBY_REQUESTED.swap(false, Ordering::Relaxed)
+}
+
+/// Whether a standby is pending (peek, without clearing).
+pub fn is_standby_requested() -> bool {
+    STANDBY_REQUESTED.load(Ordering::Relaxed)
+}
+
+/// Ask a standing-by render loop to resume (re-acquire the OSC port + audio).
+/// Set from the dynamic resume-port listener; the standby wait loop polls it, so
+/// no wake of the (idle, non-blocking) loop is needed.
+pub fn request_resume() {
+    RESUME_REQUESTED.store(true, Ordering::Relaxed);
+}
+
+/// Take (and clear) a pending resume request.
+pub fn take_resume_request() -> bool {
+    RESUME_REQUESTED.swap(false, Ordering::Relaxed)
 }
 
 // Windows: HANDLE of the manual-reset event used to wake process_chunks_with_shutdown.
@@ -342,6 +372,18 @@ pub fn request_shutdown() {
     }
 }
 
+/// Request that the render loop enter standby (release OSC port + audio, stay
+/// alive). Wakes the loop out of a blocking input read via the self-pipe, like
+/// `request_shutdown`, so it notices promptly even when its input is idle.
+#[cfg(unix)]
+pub fn request_standby() {
+    STANDBY_REQUESTED.store(true, Ordering::Relaxed);
+    let fd = SIGNAL_WRITE_FD.load(Ordering::Relaxed);
+    if fd >= 0 {
+        unsafe { libc::write(fd, b"\x03".as_ptr() as *const libc::c_void, 1) };
+    }
+}
+
 /// Programmatically trigger a clean shutdown — equivalent of SIGTERM on Unix.
 ///
 /// Sets `SHUTDOWN_REQUESTED` and signals the overlapped-I/O event so that
@@ -350,6 +392,15 @@ pub fn request_shutdown() {
 #[cfg(windows)]
 pub fn request_shutdown() {
     SHUTDOWN_REQUESTED.store(true, Ordering::Relaxed);
+    signal_shutdown_event();
+}
+
+/// Request that the render loop enter standby (release OSC port + audio, stay
+/// alive). Signals the overlapped-I/O event so the loop wakes out of a blocking
+/// input read, like `request_shutdown`.
+#[cfg(windows)]
+pub fn request_standby() {
+    STANDBY_REQUESTED.store(true, Ordering::Relaxed);
     signal_shutdown_event();
 }
 


### PR DESCRIPTION
## Problem

A yieldable standby (the OS **service**, or a watchdog-launched CLI standby) used to **exit** on `/omniphony/control/yield_port` and rely on the watchdog to respawn it after mpv. That works for a CLI standby but **not for the service**: systemd `Restart=on-failure` and Windows have no clean-exit restart, so the service never came back after mpv — and restarting a Windows service needs elevation (UAC). Hence the reported "after mpv, the service is stopped / can't tell service vs cli".

## Approach (your idea: standby/resume, not kill+respawn)

Keep the process alive and hand the port off:

- **Yield handler** allocates a **dynamic resume port**, replies it to the requester (mpv) on `/omniphony/yield/resume_port`, and signals standby instead of shutdown (`sys::shutdown::request_standby`).
- **Render loop** releases the audio output (`audio_writer = None` → an exclusive ASIO device frees for mpv) and the OSC RX port (`OscSender::enter_standby`), then idles — **keeping the engine + VBAP table warm** (fast resume) — until resume. The writer rebuilds lazily on the first frame after resume.
- **The port taker (mpv)** records the advertised resume port and, as it releases the port at `OscSender::Drop` (quit / `orender_destroy`), sends `/omniphony/control/resume` so the standby re-acquires it. Safety net: the standby also slow-polls the RX port in case mpv crashes without sending resume.

No watchdog change needed: the standby self-resumes and re-binds the port, so the watchdog's port probe sees it busy and never double-spawns. Pairs with #97 (auto-start off on service install, `· service` label).

## Validation

- **Headless Linux E2E**: a `--osc-yield` standby on a test port — on `yield_port` it stays alive, advertises a resume port, and **frees the RX port**; on `resume` it **re-acquires** it. Release/re-bind confirmed via `/proc` sockets; logs show `Entering standby` → `Resuming from standby`.
- New unit test for the resume-port advertise + resume-delivery handshake; full renderer test suite green; `orender_engine`/`orender_ffi` cross-compile for `x86_64-pc-windows-gnu`; `cargo fmt --check` clean.

## Still to validate on real setups

- Real mpv play→stop cycle (the embedded-renderer side of the handshake runs through the same `bind_rx_socket`/`OscSender::Drop` path).
- Windows ASIO: the audio device actually frees for mpv during standby and is re-acquired on resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)