### PR TITLE
binaural: dry headphone output by default (reflections + reverb off)

### DIFF
--- a/omniphony-renderer/BINAURAL.md
+++ b/omniphony-renderer/BINAURAL.md
@@ -54,12 +54,12 @@ in Studio and over OSC (addresses listed at the end).
 | `hrtf_sofa_path` | — | SOFA file used when `hrir_source: sofa` |
 | `head_tracking.osc_address` | — | OSC address carrying the orientation (empty disables tracking) |
 | `head_tracking.format` | `auto` | `auto` / `quat` / `rotvec` / `euler` |
-| `reflections.enabled` | `true` | shoebox early reflections (externalization) |
+| `reflections.enabled` | `false` | shoebox early reflections (externalization) |
 | `reflections.room_width_m` | `4.0` | room extent, x (clamped 1–20 m) |
 | `reflections.room_depth_m` | `5.0` | room extent, y |
 | `reflections.room_height_m` | `2.7` | room extent, z |
 | `reflections.level` | `0.5` | per-reflection wall gain (0–1) |
-| `reverb.enabled` | `true` | late-reverb tail (stereo FDN) |
+| `reverb.enabled` | `false` | late-reverb tail (stereo FDN) |
 | `reverb.level` | `0.25` | reverb return level (0–1) |
 | `reverb.rt60_s` | `0.35` | broadband decay time (s) — living-room-ish, not a hall |
 | `reverb.predelay_ms` | `20` | gap between direct sound and tail start |

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -325,7 +325,7 @@ pub struct BinauralConfig {
 /// Models the (small, dry) listening room, not the scene's acoustics.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct ReverbConfig {
-    /// Master enable. Default true.
+    /// Master enable. Default false (dry headphone output unless opted in).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// Return level (0..1).
@@ -346,7 +346,7 @@ pub struct ReverbConfig {
 /// stage (six first-order images, listener at the room centre).
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct ReflectionsConfig {
-    /// Master enable. Default true.
+    /// Master enable. Default false (dry headphone output unless opted in).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// Room width (x), metres.

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -149,7 +149,9 @@ pub struct BinauralReflections {
 impl Default for BinauralReflections {
     fn default() -> Self {
         Self {
-            enabled: true,
+            // Off by default (dry headphone output); opt-in like the late
+            // reverb. Room size / level below apply once enabled.
+            enabled: false,
             room_size_m: [4.0, 5.0, 2.7],
             level: 0.5,
         }
@@ -177,7 +179,10 @@ pub struct BinauralReverb {
 impl Default for BinauralReverb {
     fn default() -> Self {
         Self {
-            enabled: true,
+            // Off by default: the late-reverb tail isn't convincing enough yet,
+            // so headphone output is dry unless the user opts in. The level/
+            // rt60/predelay below are the values used once it's enabled.
+            enabled: false,
             level: 0.25,
             rt60_s: 0.35,
             predelay_ms: 20.0,

--- a/omniphony-studio/src/controls/binaural.js
+++ b/omniphony-studio/src/controls/binaural.js
@@ -23,6 +23,18 @@ function send(cmd, args) {
   invoke(cmd, args).catch((e) => console.error('[binaural]', cmd, e));
 }
 
+// Show the reflections / reverb parameter blocks only when their master switch
+// is on, so a dry (default) headphone setup isn't cluttered with inactive
+// controls. Driven from the switch change handlers and applyBinauralState.
+function syncBinauralParamVisibility() {
+  const refl = el('binauralReflEnabled');
+  const reflParams = el('binauralReflParams');
+  if (reflParams) reflParams.style.display = refl && refl.checked ? 'grid' : 'none';
+  const rev = el('binauralRevEnabled');
+  const revParams = el('binauralRevParams');
+  if (revParams) revParams.style.display = rev && rev.checked ? 'grid' : 'none';
+}
+
 export function initBinauralPanel() {
   if (bound) return;
   bound = true;
@@ -89,6 +101,7 @@ export function initBinauralPanel() {
   const reflEnabled = el('binauralReflEnabled');
   if (reflEnabled) {
     reflEnabled.addEventListener('change', (e) => {
+      syncBinauralParamVisibility();
       if (applying) return;
       send('control_binaural_reflections_enabled', { enable: e.target.checked ? 1 : 0 });
     });
@@ -130,6 +143,7 @@ export function initBinauralPanel() {
   const revEnabled = el('binauralRevEnabled');
   if (revEnabled) {
     revEnabled.addEventListener('change', (e) => {
+      syncBinauralParamVisibility();
       if (applying) return;
       send('control_binaural_reverb_enabled', { enable: e.target.checked ? 1 : 0 });
     });
@@ -205,6 +219,9 @@ export function initBinauralPanel() {
       send('control_head_tracking_invert', { enable: e.target.checked ? 1 : 0 });
     });
   }
+
+  // Reflect the initial (default-off) switch state.
+  syncBinauralParamVisibility();
 }
 
 // Apply the `binaural` object from the renderer state bundle to the controls.
@@ -311,6 +328,9 @@ export function applyBinauralState(b) {
     }
     const air = el('binauralAirAbsorption');
     if (air && typeof b.airAbsorption === 'boolean') air.checked = b.airAbsorption;
+
+    // The renderer's enabled state drives the param blocks' visibility.
+    syncBinauralParamVisibility();
 
     const t = b.tracking || {};
     if (typeof t.address === 'string') setVal('binauralTrackAddress', t.address);

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -99,7 +99,7 @@ export function rendererPanelMarkup() {
             <div class="renderer-subpanel-body" style="margin-top:0.25rem;padding:0.3rem 0.4rem;background:rgba(255,255,255,0.03);border-radius:6px;display:grid;gap:0.3rem">
               <div class="switch-row" style="margin-top:0;font-size:0.7rem;color:#8fa6bd;">
                 <span data-help-i18n="help.binaural.earlyReflections">Early reflections</span>
-                <input id="binauralReflEnabled" type="checkbox" checked />
+                <input id="binauralReflEnabled" type="checkbox" />
               </div>
               <div class="binaural-help-row">
                 <div style="font-size:0.65rem;color:#888;margin-bottom:0.15rem;display:flex;justify-content:space-between;">
@@ -119,7 +119,7 @@ export function rendererPanelMarkup() {
               </div>
               <div class="switch-row" style="font-size:0.7rem;color:#8fa6bd;margin-top:0.2rem;border-top:1px solid rgba(255,255,255,0.05);padding-top:0.3rem;">
                 <span data-help-i18n="help.binaural.lateReverb">Late reverb</span>
-                <input id="binauralRevEnabled" type="checkbox" checked />
+                <input id="binauralRevEnabled" type="checkbox" />
               </div>
               <div class="binaural-help-row">
                 <div style="font-size:0.65rem;color:#888;margin-bottom:0.15rem;display:flex;justify-content:space-between;">

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -101,6 +101,7 @@ export function rendererPanelMarkup() {
                 <span data-help-i18n="help.binaural.earlyReflections">Early reflections</span>
                 <input id="binauralReflEnabled" type="checkbox" />
               </div>
+              <div id="binauralReflParams" style="display:none;gap:0.3rem">
               <div class="binaural-help-row">
                 <div style="font-size:0.65rem;color:#888;margin-bottom:0.15rem;display:flex;justify-content:space-between;">
                   <span data-help-i18n="help.binaural.reflectionLevel" data-help-anchor=".binaural-help-row">Reflection level</span>
@@ -117,10 +118,12 @@ export function rendererPanelMarkup() {
                 <input id="binauralReflRoomD" type="range" min="1" max="20" step="0.1" value="5" style="width:100%;" />
                 <input id="binauralReflRoomH" type="range" min="1" max="20" step="0.1" value="2.7" style="width:100%;" />
               </div>
+              </div>
               <div class="switch-row" style="font-size:0.7rem;color:#8fa6bd;margin-top:0.2rem;border-top:1px solid rgba(255,255,255,0.05);padding-top:0.3rem;">
                 <span data-help-i18n="help.binaural.lateReverb">Late reverb</span>
                 <input id="binauralRevEnabled" type="checkbox" />
               </div>
+              <div id="binauralRevParams" style="display:none;gap:0.3rem">
               <div class="binaural-help-row">
                 <div style="font-size:0.65rem;color:#888;margin-bottom:0.15rem;display:flex;justify-content:space-between;">
                   <span data-help-i18n="help.binaural.reverbLevel" data-help-anchor=".binaural-help-row">Reverb level</span>
@@ -134,6 +137,7 @@ export function rendererPanelMarkup() {
                   <span id="binauralRevRt60Val">0.35</span>
                 </div>
                 <input id="binauralRevRt60" type="range" min="0.1" max="1.5" step="0.05" value="0.35" style="width:100%;" />
+              </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Per feedback — the binaural listening-room simulation isn't convincing enough yet, so **default headphone output is now dry**: both **early reflections** and **late reverb** start disabled (opt-in).

- Flip the `BinauralReflections` / `BinauralReverb` default `enabled` to `false` (`renderer/src/live_params.rs`). A user's explicit `render.binaural.{reflections,reverb}.enabled = true` still turns them on — `renderer_build.rs` only overrides when the config value is present. Level / room size / RT60 / pre-delay defaults are unchanged and apply once enabled.
- `config.rs` doc comments + `BINAURAL.md` table updated (default `true` → `false`).
- Studio: the *Early reflections* / *Late reverb* switches start unchecked to match (the renderer state still drives them once connected).

Validated: renderer builds, binaural DSP tests green (they set `enabled` explicitly, unaffected), `cargo fmt --check` clean, Studio frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)