### PR TITLE
orender: Atmos profile, bed/objects & DialNorm for mpv track info (engine + FFI)

### DIFF
--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -56,6 +56,18 @@ pub struct Engine {
     has_objects: bool,
     loudness_applied: bool,
     decoded_samples: u64,
+    /// Dynamic object count of the last rendered frame (`channel_count − beds`),
+    /// `0` for plain multichannel content. Surfaced over FFI for the host's track
+    /// info display. Reset per segment.
+    last_object_count: u32,
+    /// Dialogue normalisation level (dBFS, ≤ 0) once a major-sync frame has
+    /// declared it. Surfaced over FFI for the host's track info display. Reset
+    /// per segment.
+    last_dialnorm: Option<i8>,
+    /// Channel labels of the bed of the last object-based frame (empty for plain
+    /// multichannel / no bed). Surfaced over FFI so the host can show the bed
+    /// composition (e.g. "LFE+11 objects"). Reused buffer; reset per segment.
+    last_bed_labels: Vec<RChannelLabel>,
 
     // ── DRC gain ramp state (continues across frames) ──
     drc_gain: f32,
@@ -197,6 +209,9 @@ impl Engine {
             has_objects: false,
             loudness_applied: false,
             decoded_samples: 0,
+            last_object_count: 0,
+            last_dialnorm: None,
+            last_bed_labels: Vec::new(),
             drc_gain: 1.0,
             drc_target_gain: 1.0,
             drc_ramp_samples_remaining: 0,
@@ -479,6 +494,25 @@ impl Engine {
         self.bridge.bridge.is_spatial()
     }
 
+    /// Dynamic object count of the last rendered frame (decoded `channel_count`
+    /// minus the bed channels), or `0` for plain multichannel content. For the
+    /// host's track info display.
+    pub fn object_count(&self) -> u32 {
+        self.last_object_count
+    }
+
+    /// Dialogue normalisation level in dBFS (≤ 0) once the stream has declared
+    /// it, else `None`. For the host's track info display.
+    pub fn dialnorm_db(&self) -> Option<i8> {
+        self.last_dialnorm
+    }
+
+    /// Channel labels of the bed of the last object-based frame (empty for plain
+    /// multichannel / no bed). For the host's track info display.
+    pub fn bed_labels(&self) -> &[RChannelLabel] {
+        &self.last_bed_labels
+    }
+
     /// Configured render mode for channel-based (non-object) content, as a small
     /// code for the C FFI: 0 = host (the host should fall back to its native
     /// decoder for plain multichannel streams), non-zero = spatial (render
@@ -547,6 +581,10 @@ impl Engine {
         self.frame_events.clear();
         self.loudness_applied = false;
         self.object_names.clear();
+        // A new segment may re-declare a different object count / dialnorm / bed.
+        self.last_object_count = 0;
+        self.last_dialnorm = None;
+        self.last_bed_labels.clear();
     }
 
     /// Push the live DRC mode to the bridge when it changes (selects which DRC
@@ -670,6 +708,7 @@ impl Engine {
         if !self.loudness_applied {
             if let Some(dialogue_level) = frame.dialogue_level.into_option() {
                 self.renderer.set_loudness(dialogue_level);
+                self.last_dialnorm = Some(dialogue_level);
                 self.loudness_applied = true;
                 if want_osc {
                     if let Some(osc) = self.osc.as_ref() {
@@ -897,9 +936,28 @@ impl Engine {
         )?;
         let render_time_ms = render_started.elapsed().as_secs_f32() * 1000.0;
 
+        // Dynamic object count = decoded channels minus the bed channels. Only
+        // meaningful for object-based content; plain multichannel reports 0.
+        let num_beds = self.bed_indices.as_ref().map_or(0, |b| b.len());
+        let n_objects = (channel_count as u32).saturating_sub(num_beds as u32);
+        self.last_object_count = if self.has_objects { n_objects } else { 0 };
+
+        // Bed composition for the host's track-info display, e.g. "LFE+11
+        // objects". The renderer lays bed channels out first in PCM order (see
+        // `build_spatial_channel_events`: beds at channels 0..num_beds, objects
+        // after), so the bed labels are the first `num_beds` channel labels —
+        // NOT `channel_labels[bed_id]` (`bed_indices` are OAMD bed ids, a
+        // different space). Reuse the buffer.
+        self.last_bed_labels.clear();
+        if self.has_objects {
+            for ch in 0..num_beds {
+                if let Some(&lbl) = frame.channel_labels.get(ch) {
+                    self.last_bed_labels.push(lbl);
+                }
+            }
+        }
+
         if let Some(perf) = self.perf.as_mut() {
-            let num_beds = self.bed_indices.as_ref().map_or(0, |b| b.len());
-            let n_objects = (channel_count as u32).saturating_sub(num_beds as u32);
             perf.record(
                 frame.sample_count,
                 n_objects,

--- a/omniphony-renderer/orender_engine/tests/parity.rs
+++ b/omniphony-renderer/orender_engine/tests/parity.rs
@@ -100,6 +100,20 @@ fn renders_real_truehd_atmos_stream() {
         "expected at least one rendered object frame"
     );
 
+    // Presentation info surfaced for the host's track-info display (FFI:
+    // orender_object_count / orender_dialnorm_db). An Atmos stream that rendered
+    // object frames must report a positive object count; DialNorm is logged
+    // rather than asserted (its presence depends on the fixture's major sync).
+    eprintln!(
+        "parity harness: object_count={} dialnorm_db={:?}",
+        engine.object_count(),
+        engine.dialnorm_db()
+    );
+    assert!(
+        engine.object_count() > 0,
+        "Atmos stream must report a positive object count"
+    );
+
     // NOTE: this fixture (`truehd_atmos_prefix_32k.mlp`) is a metadata prefix
     // whose audio decodes to silence (verified: valid OAMD/bed metadata, zero
     // PCM), so `peak` is expected to be 0.0 here. We therefore don't assert on

--- a/omniphony-renderer/orender_ffi/include/orender.h
+++ b/omniphony-renderer/orender_ffi/include/orender.h
@@ -90,6 +90,33 @@ void orender_destroy(struct OrenderRenderer *r);
 int orender_is_spatial(const struct OrenderRenderer *r);
 
 /**
+ * Dynamic object count of the last rendered frame (decoded channels minus the
+ * bed channels) for object-based content, `0` for plain multichannel, `-1` on
+ * a NULL handle / error. For the host's track info display. Meaningful after at
+ * least one [`orender_process`] call.
+ */
+int orender_object_count(const struct OrenderRenderer *r);
+
+/**
+ * Dialogue normalisation level in dBFS (always ≤ 0) once the stream has
+ * declared it, or [`i32::MIN`] when unknown / not yet seen (also on a NULL
+ * handle / error). For the host's track info display.
+ */
+int orender_dialnorm_db(const struct OrenderRenderer *r);
+
+/**
+ * Write the bed channel labels of the last object-based frame (one
+ * [`RChannelLabel`] byte per bed channel) so the host can show the bed
+ * composition (e.g. "LFE+11 objects").
+ *
+ * Same query/fill convention as [`orender_channel_layout`]: returns the bed
+ * channel count `N`; if `out_labels` is non-NULL and `cap >= N`, the first `N`
+ * bytes are filled (else nothing is written — call with `out_labels = NULL` to
+ * query `N`). `0` for plain multichannel / no bed / NULL handle / error.
+ */
+uint32_t orender_bed_layout(const struct OrenderRenderer *r, uint8_t *out_labels, uint32_t cap);
+
+/**
  * Configured render mode for channel-based (non-object) content:
  * 0 = host, 1 = spatial; <0 on error. When this is `host` (0) and
  * [`orender_is_spatial`] reports 0, the host should decline this track and fall

--- a/omniphony-renderer/orender_ffi/src/lib.rs
+++ b/omniphony-renderer/orender_ffi/src/lib.rs
@@ -353,6 +353,69 @@ pub unsafe extern "C" fn orender_is_spatial(r: *const OrenderRenderer) -> c_int 
     .unwrap_or(-1)
 }
 
+/// Dynamic object count of the last rendered frame (decoded channels minus the
+/// bed channels) for object-based content, `0` for plain multichannel, `-1` on
+/// a NULL handle / error. For the host's track info display. Meaningful after at
+/// least one [`orender_process`] call.
+#[no_mangle]
+pub unsafe extern "C" fn orender_object_count(r: *const OrenderRenderer) -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        if r.is_null() {
+            return -1;
+        }
+        (*(r as *const Engine)).object_count() as c_int
+    }))
+    .unwrap_or(-1)
+}
+
+/// Dialogue normalisation level in dBFS (always ≤ 0) once the stream has
+/// declared it, or [`i32::MIN`] when unknown / not yet seen (also on a NULL
+/// handle / error). For the host's track info display.
+#[no_mangle]
+pub unsafe extern "C" fn orender_dialnorm_db(r: *const OrenderRenderer) -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        if r.is_null() {
+            return c_int::MIN;
+        }
+        match (*(r as *const Engine)).dialnorm_db() {
+            Some(db) => db as c_int,
+            None => c_int::MIN,
+        }
+    }))
+    .unwrap_or(c_int::MIN)
+}
+
+/// Write the bed channel labels of the last object-based frame (one
+/// [`RChannelLabel`] byte per bed channel) so the host can show the bed
+/// composition (e.g. "LFE+11 objects").
+///
+/// Same query/fill convention as [`orender_channel_layout`]: returns the bed
+/// channel count `N`; if `out_labels` is non-NULL and `cap >= N`, the first `N`
+/// bytes are filled (else nothing is written — call with `out_labels = NULL` to
+/// query `N`). `0` for plain multichannel / no bed / NULL handle / error.
+#[no_mangle]
+pub unsafe extern "C" fn orender_bed_layout(
+    r: *const OrenderRenderer,
+    out_labels: *mut u8,
+    cap: u32,
+) -> u32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if r.is_null() {
+            return 0;
+        }
+        let labels = (*(r as *const Engine)).bed_labels();
+        let n = labels.len() as u32;
+        if !out_labels.is_null() && cap >= n {
+            let out = std::slice::from_raw_parts_mut(out_labels, labels.len());
+            for (dst, lbl) in out.iter_mut().zip(labels.iter()) {
+                *dst = *lbl as u8;
+            }
+        }
+        n
+    }))
+    .unwrap_or(0)
+}
+
 /// Configured render mode for channel-based (non-object) content:
 /// 0 = host, 1 = spatial; <0 on error. When this is `host` (0) and
 /// [`orender_is_spatial`] reports 0, the host should decline this track and fall


### PR DESCRIPTION
Decoding through the orender path left mpv's track info (shift+I) with an empty codec profile, so the Atmos / codec details were lost compared with the native decoder. This exposes the presentation info the engine already has so the host can rebuild the profile string.

- **Engine**: track the last frame's dynamic object count, bed channel labels and DialNorm; add `object_count()` / `bed_labels()` / `dialnorm_db()`.
- **FFI**: `orender_object_count`, `orender_dialnorm_db`, `orender_bed_layout` (cbindgen-regenerated `orender.h`).

Bed labels come from the first `num_beds` channels (the renderer lays beds out first in PCM order), not `channel_labels[bed_id]` — bed ids live in a separate OAMD id space.

The consuming host change is in the mpv fork (mgth/mpv `feat/orender-track-profile`); it needs the new `liborender` symbols from this PR.

Verification: `cargo fmt --check`, `cargo test -p orender_engine` (60 + env-gated parity), `cargo build -p orender_ffi --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)