### PR TITLE
chore(studio): bump 0.4.0

### DIFF
--- a/omniphony-studio/package.json
+++ b/omniphony-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniphony-studio",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Visualisation 3D d'objets audio spatialisés via OSC",
   "scripts": {
     "dev": "vite",

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "omniphony-studio"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "flate2",
  "image",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omniphony-studio"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 
 [[bin]]

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fr.omniphony.studio",
   "productName": "Omniphony Studio",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",


### PR DESCRIPTION
Version bump to **0.4.0** for the release.

Bumps the Studio app version (`package.json`, `tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`) from 0.3.3 → 0.4.0. Once merged, `main` is promoted to `release` and tagged `v0.4.0` (triggering the `release.yml` bundle build, which pairs with harletty `v0.7.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)