### PR TITLE
feat(macos): CoreAudio output backend + macOS arm64 CI

### DIFF
--- a/.github/workflows/liborender-release.yml
+++ b/.github/workflows/liborender-release.yml
@@ -92,8 +92,37 @@ jobs:
           name: liborender-windows-x86_64
           path: ${{ github.ref_name }}-windows-x86_64.zip
 
+  build-macos:
+    needs: guard
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build orender_ffi (release)
+        run: cargo build --release -p orender_ffi
+        working-directory: omniphony-renderer
+        env:
+          RUSTFLAGS: -D warnings
+
+      - name: Package (zip)
+        run: |
+          mkdir -p staging
+          cp omniphony-renderer/target/release/liborender.dylib staging/
+          cp omniphony-renderer/orender_ffi/include/orender.h staging/
+          cd staging
+          zip "../${GITHUB_REF_NAME}-macos-arm64.zip" liborender.dylib orender.h
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: liborender-macos-arm64
+          path: ${{ github.ref_name }}-macos-arm64.zip
+
   release:
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -108,6 +137,11 @@ jobs:
         with:
           name: liborender-windows-x86_64
 
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: liborender-macos-arm64
+
       - name: Create draft release
         uses: softprops/action-gh-release@v3
         with:
@@ -116,3 +150,4 @@ jobs:
           files: |
             ${{ github.ref_name }}-linux-x86_64.zip
             ${{ github.ref_name }}-windows-x86_64.zip
+            ${{ github.ref_name }}-macos-arm64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 # Triggered by a version tag (v*) or manually.
-# Creates a draft GitHub release with Linux (.deb, .AppImage) and Windows (.msi, .exe) bundles.
+# Creates a draft GitHub release with Linux (.deb, .AppImage), Windows (.msi,
+# .exe) and macOS arm64 (.dmg/.app) bundles.
 on:
   push:
     tags: ['v*']
@@ -38,6 +39,10 @@ jobs:
         include:
           - platform: ubuntu-22.04
           - platform: windows-latest
+          # macOS Apple Silicon: CoreAudio output backend, no extra system deps.
+          # tauri-action emits a .dmg/.app; the build is unsigned (ad-hoc) until
+          # signing secrets are configured.
+          - platform: macos-14
 
     runs-on: ${{ matrix.platform }}
 

--- a/omniphony-renderer/audio_output/Cargo.toml
+++ b/omniphony-renderer/audio_output/Cargo.toml
@@ -3,7 +3,7 @@ name = "audio_output"
 version = "0.2.4"
 edition = "2024"
 license = "GPL-3.0-only"
-description = "Audio output backends (PipeWire, ASIO)"
+description = "Audio output backends (PipeWire, ASIO, CoreAudio)"
 
 [lib]
 name = "audio_output"
@@ -22,6 +22,10 @@ pipewire = { version = "0.9.2", features = ["v0_3_49"] }
 
 [target.'cfg(windows)'.dependencies]
 cpal = { version = "0.15.3", features = ["asio"] }
+
+# macOS: cpal's default host is CoreAudio, so no extra feature is needed.
+[target.'cfg(target_os = "macos")'.dependencies]
+cpal = "0.15.3"
 
 [features]
 pipewire = []

--- a/omniphony-renderer/audio_output/src/cpal_output.rs
+++ b/omniphony-renderer/audio_output/src/cpal_output.rs
@@ -1,4 +1,7 @@
-#![cfg(target_os = "windows")]
+#![cfg(any(target_os = "windows", target_os = "macos"))]
+//! cpal-backed realtime output writer shared by the Windows (ASIO) and macOS
+//! (CoreAudio) backends. The two platforms differ only in which cpal host they
+//! open; the ring-buffer, local resampler and adaptive-rate servo are identical.
 
 use anyhow::{Result, anyhow};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -36,12 +39,34 @@ const BUFFER_SIZE: usize = 48000 * 16 * 4;
 const MIN_BUFFER_MS: u32 = 25;
 const DEFAULT_TARGET_BUFFER_MS: u32 = 220;
 const MAX_BUFFER_MS: u32 = 250;
-pub struct AsioWriter {
+
+/// Human-readable label for the active cpal output backend, used in logs and
+/// error messages (referenced via inline `{BACKEND}` format args throughout).
+#[cfg(target_os = "windows")]
+const BACKEND: &str = "ASIO";
+#[cfg(target_os = "macos")]
+const BACKEND: &str = "CoreAudio";
+
+/// Open the cpal host that backs realtime output on this platform: the ASIO
+/// host on Windows, the default (CoreAudio) host on macOS.
+fn output_host() -> Result<cpal::Host> {
+    #[cfg(target_os = "windows")]
+    {
+        cpal::host_from_id(cpal::HostId::Asio)
+            .map_err(|e| anyhow!("{BACKEND} host not available: {:?}", e))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Ok(cpal::default_host())
+    }
+}
+
+pub struct CpalWriter {
     sample_buffer: Arc<ArrayQueue<f32>>,
     input_sample_rate: u32,
     _output_sample_rate: u32,
     channel_count: u32,         // Number of audio channels we're producing
-    _device_channel_count: u32, // Number of channels the ASIO device expects
+    _device_channel_count: u32, // Number of channels the {BACKEND} device expects
     _stream_ready: Arc<AtomicBool>,
     enable_adaptive_resampling: bool, // Enable PI controller for buffer stability
     max_buffer_fill: usize,
@@ -61,10 +86,9 @@ pub struct AsioWriter {
     _stream: Option<cpal::Stream>,
 }
 
-/// Get a list of available ASIO device names
-pub fn list_asio_devices() -> Result<Vec<String>> {
-    let host = cpal::host_from_id(cpal::HostId::Asio)
-        .map_err(|e| anyhow!("ASIO Host not available: {:?}", e))?;
+/// Get a list of available output device names for this platform's backend.
+pub fn list_output_devices() -> Result<Vec<String>> {
+    let host = output_host()?;
 
     let devices: Vec<String> = host
         .output_devices()?
@@ -74,10 +98,10 @@ pub fn list_asio_devices() -> Result<Vec<String>> {
     Ok(devices)
 }
 
-impl AsioWriter {
-    pub fn list_asio_devices() -> Result<()> {
-        println!("Available ASIO Devices:");
-        let devices = list_asio_devices()?;
+impl CpalWriter {
+    pub fn list_output_devices() -> Result<()> {
+        println!("Available {BACKEND} Devices:");
+        let devices = list_output_devices()?;
 
         for (i, device_name) in devices.iter().enumerate() {
             println!("  {}: {}", i, device_name);
@@ -157,11 +181,10 @@ impl AsioWriter {
         let max_buffer_fill = (samples_per_ms * max_buffer_ms as usize)
             .max(target_buffer_fill + channel_count as usize);
 
-        // Initialize CPAL ASIO host
-        let host = cpal::host_from_id(cpal::HostId::Asio)
-            .map_err(|e| anyhow!("ASIO Host not available: {:?}", e))?;
+        // Open the platform's cpal output host (ASIO on Windows, CoreAudio on macOS).
+        let host = output_host()?;
 
-        log::info!("ASIO Host initialized");
+        log::info!("{BACKEND} host initialized");
 
         // Find device by name if specified, otherwise use default
         let device = if let Some(ref target_name) = output_device {
@@ -178,22 +201,24 @@ impl AsioWriter {
 
             found_device.ok_or_else(|| {
                 anyhow!(
-                    "ASIO device '{}' not found. Use 'orender list-asio-devices' to see available devices.",
-                    target_name
+                    "{BACKEND} output device '{target_name}' not found; run the platform list-output-devices command to see available devices.",
                 )
             })?
         } else {
             host.default_output_device()
-                .ok_or_else(|| anyhow!("No default ASIO output device found"))?
+                .ok_or_else(|| anyhow!("No default {BACKEND} output device found"))?
         };
 
-        log::info!("Using ASIO device: {}", device.name().unwrap_or_default());
+        log::info!(
+            "Using {BACKEND} device: {}",
+            device.name().unwrap_or_default()
+        );
 
         // Find a supported configuration that has at least the required channels
         let supported_configs: Vec<_> = device.supported_output_configs()?.collect();
 
         log::info!(
-            "Looking for ASIO config supporting {} channels at {} Hz",
+            "Looking for {BACKEND} config supporting {} channels at {} Hz",
             channel_count,
             output_sample_rate
         );
@@ -219,7 +244,7 @@ impl AsioWriter {
             .min_by_key(|c| c.channels())
             .ok_or_else(|| {
                 anyhow!(
-                    "ASIO device does not support {} channels at {} Hz. Available configs: {:?}",
+                    "{BACKEND} device does not support {} channels at {} Hz. Available configs: {:?}",
                     channel_count,
                     output_sample_rate,
                     supported_configs
@@ -245,7 +270,7 @@ impl AsioWriter {
 
         if resample_ratio != 1.0 {
             log::info!(
-                "ASIO Config: {} Hz (resampling from {} Hz, ratio {:.3}x), {} device channels (using {} for output)",
+                "{BACKEND} Config: {} Hz (resampling from {} Hz, ratio {:.3}x), {} device channels (using {} for output)",
                 output_sample_rate,
                 input_sample_rate,
                 resample_ratio,
@@ -254,7 +279,7 @@ impl AsioWriter {
             );
         } else {
             log::info!(
-                "ASIO Config: {} Hz, {} device channels (using {} for output)",
+                "{BACKEND} Config: {} Hz, {} device channels (using {} for output)",
                 output_sample_rate,
                 device_channel_count,
                 channel_count
@@ -275,7 +300,7 @@ impl AsioWriter {
             log::info!("Adaptive resampling disabled (fixed resampling ratio)");
         }
         log::info!(
-            "ASIO buffer thresholds ({}ch @ {}Hz input): min={} target={} max={} samples",
+            "{BACKEND} buffer thresholds ({}ch @ {}Hz input): min={} target={} max={} samples",
             channel_count,
             input_sample_rate,
             min_buffer_fill,
@@ -378,7 +403,7 @@ impl AsioWriter {
                 let callback_frames = data.len() / device_channel_count_for_callback as usize;
                 let callback_audio_samples = callback_frames * channel_count as usize;
                 // Ring-buffer occupancy is tracked in input-domain samples, while the
-                // ASIO callback consumes output-domain samples after local resampling.
+                // {BACKEND} callback consumes output-domain samples after local resampling.
                 // Convert the callback midpoint estimate back to input-domain samples
                 // before comparing against the input-domain fill level.
                 let callback_input_domain_samples = if effective_resample_ratio > 0.0 {
@@ -397,7 +422,7 @@ impl AsioWriter {
                 pipeline_latency_ms_bits_clone
                     .store(callback_midpoint_ms.to_bits(), Ordering::Relaxed);
                 let current_asio_cfg = live_config_for_callback.lock().clone();
-                // ASIO callback dt comes from the nominal frame size of
+                // {BACKEND} callback dt comes from the nominal frame size of
                 // the active buffer. We don't have an atomic-published dt
                 // here as on the PipeWire path; the configured value is
                 // accurate enough for the cutoff math.
@@ -411,7 +436,7 @@ impl AsioWriter {
                     available_samples,
                     output_fifo_input_domain_samples,
                     pending_resampler_input_samples,
-                    0, // ASIO backend has no output pacer stage
+                    0, // {BACKEND} backend has no output pacer stage
                     callback_input_domain_samples,
                     channel_count as usize,
                     input_sample_rate,
@@ -501,7 +526,7 @@ impl AsioWriter {
 
                         if callback_count % 100 == 0 {
                             log::trace!(
-                                "ASIO Adaptive: buf={}/{} drift={} ratio={:.6} (base={:.2} P={:.6} I={:.6} kp={:.6} ki={:.6} max_adjust={:.6})",
+                                "{BACKEND} Adaptive: buf={}/{} drift={} ratio={:.6} (base={:.2} P={:.6} I={:.6} kp={:.6} ki={:.6} max_adjust={:.6})",
                                 metrics.control_available,
                                 target_buffer_fill,
                                 decision.step.drift,
@@ -661,7 +686,7 @@ impl AsioWriter {
                     }
                 }
 
-                // 3. Fill ASIO callback buffer from FIFO
+                // 3. Fill {BACKEND} callback buffer from FIFO
                 if far_decision.hard_recover_high {
                     let plan = compute_hard_recover_high_plan(
                         callback_input_domain_samples,
@@ -710,8 +735,8 @@ impl AsioWriter {
                     // Underrun
                     note_refill_or_underrun(
                         &mut runtime_state,
-                        "ASIO underrun",
-                        "ASIO underrun",
+                        "output underrun",
+                        "output underrun",
                         resampler_fifo.output_len(),
                         audio_samples_needed,
                     );
@@ -823,7 +848,7 @@ impl AsioWriter {
         f32::from_bits(self.control_latency_ms_bits.load(Ordering::Relaxed))
     }
 
-    /// EMA-smoothed control latency. The ASIO backend does not yet maintain a
+    /// EMA-smoothed control latency. The {BACKEND} backend does not yet maintain a
     /// separate smoothed metric, so it falls back to the raw control latency.
     pub fn smoothed_control_audio_delay_ms(&self) -> f32 {
         self.control_audio_delay_ms()

--- a/omniphony-renderer/audio_output/src/lib.rs
+++ b/omniphony-renderer/audio_output/src/lib.rs
@@ -244,7 +244,10 @@ pub fn compute_adaptive_step(
     }
 }
 
-pub mod asio;
+// cpal-backed realtime output, shared by the Windows (ASIO) and macOS
+// (CoreAudio) backends. Not built on Linux (PipeWire handles output there).
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub mod cpal_output;
 #[cfg(target_os = "linux")]
 pub mod pipewire;
 
@@ -254,5 +257,16 @@ pub use pipewire::{PipewireBufferConfig, PipewireWriter, list_pipewire_output_de
 #[cfg(target_os = "linux")]
 pub type PipewireAdaptiveResamplingConfig = AdaptiveResamplingConfig;
 
+// On Windows the cpal writer is the ASIO backend; on macOS it is CoreAudio.
+// Both share `cpal_output::CpalWriter`; expose them under platform-specific
+// aliases so the CLI keeps stable, descriptive names.
 #[cfg(target_os = "windows")]
-pub use asio::{AsioWriter, list_asio_devices};
+pub use cpal_output::{CpalWriter as AsioWriter, list_output_devices as list_asio_devices};
+
+#[cfg(target_os = "macos")]
+pub use cpal_output::{
+    CpalWriter as CoreAudioWriter, list_output_devices as list_coreaudio_devices,
+};
+
+#[cfg(target_os = "macos")]
+pub type CoreAudioAdaptiveResamplingConfig = AdaptiveResamplingConfig;

--- a/omniphony-renderer/orender_ffi/build.rs
+++ b/omniphony-renderer/orender_ffi/build.rs
@@ -20,6 +20,15 @@ fn main() {
     if target_os == "linux" && profile == "release" {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,liborender.so.0");
     }
+    // On macOS, stamp the release dylib with an `@rpath` install name so a
+    // bundled consumer (mpv, Studio) resolves `liborender.dylib` via its own
+    // rpath / `@loader_path` rather than the absolute build-tree path that the
+    // linker would otherwise record. Debug builds keep the default install
+    // name so the C smoke test links against `target/debug/liborender.dylib`
+    // directly, mirroring the Linux soname handling above.
+    if target_os == "macos" && profile == "release" {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,@rpath/liborender.dylib");
+    }
 
     match cbindgen::Builder::new()
         .with_crate(&crate_dir)

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -105,6 +105,10 @@ pub enum Commands {
     /// List available ASIO output devices (Windows only)
     #[cfg(target_os = "windows")]
     ListAsioDevices,
+
+    /// List available CoreAudio output devices (macOS only)
+    #[cfg(target_os = "macos")]
+    ListCoreaudioDevices,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -876,6 +880,9 @@ pub enum OutputBackend {
     /// ASIO audio output (Windows only, requires 'asio' feature).
     #[cfg(target_os = "windows")]
     Asio,
+    /// CoreAudio audio output (macOS only).
+    #[cfg(target_os = "macos")]
+    Coreaudio,
     /// Placeholder used when no realtime output backend is compiled in.
     #[value(skip)]
     Unsupported,
@@ -920,8 +927,28 @@ impl OutputBackend {
         {
             return Some(Self::Asio);
         }
+        #[cfg(target_os = "macos")]
+        {
+            return Some(Self::Coreaudio);
+        }
         #[allow(unreachable_code)]
         None
+    }
+
+    /// True when this backend is the cpal-based local output for the current
+    /// platform (ASIO on Windows, CoreAudio on macOS). Lets the shared
+    /// latency-target re-init and runtime-reset logic stay platform-agnostic.
+    pub fn is_local_cpal(self) -> bool {
+        #[cfg(target_os = "windows")]
+        let local = matches!(self, Self::Asio);
+        #[cfg(target_os = "macos")]
+        let local = matches!(self, Self::Coreaudio);
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        let local = {
+            let _ = self;
+            false
+        };
+        local
     }
 }
 
@@ -1090,6 +1117,8 @@ impl std::str::FromStr for OutputBackend {
             "pipewire" => Ok(Self::Pipewire),
             #[cfg(target_os = "windows")]
             "asio" => Ok(Self::Asio),
+            #[cfg(target_os = "macos")]
+            "coreaudio" | "core-audio" => Ok(Self::Coreaudio),
             _ => Err(format!("Unknown output backend: {s}")),
         }
     }

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -27,6 +27,18 @@ fn list_available_output_devices(_backend: OutputBackend) -> Vec<OutputDeviceOpt
         .collect()
 }
 
+#[cfg(target_os = "macos")]
+fn list_available_output_devices(_backend: OutputBackend) -> Vec<OutputDeviceOption> {
+    audio_output::list_coreaudio_devices()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|name| OutputDeviceOption {
+            value: name.clone(),
+            label: name,
+        })
+        .collect()
+}
+
 #[cfg(target_os = "linux")]
 fn list_available_output_devices(backend: OutputBackend) -> Vec<OutputDeviceOption> {
     match backend {
@@ -40,7 +52,7 @@ fn list_available_output_devices(backend: OutputBackend) -> Vec<OutputDeviceOpti
     }
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
 fn list_available_output_devices(_backend: OutputBackend) -> Vec<OutputDeviceOption> {
     Vec::new()
 }

--- a/omniphony-renderer/src/cli/decode/output.rs
+++ b/omniphony-renderer/src/cli/decode/output.rs
@@ -1,8 +1,8 @@
 use anyhow::{Result, anyhow};
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use audio_output::AdaptiveResamplingConfig;
-#[cfg(target_os = "windows")]
-use audio_output::asio::AsioWriter;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use audio_output::cpal_output::CpalWriter;
 #[cfg(target_os = "linux")]
 use audio_output::pipewire::{
     PipewireAdaptiveResamplingConfig, PipewireBufferConfig, PipewireWriter,
@@ -71,8 +71,10 @@ impl AudioSamples {
 pub enum AudioWriter {
     #[cfg(target_os = "linux")]
     Pipewire(PipewireWriter),
-    #[cfg(target_os = "windows")]
-    Asio(AsioWriter),
+    /// cpal-backed local output: ASIO on Windows, CoreAudio on macOS. Both
+    /// share `CpalWriter`, so a single variant serves both platforms.
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    Cpal(CpalWriter),
     Unsupported,
 }
 
@@ -127,8 +129,10 @@ impl AudioWriter {
         Ok(AudioWriter::Pipewire(pipewire_writer))
     }
 
-    #[cfg(target_os = "windows")]
-    pub fn create_asio(
+    /// Create the platform's cpal-backed realtime output writer: ASIO on
+    /// Windows, CoreAudio on macOS. Both go through `CpalWriter`.
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    pub fn create_cpal(
         input_sample_rate: u32,
         sample_rate: u32,
         channel_count: u32,
@@ -137,7 +141,7 @@ impl AudioWriter {
         enable_adaptive_resampling: bool,
         adaptive_config: AdaptiveResamplingConfig,
     ) -> Result<Self> {
-        let asio_writer = AsioWriter::new(
+        let cpal_writer = CpalWriter::new(
             input_sample_rate,
             sample_rate,
             channel_count,
@@ -146,7 +150,7 @@ impl AudioWriter {
             enable_adaptive_resampling,
             adaptive_config,
         )?;
-        Ok(AudioWriter::Asio(asio_writer))
+        Ok(AudioWriter::Cpal(cpal_writer))
     }
 
     pub fn write_pcm_samples(
@@ -154,7 +158,7 @@ impl AudioWriter {
         samples: &AudioSamples,
         _channel_count: usize,
     ) -> Result<()> {
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = samples;
 
         match self {
@@ -168,10 +172,10 @@ impl AudioWriter {
                 }
                 Ok(())
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio_writer) => {
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
                 let samples_f32 = samples.to_f32();
-                asio_writer.write_samples(&samples_f32)?;
+                w.write_samples(&samples_f32)?;
                 Ok(())
             }
             AudioWriter::Unsupported => Err(anyhow!("No supported realtime output backend")),
@@ -203,8 +207,8 @@ impl AudioWriter {
                 drop(w);
                 Ok(())
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(mut w) => {
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(mut w) => {
                 w.flush()?;
                 drop(w);
                 Ok(())
@@ -220,9 +224,9 @@ impl AudioWriter {
                 pipewire_writer.flush()?;
                 Ok(())
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio_writer) => {
-                asio_writer.flush()?;
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
+                w.flush()?;
                 Ok(())
             }
             AudioWriter::Unsupported => Err(anyhow!("No supported realtime output backend")),
@@ -238,8 +242,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => Some(pw.latency_ms()),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => Some(asio.latency_ms()),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => Some(w.latency_ms()),
             AudioWriter::Unsupported => None,
         }
     }
@@ -250,8 +254,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => pw.rate_adjust(),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => asio.rate_adjust(),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => w.rate_adjust(),
             AudioWriter::Unsupported => None,
         }
     }
@@ -260,8 +264,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => pw.adaptive_band(),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => asio.adaptive_band(),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => w.adaptive_band(),
             AudioWriter::Unsupported => None,
         }
     }
@@ -270,8 +274,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => pw.adaptive_runtime_state(),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => asio.adaptive_runtime_state(),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => w.adaptive_runtime_state(),
             AudioWriter::Unsupported => None,
         }
     }
@@ -307,9 +311,9 @@ impl AudioWriter {
                 let v = pw.target_control_latency_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => {
-                let v = asio.target_control_latency_ms();
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
+                let v = w.target_control_latency_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
             AudioWriter::Unsupported => None,
@@ -324,9 +328,9 @@ impl AudioWriter {
                 let v = pw.total_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => {
-                let v = asio.total_audio_delay_ms();
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
+                let v = w.total_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
             AudioWriter::Unsupported => None,
@@ -346,9 +350,9 @@ impl AudioWriter {
                 let v = pw.measured_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => {
-                let v = asio.measured_audio_delay_ms();
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
+                let v = w.measured_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
             AudioWriter::Unsupported => None,
@@ -362,9 +366,9 @@ impl AudioWriter {
                 let v = pw.control_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => {
-                let v = asio.control_audio_delay_ms();
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
+                let v = w.control_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
             AudioWriter::Unsupported => None,
@@ -378,9 +382,9 @@ impl AudioWriter {
                 let v = pw.smoothed_control_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => {
-                let v = asio.smoothed_control_audio_delay_ms();
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => {
+                let v = w.smoothed_control_audio_delay_ms();
                 if v > 0.0 { Some(v) } else { None }
             }
             AudioWriter::Unsupported => None,
@@ -396,8 +400,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => Some(pw.avail_input_audio_delay_ms().max(0.0)),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => Some(asio.avail_input_audio_delay_ms().max(0.0)),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => Some(w.avail_input_audio_delay_ms().max(0.0)),
             AudioWriter::Unsupported => None,
         }
     }
@@ -406,8 +410,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => Some(pw.output_fifo_audio_delay_ms().max(0.0)),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => Some(asio.output_fifo_audio_delay_ms().max(0.0)),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => Some(w.output_fifo_audio_delay_ms().max(0.0)),
             AudioWriter::Unsupported => None,
         }
     }
@@ -416,8 +420,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => Some(pw.resampler_pending_audio_delay_ms().max(0.0)),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => Some(asio.resampler_pending_audio_delay_ms().max(0.0)),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => Some(w.resampler_pending_audio_delay_ms().max(0.0)),
             AudioWriter::Unsupported => None,
         }
     }
@@ -429,8 +433,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => pw.diag_atomic_handles(),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(_) => Vec::new(),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(_) => Vec::new(),
             AudioWriter::Unsupported => Vec::new(),
         }
     }
@@ -440,8 +444,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => pw.request_ratio_reset(),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => asio.request_ratio_reset(),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => w.request_ratio_reset(),
             AudioWriter::Unsupported => {}
         }
     }
@@ -451,8 +455,8 @@ impl AudioWriter {
         match self {
             #[cfg(target_os = "linux")]
             AudioWriter::Pipewire(pw) => pw.update_adaptive_config(config),
-            #[cfg(target_os = "windows")]
-            AudioWriter::Asio(asio) => asio.update_adaptive_config(config),
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            AudioWriter::Cpal(w) => w.update_adaptive_config(config),
             AudioWriter::Unsupported => {}
         }
     }

--- a/omniphony-renderer/src/cli/decode/output_runtime_sync.rs
+++ b/omniphony-renderer/src/cli/decode/output_runtime_sync.rs
@@ -70,13 +70,13 @@ impl<'a> OutputRuntimeCoordinator<'a> {
     }
 
     fn sync_requested_output_device(&mut self, output_backend: OutputBackend) -> Result<()> {
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         {
             let _ = output_backend;
             return Ok(());
         }
 
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
         {
             let requested = self
                 .audio_control
@@ -154,7 +154,7 @@ impl<'a> OutputRuntimeCoordinator<'a> {
             }
         }
 
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
         {
             let requested = self
                 .audio_control
@@ -164,24 +164,24 @@ impl<'a> OutputRuntimeCoordinator<'a> {
             if requested != self.runtime.latency_target_ms {
                 self.runtime.latency_target_ms = requested.max(1);
                 log::info!(
-                    "Applying requested ASIO latency target: {} ms",
+                    "Applying requested output latency target: {} ms",
                     self.runtime.latency_target_ms
                 );
 
-                if matches!(output_backend, OutputBackend::Asio) {
+                if output_backend.is_local_cpal() {
                     self.flush_and_invalidate_writer();
                 }
             }
         }
 
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = output_backend;
 
         Ok(())
     }
 
     fn sync_requested_adaptive_tuning(&mut self, _output_backend: OutputBackend) -> Result<()> {
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
         {
             let requested = self
                 .audio_control
@@ -377,14 +377,14 @@ impl<'a> OutputRuntimeCoordinator<'a> {
                 .update_adaptive_config(self.runtime.adaptive_resampling_config.clone());
         }
 
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = output_backend;
 
         Ok(())
     }
 
     fn sync_ratio_reset(&mut self) {
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
         if let Some(audio) = self.audio_control {
             if audio.take_ratio_reset() {
                 self.output.request_ratio_reset();
@@ -399,16 +399,18 @@ fn should_reset_writer(output_backend: OutputBackend) -> bool {
         OutputBackend::Pipewire => true,
         #[cfg(target_os = "windows")]
         OutputBackend::Asio => true,
+        #[cfg(target_os = "macos")]
+        OutputBackend::Coreaudio => true,
         _ => false,
     }
 }
 
 fn output_backend_supported_for_runtime_reset() -> bool {
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     {
         true
     }
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     {
         false
     }

--- a/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
+++ b/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
@@ -50,7 +50,7 @@ impl<'a> WriterLifecycleCoordinator<'a> {
         sample_rate: u32,
         channel_count: usize,
     ) -> Result<()> {
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = (output_backend, sample_rate, channel_count);
 
         if self.output.audio_writer.is_none() && !self.output.output_init_failed {
@@ -138,18 +138,18 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                 return Ok(());
             }
 
-            #[cfg(target_os = "windows")]
-            if output_backend == OutputBackend::Asio {
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            if output_backend.is_local_cpal() {
                 if let Some(output_rate) = self.runtime.output_sample_rate {
                     log::info!(
-                        "Creating ASIO audio stream with upsampling: {} Hz -> {} Hz, {} channels",
+                        "Creating realtime audio stream with upsampling: {} Hz -> {} Hz, {} channels",
                         sample_rate,
                         output_rate,
                         channel_count
                     );
                 } else {
                     log::info!(
-                        "Creating ASIO audio stream: {} Hz, {} channels",
+                        "Creating realtime audio stream: {} Hz, {} channels",
                         sample_rate,
                         channel_count
                     );
@@ -235,7 +235,7 @@ impl<'a> WriterLifecycleCoordinator<'a> {
         #[cfg(target_os = "linux")] pipewire_channel_names: Option<Vec<String>>,
         #[cfg(not(target_os = "linux"))] _pipewire_channel_names: Option<Vec<String>>,
     ) -> Result<AudioWriter> {
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = (output_backend, sample_rate, channel_count);
 
         match output_backend {
@@ -277,20 +277,31 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                 }
             }
             #[cfg(target_os = "windows")]
-            OutputBackend::Asio => {
-                let effective_sample_rate = self.runtime.output_sample_rate.unwrap_or(sample_rate);
-                Ok(AudioWriter::create_asio(
-                    sample_rate,
-                    effective_sample_rate,
-                    channel_count as u32,
-                    self.runtime.output_device.clone(),
-                    self.runtime.latency_target_ms,
-                    self.runtime.enable_adaptive_resampling,
-                    self.runtime.adaptive_resampling_config.clone(),
-                )?)
-            }
+            OutputBackend::Asio => self.build_cpal_audio_writer(sample_rate, channel_count),
+            #[cfg(target_os = "macos")]
+            OutputBackend::Coreaudio => self.build_cpal_audio_writer(sample_rate, channel_count),
             OutputBackend::Unsupported => Err(anyhow!("No supported realtime output backend")),
         }
+    }
+
+    /// Build the cpal-backed realtime writer — ASIO on Windows, CoreAudio on
+    /// macOS. Both platforms feed the same `CpalWriter` via `create_cpal`.
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    fn build_cpal_audio_writer(
+        &self,
+        sample_rate: u32,
+        channel_count: usize,
+    ) -> Result<AudioWriter> {
+        let effective_sample_rate = self.runtime.output_sample_rate.unwrap_or(sample_rate);
+        AudioWriter::create_cpal(
+            sample_rate,
+            effective_sample_rate,
+            channel_count as u32,
+            self.runtime.output_device.clone(),
+            self.runtime.latency_target_ms,
+            self.runtime.enable_adaptive_resampling,
+            self.runtime.adaptive_resampling_config.clone(),
+        )
     }
 }
 
@@ -304,6 +315,8 @@ fn effective_audio_state(
         OutputBackend::Pipewire => (output_rate.unwrap_or(input_sample_rate), "f32le"),
         #[cfg(target_os = "windows")]
         OutputBackend::Asio => (output_rate.unwrap_or(input_sample_rate), "f32le"),
+        #[cfg(target_os = "macos")]
+        OutputBackend::Coreaudio => (output_rate.unwrap_or(input_sample_rate), "f32le"),
         _ => (input_sample_rate, "s24le"),
     }
 }

--- a/omniphony-renderer/src/cli/list_asio_devices.rs
+++ b/omniphony-renderer/src/cli/list_asio_devices.rs
@@ -10,7 +10,7 @@ pub fn cmd_list_asio_devices() -> Result<()> {
     println!("Available ASIO devices:");
     println!();
 
-    let devices = audio_output::asio::list_asio_devices()?;
+    let devices = audio_output::list_asio_devices()?;
 
     if devices.is_empty() {
         println!("  No ASIO devices found.");

--- a/omniphony-renderer/src/cli/list_coreaudio_devices.rs
+++ b/omniphony-renderer/src/cli/list_coreaudio_devices.rs
@@ -1,0 +1,27 @@
+//! List available CoreAudio output devices (macOS only)
+
+use anyhow::Result;
+
+/// Execute the list-coreaudio-devices command
+///
+/// Lists all available CoreAudio output devices on the system.
+pub fn cmd_list_coreaudio_devices() -> Result<()> {
+    println!();
+    println!("Available CoreAudio devices:");
+    println!();
+
+    let devices = audio_output::list_coreaudio_devices()?;
+
+    if devices.is_empty() {
+        println!("  No CoreAudio output devices found.");
+    } else {
+        for (idx, device) in devices.iter().enumerate() {
+            println!("  {}. {}", idx + 1, device);
+        }
+        println!();
+        println!("Use --output-device with the exact device name to select a device.");
+    }
+
+    println!();
+    Ok(())
+}

--- a/omniphony-renderer/src/cli/mod.rs
+++ b/omniphony-renderer/src/cli/mod.rs
@@ -3,3 +3,5 @@ pub(crate) mod decode;
 pub(crate) mod generate_vbap;
 #[cfg(target_os = "windows")]
 pub(crate) mod list_asio_devices;
+#[cfg(target_os = "macos")]
+pub(crate) mod list_coreaudio_devices;

--- a/omniphony-renderer/src/main.rs
+++ b/omniphony-renderer/src/main.rs
@@ -6,6 +6,8 @@ use cli::decode::cmd_render;
 use cli::generate_vbap::cmd_generate_vbap;
 #[cfg(target_os = "windows")]
 use cli::list_asio_devices::cmd_list_asio_devices;
+#[cfg(target_os = "macos")]
+use cli::list_coreaudio_devices::cmd_list_coreaudio_devices;
 use log::{error, info};
 use std::ffi::OsString;
 
@@ -28,6 +30,8 @@ where
         OsString::from("generate-vbap"),
         #[cfg(target_os = "windows")]
         OsString::from("list-asio-devices"),
+        #[cfg(target_os = "macos")]
+        OsString::from("list-coreaudio-devices"),
         OsString::from("help"),
     ];
     let top_level_passthrough = [
@@ -166,6 +170,8 @@ fn main() -> Result<()> {
         Commands::GenerateVbap(ref args) => cmd_generate_vbap(args),
         #[cfg(target_os = "windows")]
         Commands::ListAsioDevices => cmd_list_asio_devices(),
+        #[cfg(target_os = "macos")]
+        Commands::ListCoreaudioDevices => cmd_list_coreaudio_devices(),
     })();
 
     if let Err(ref err) = result {

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   },
   "bundle": {
     "active": true,
-    "icon": ["icons/icon.ico", "icons/icon.png"],
+    "icon": ["icons/icon.ico", "icons/icon.png", "icons/icon.icns"],
     "externalBin": ["binaries/orender"],
     "resources": {
       "../../layouts/*.yaml": "layouts/",
@@ -20,6 +20,9 @@
       "nsis": {
         "installMode": "both"
       }
+    },
+    "macOS": {
+      "minimumSystemVersion": "11.0"
     }
   },
   "app": {


### PR DESCRIPTION
## Summary
Add native macOS (Apple Silicon) support to the renderer and Studio.

- **audio_output**: generalize the ASIO writer into a host-agnostic `cpal_output::CpalWriter` (`asio.rs` → `cpal_output.rs`). macOS opens cpal's default CoreAudio host, Windows the ASIO host; the adaptive-resampling callback is shared, so the Windows build exercises the same code.
- **CLI**: single `AudioWriter::Cpal` variant, `OutputBackend::Coreaudio` + `is_local_cpal()`, macOS default, FromStr alias, `list-coreaudio-devices`; cpal-gated runtime-sync / writer-lifecycle / device-listing blocks broadened to macOS.
- **orender_ffi**: `@rpath/liborender.dylib` install name on release macOS builds.
- **Studio**: macOS bundle block + `icon.icns` in `tauri.conf.json`.
- **CI**: build `liborender.dylib` in `liborender-release.yml`; add `macos-14` to the Studio release matrix.

Live audio input/capture stays Linux-only; macOS covers file decode → render → CoreAudio output.

## Testing
- `cargo check --workspace` + `cargo fmt --check` clean on Linux (no regressions).
- macOS compile/playback is validated by the new `macos-14` jobs (tag-triggered) — not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
