### PR TITLE
fix(macos): output_device/latency cfg + macOS CI compile gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,33 @@ jobs:
       - name: Build Studio frontend
         working-directory: omniphony-studio
         run: npm run build
+
+  build-macos:
+    # macOS arm64 compile gate. The renderer workspace pulls the CoreAudio
+    # output backend (cpal) and the `sys` signal/IO layer, both of which carry
+    # macOS-specific code paths. Build-only (no PipeWire/Tauri) — this catches
+    # macOS portability regressions on PRs, before the tag-triggered release
+    # builds (liborender / Studio / mpv) ever run on macOS.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            omniphony-renderer/target
+          key: macos-ci-cargo-${{ hashFiles('omniphony-renderer/**/Cargo.toml') }}
+          restore-keys: macos-ci-cargo-
+
+      - name: Build renderer workspace (macOS arm64)
+        working-directory: omniphony-renderer
+        run: cargo build --workspace

--- a/omniphony-renderer/src/cli/command.rs
+++ b/omniphony-renderer/src/cli/command.rs
@@ -180,7 +180,7 @@ pub struct RenderArgs {
     /// Output device or target name.
     /// PipeWire: node target name (e.g. "omniphony_router")
     /// ASIO: device name as listed by `orender list-asio-devices`
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     #[arg(
         long,
         value_name = "NAME",
@@ -193,7 +193,7 @@ pub struct RenderArgs {
     /// Playback starts once the ring buffer has reached this level, and the PI
     /// controller (--enable-adaptive-resampling) maintains it at this level.
     /// Default: 500 (Linux/PipeWire), 220 (Windows/ASIO).
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     #[arg(long, value_name = "MS")]
     pub latency_target_ms: Option<u32>,
 
@@ -712,7 +712,7 @@ pub struct InputLiveArgs {
     pub output_backend: Option<OutputBackend>,
 
     /// Output device or target name.
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     #[arg(
         long,
         value_name = "NAME",
@@ -722,7 +722,7 @@ pub struct InputLiveArgs {
     pub output_device: Option<String>,
 
     /// Target buffer latency in milliseconds.
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     #[arg(long, value_name = "MS")]
     pub latency_target_ms: Option<u32>,
 

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -227,8 +227,10 @@ fn configure_linux_runtime_output(
     handler.runtime.adaptive_resampling_config = build_adaptive_resampling_config(args, render_cfg);
 }
 
-#[cfg(target_os = "windows")]
-fn configure_windows_runtime_output(
+// ASIO (Windows) and CoreAudio (macOS) share the same runtime-output setup:
+// just the device name + adaptive resampling config (no PipeWire buffer tuning).
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn configure_cpal_runtime_output(
     handler: &mut DecodeHandler,
     args: &RenderArgs,
     render_cfg: Option<&renderer::config::RenderConfig>,
@@ -429,14 +431,14 @@ fn init_osc_runtime(
                 let defaults = PipewireBufferConfig::default();
                 Some(args.latency_target_ms.unwrap_or(defaults.latency_ms))
             }
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             {
                 Some(
                     args.latency_target_ms
                         .unwrap_or(handler.runtime.latency_target_ms),
                 )
             }
-            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
             {
                 None
             }
@@ -549,8 +551,8 @@ pub fn init_render_handler(
 
     #[cfg(target_os = "linux")]
     configure_linux_runtime_output(handler, args, render_cfg.as_ref());
-    #[cfg(target_os = "windows")]
-    configure_windows_runtime_output(handler, args, render_cfg.as_ref());
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    configure_cpal_runtime_output(handler, args, render_cfg.as_ref());
 
     handler.runtime.output_sample_rate = args.output_sample_rate;
     handler.runtime.enable_adaptive_resampling = args.enable_adaptive_resampling;

--- a/omniphony-renderer/src/cli/decode/config_resolution.rs
+++ b/omniphony-renderer/src/cli/decode/config_resolution.rs
@@ -322,11 +322,11 @@ pub(super) fn merge_render_config(
     }
 
     // Platform-specific Option fields
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     if args.latency_target_ms.is_none() {
         args.latency_target_ms = cfg.latency_target;
     }
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     if args.output_device.is_none() {
         if let Some(ref s) = cfg.output_device {
             args.output_device = Some(s.clone());
@@ -541,7 +541,7 @@ pub(super) fn effective_to_config(
     renderer::config_fields::osc_rx_port::store(&mut render, args.osc_rx_port);
     renderer::config_fields::osc_host::store(&mut render, &args.osc_host);
     renderer::config_fields::osc_port::store(&mut render, args.osc_port);
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     {
         render.output_device = args.output_device.clone();
         render.latency_target = args.latency_target_ms;

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -54,12 +54,12 @@ impl DiagPublishCadence {
 
 #[derive(Clone)]
 pub struct RuntimeOutputState {
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     pub output_device: Option<String>,
     #[cfg(target_os = "linux")]
     pub pw_buffer_config: PipewireBufferConfig,
     pub adaptive_resampling_config: AdaptiveResamplingConfig,
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     pub latency_target_ms: u32,
     pub output_sample_rate: Option<u32>,
     pub enable_adaptive_resampling: bool,
@@ -68,12 +68,12 @@ pub struct RuntimeOutputState {
 impl Default for RuntimeOutputState {
     fn default() -> Self {
         Self {
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
             output_device: None,
             #[cfg(target_os = "linux")]
             pw_buffer_config: PipewireBufferConfig::default(),
             adaptive_resampling_config: AdaptiveResamplingConfig::default(),
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
             latency_target_ms: 220,
             output_sample_rate: None,
             enable_adaptive_resampling: false,


### PR DESCRIPTION
Broaden the local-output runtime fields (output_device, latency_target_ms) and their config/setup paths to macOS so the orender CLI/Studio sidecar compiles with the CoreAudio backend. Adds a macos-14 `cargo build --workspace` CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)