### PR TITLE
fix(binaural): restore 2-channel headphone output (revert 4881d3e)

### DIFF
--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -470,10 +470,15 @@ impl Engine {
     /// map. Speakers whose layout name is unrecognised map to
     /// [`RChannelLabel::Unknown`].
     pub fn channel_layout(&self) -> Vec<RChannelLabel> {
-        // Always the speaker-array layout: binaural (headphone) output is now
-        // emitted as a full speaker frame with the ears in FL/FR, not a bare
-        // stereo pair, so the channel count and chmap stay constant across a
-        // binaural ↔ speaker toggle (no host audio-output reinit).
+        // Binaural output is a plain stereo pair; the layout MUST match
+        // `channel_count()` (2) or the host builds an inconsistent chmap and the
+        // frame is malformed (silence).
+        if self.renderer.output_channel_count() == 2 {
+            return vec![
+                crate::channel_layout::label_for_speaker_name("FL"),
+                crate::channel_layout::label_for_speaker_name("FR"),
+            ];
+        }
         self.renderer
             .speaker_layout()
             .speakers

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -591,7 +591,6 @@ impl SpatialRenderer {
             binaural: crate::binaural::BinauralRenderer::new(sample_rate),
             binaural_pos_buf: Vec::new(),
             binaural_gain_buf: Vec::new(),
-            binaural_stereo_buf: Vec::new(),
             render_bands,
             unified_table,
             render_bands_topology_identity: topology_identity,

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -184,11 +184,6 @@ pub struct SpatialRenderer {
     /// Scratch per-channel gains for the binaural path (reused).
     binaural_gain_buf: Vec<f32>,
 
-    /// Reusable interleaved-stereo scratch the binaural stage renders into
-    /// before its L/R ears are scattered into the FL/FR slots of the full
-    /// speaker-count output frame.
-    binaural_stereo_buf: Vec<f32>,
-
     /// Per-band VBAP engines.  Always has at least one entry (the "all speakers" band when
     /// no crossover is configured).  Each engine returns full-size `Gains` (`num_speakers`).
     render_bands: Vec<BandRenderer>,
@@ -444,8 +439,7 @@ impl SpatialRenderer {
     ) -> Result<RenderedFrame> {
         // ── 0. Independent binaural (headphone) path ─────────────────────────
         // When headphone output is selected, bypass the entire VBAP / crossover /
-        // speaker chain and emit a full speaker-count frame with the two binaural
-        // ears in the FL/FR slots (see the branch below). The branch is taken
+        // speaker chain and emit a 2-channel frame. The branch is taken below,
         // after `update_metadata` has applied the pending events (new ramp
         // targets); the branch itself advances each object's position ramp for
         // the block. Flag it here.
@@ -653,9 +647,9 @@ impl SpatialRenderer {
                 )
             };
             self.binaural.ensure_source(&hrir_source);
-            // Render the two binaural ears into a reusable stereo scratch.
-            self.binaural_stereo_buf.clear();
-            self.binaural_stereo_buf.resize(sample_length * 2, 0.0);
+            let mut output = samples_buf;
+            output.clear();
+            output.resize(sample_length * 2, 0.0);
             self.binaural.render_frame(
                 input_pcm,
                 input_channel_count,
@@ -663,7 +657,7 @@ impl SpatialRenderer {
                 &binaural_params,
                 &self.binaural_pos_buf,
                 &self.binaural_gain_buf,
-                &mut self.binaural_stereo_buf,
+                &mut output,
             );
             // Output gain parity with the speaker path: master gain × dialnorm
             // (auto-gain reductions are already folded into master_gain).
@@ -686,20 +680,11 @@ impl SpatialRenderer {
             };
             let gain_l = total_gain * ear(0);
             let gain_r = total_gain * ear(1);
-            // Emit a FULL speaker-count frame with the two ears scattered into
-            // the FL/FR slots (every other channel silent). Keeping the output
-            // channel count identical to the speaker path means the host never
-            // sees a format change on a binaural↔speaker toggle, so it does not
-            // tear down and recreate its audio output — that reinit pops on the
-            // multichannel chain. The headphone feed taps FL/FR downstream.
-            let (fl_idx, fr_idx) = binaural_ear_speakers(active_layout, self.num_speakers);
-            let mut output = samples_buf;
-            output.clear();
-            output.resize(sample_length * self.num_speakers, 0.0);
-            for i in 0..sample_length {
-                let base = i * self.num_speakers;
-                output[base + fl_idx] = self.binaural_stereo_buf[i * 2] * gain_l;
-                output[base + fr_idx] = self.binaural_stereo_buf[i * 2 + 1] * gain_r;
+            if (gain_l - 1.0).abs() > f32::EPSILON || (gain_r - 1.0).abs() > f32::EPSILON {
+                for frame in output.chunks_exact_mut(2) {
+                    frame[0] *= gain_l;
+                    frame[1] *= gain_r;
+                }
             }
             return Ok(RenderedFrame {
                 samples: output,
@@ -1378,15 +1363,14 @@ impl SpatialRenderer {
         self.num_speakers
     }
 
-    /// Number of channels the renderer emits — always the speaker-array count,
-    /// in both speaker and binaural mode. Binaural (headphone) output is
-    /// rendered into the FL/FR slots of the full speaker frame (see the binaural
-    /// branch in [`Self::render_frame`]) rather than as a bare stereo pair, so
-    /// the host's output format never changes when toggling binaural ↔ speaker.
-    /// A channel-count change would force the host to tear down and recreate its
-    /// audio output, which pops audibly on a multichannel chain.
+    /// Number of channels the renderer actually emits this frame: 2 in binaural
+    /// (headphone) mode, otherwise the speaker count. Hosts must size their sink
+    /// and `RenderedAudio` from this, not from [`num_speakers`](Self::num_speakers).
     pub fn output_channel_count(&self) -> usize {
-        self.num_speakers
+        match self.control.live.read().binaural.output_mode {
+            crate::live_params::OutputMode::Binaural => 2,
+            crate::live_params::OutputMode::SpeakerArray => self.num_speakers,
+        }
     }
 
     pub fn speaker_layout(&self) -> crate::speaker_layout::SpeakerLayout {
@@ -1409,28 +1393,6 @@ impl SpatialRenderer {
     pub fn spread_resolution(&self) -> f32 {
         self.spread_resolution
     }
-}
-
-/// Output channel indices the two binaural ears are written to: the layout's
-/// `FL`/`FR` speakers (matched by name, case-insensitive). The headphone feed
-/// taps those channels downstream, so the ears must land there. Falls back to
-/// the first two channels when a name is absent, and clamps to the channel
-/// count so a degenerate (1-speaker) layout cannot index out of bounds.
-fn binaural_ear_speakers(
-    layout: &crate::speaker_layout::SpeakerLayout,
-    num_speakers: usize,
-) -> (usize, usize) {
-    let last = num_speakers.saturating_sub(1);
-    let mut fl = 0usize;
-    let mut fr = last.min(1);
-    for (i, s) in layout.speakers.iter().enumerate() {
-        match s.name.to_ascii_uppercase().as_str() {
-            "FL" => fl = i,
-            "FR" => fr = i,
-            _ => {}
-        }
-    }
-    (fl.min(last), fr.min(last))
 }
 
 #[cfg(test)]

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -744,40 +744,26 @@ fn binaural_object_ramp_advances_and_lateralizes() {
         sample_pos: Some(0),
     }];
 
-    // Binaural now emits a full speaker-count frame with the ears scattered
-    // into the FL/FR slots (channels 0/1 for this layout), not a bare stereo
-    // pair — so the host's output format never changes on a binaural↔speaker
-    // toggle.
-    let ns = r.num_speakers();
     let first = r.render_frame(&pcm, 1, &event, Vec::new(), false).unwrap();
     assert_eq!(
         first.samples.len(),
-        40 * ns,
-        "binaural output must be a full speaker frame"
+        40 * 2,
+        "binaural output must be stereo"
     );
 
     // Let the ramp finish and the ITD delay lines / HRIR tails settle, then
-    // measure FL/FR ear energies over a few blocks. Also accumulate the energy
-    // in every other channel: the ears go to FL/FR only, so the rest must stay
-    // silent (otherwise the headphone FL/FR tap would be wrong).
-    let (mut e_l, mut e_r, mut e_other) = (0.0f32, 0.0f32, 0.0f32);
+    // measure ear energies over a few blocks.
+    let (mut e_l, mut e_r) = (0.0f32, 0.0f32);
     for i in 0..8 {
         let pcm = noise_block();
         let out = r.render_frame(&pcm, 1, &[], Vec::new(), false).unwrap();
         if i >= 4 {
-            for s in out.samples.chunks_exact(ns) {
+            for s in out.samples.chunks_exact(2) {
                 e_l += s[0] * s[0];
                 e_r += s[1] * s[1];
-                for &v in &s[2..] {
-                    e_other += v * v;
-                }
             }
         }
     }
-    assert_eq!(
-        e_other, 0.0,
-        "binaural energy leaked outside the FL/FR slots: E_other={e_other}"
-    );
 
     let pos = r
         .channel_states


### PR DESCRIPTION
## Problem

In headphone (binaural) mode the sound image collapsed to the centre and did
**not** follow head tracking, even though head-tracking input was fully working
end to end (verified live: the renderer's `head_pose` updates and the L/R VU
meters swap on a 180° turn).

## Root cause

`4881d3e` ("fix(binaural): emit a full speaker frame so the output format never
changes") made binaural output a full speaker-count frame with the two ears in
the **FL/FR slots** (every other channel silent), to keep the channel count
constant across a binaural↔speaker toggle and avoid a host audio-output reinit
pop.

The side effect: the head-tracked L/R is now subject to the host's
multichannel→stereo downmix for the headphone device, which folds FL/FR toward
the centre. So the correct, head-tracked stereo the renderer produces never
reaches the ears as discrete L/R — it collapses to the middle. The render was
fine; only the output stage was wrong.

## Fix

Revert to a bare **2-channel** binaural output so the head-tracked stereo
reaches the headphones discretely (no centre-folding downmix in the path).

Verified on the live mpv/liborender path:
- spatialisation and head tracking now work correctly on headphones;
- the digital-noise glitch previously heard on the binaural↔speaker transition
  is gone too;
- the channel-count toggle pop that `4881d3e` aimed to avoid did **not**
  reappear in testing. If it ever resurfaces, the proper fix is a discrete
  FL/FR stereo tap for the headphone feed rather than widening the renderer's
  output channel count.

## Validation

`cargo fmt --check` clean, `cargo build` clean, full test suite green
(`renderer` 60/0, `orender_engine` 2/0, incl. the binaural ramp/lateralisation
test restored to the 2-channel expectation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
