### PR TITLE
docs: document head tracking (nxosc source + OSC head/tracking addresses)

### DIFF
--- a/docs/osc-control-contract.md
+++ b/docs/osc-control-contract.md
@@ -119,6 +119,24 @@ latency. See `PI_TUNING_PROCEDURE.md` and `docs/latency-regulation.md`.
 | `/control/render/bridge_path` | s | Path to the format bridge library. |
 | `/control/render/input_pipe` | s | Named-pipe input path. |
 
+### Head tracking (binaural)
+
+Live head-pose control for the binaural (headphone) path. The orientation
+*feed* itself arrives on a **user-configured** address
+(`head_tracking.osc_address`, e.g. `/gamerotationvector` for Sensors2OSC /
+`nxosc`) parsed per `head_tracking.format` — that is config, not a fixed
+contract address. See `omniphony-renderer/BINAURAL.md`.
+
+| Address | Args | Meaning |
+|---|---|---|
+| `/control/head/orientation` | f×3 (euler °) | Set head pose directly (yaw, pitch, roll). |
+| `/control/head/quat` | f×4 | Set head pose directly (quaternion). |
+| `/control/head/recenter` | — | Capture the current orientation as "front". |
+| `/control/head/tracking/address` | s | Feed address the engine listens on (`""` disables tracking). |
+| `/control/head/tracking/format` | s | `auto` \| `quat` \| `rotvec` \| `euler`. |
+| `/control/head/tracking/smoothing` | f `[0,0.99]` | Pose smoothing (higher = smoother/laggier). |
+| `/control/head/tracking/invert` | int bool | Mirror the applied rotation. |
+
 ### Layout
 
 | Address | Args | Meaning |
@@ -168,6 +186,8 @@ exhaustive machine-readable list.
   `render/bridge_path`, `render/bridge_error`, `vbap/allow_negative_z`,
   `render_evaluation/*` (mirrors of the control resolutions), `speakers`,
   `speakers/recomputing`, `speakers/recompute_error`, `layout`.
+- **Head tracking** — `head_pose` (4-float quaternion `w,x,y,z`, broadcast at
+  ~30 Hz while a tracking feed is active, for low-latency client display).
 - **Metering / timing** — `clip`, `decode_time_ms`, `render_time_ms`,
   `write_time_ms`, `crossover_time_ms`, `frame_duration_ms`, `monitoring`,
   `loudness`, `realtime/{master_gain,object_gain,speaker_gain}`.

--- a/omniphony-renderer/BINAURAL.md
+++ b/omniphony-renderer/BINAURAL.md
@@ -89,6 +89,22 @@ the phone strapped to the headband:
 `smoothing` (0–0.99, default 0.2) trades a little latency for pose stability;
 with Game Rotation Vector you can usually lower it.
 
+### Other sources
+
+The setup above uses a phone, but any OSC orientation source works. For the
+**Waves Nx Head Tracker** (Bluetooth LE, Linux/BlueZ) there is a small Rust
+CLI — **[`nxosc`](https://github.com/mgth/nx-tracker-osc)** — that decodes the
+tracker and emits the same `/gamerotationvector` feed, so it drops straight
+into the steps above in place of Sensors2OSC:
+
+```sh
+nxosc run --profile omniphony --osc-address /gamerotationvector --osc-target 127.0.0.1:9000
+```
+
+Keep `head_tracking.osc_address: /gamerotationvector` and `format: auto`.
+`nxosc` also has a `--profile scenerotator` mode to drive an IEM SceneRotator
+directly instead.
+
 ## Usage tips
 
 - **The room is YOUR room, not the scene's.** The reflections and the reverb


### PR DESCRIPTION
## What

Head tracking was only documented in `omniphony-renderer/BINAURAL.md`; the central OSC contract didn't list the head-tracking addresses at all, and `nxosc` (the new Waves Nx tracker bridge) wasn't mentioned anywhere.

- **BINAURAL.md** — add an *Other sources* note: [`nxosc`](https://github.com/mgth/nx-tracker-osc) decodes the Waves Nx Head Tracker (BLE/BlueZ) and emits the same `/gamerotationvector` feed, a drop-in for the Sensors2OSC setup (with the equivalent `nxosc run` command).
- **osc-control-contract.md** — add a *Head tracking (binaural)* control subsection (`/control/head/orientation|quat|recenter`, `/control/head/tracking/{address,format,smoothing,invert}`) and the `/state/head_pose` broadcast. All verified against the dispatcher in `runtime_control/src/osc.rs` and the broadcaster in `orender_engine/src/osc.rs`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)