### PR TITLE
fix: re-handshake Studio on CLI/mpv producer swap

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -324,6 +324,12 @@ pub struct OscSender {
     force_full_next: Arc<AtomicBool>,
     /// Monotonic identifier for the current logical content generation.
     content_generation: u64,
+    /// Random identifier for THIS producer instance, echoed in every
+    /// `/omniphony/heartbeat/ack`. A client that sees this value change knows a
+    /// *different* renderer instance now answers on the same RX port (a CLI⇄mpv
+    /// swap) even when the link never visibly dropped, and can re-handshake.
+    /// Stable for the lifetime of the instance (incl. standby/resume cycles).
+    instance_epoch: i32,
     /// Stop flag for the background OSC listener thread.
     listener_stop: Arc<AtomicBool>,
     /// Join handle for the background OSC listener thread.
@@ -341,6 +347,17 @@ impl OscSender {
         let socket = UdpSocket::bind("0.0.0.0:0")?;
         let clients = Arc::new(OscClientRegistry::new(CLIENT_TIMEOUT));
         clients.insert_permanent(SocketAddr::V4(default_target));
+        // Per-instance id: mixes pid and a sub-second timestamp so it differs
+        // both across processes (CLI vs the mpv-embedded host) and across
+        // successive instances in the same process. Only its *change* matters,
+        // not its distribution, so a cheap hash avoids pulling in an RNG crate.
+        let instance_epoch = {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0);
+            (std::process::id() ^ nanos.rotate_left(13)) as i32
+        };
         Ok(Self {
             socket: Arc::new(socket),
             clients,
@@ -349,6 +366,7 @@ impl OscSender {
             prev_objects: None,
             force_full_next: Arc::new(AtomicBool::new(true)),
             content_generation: 0,
+            instance_epoch,
             listener_stop: Arc::new(AtomicBool::new(false)),
             listener_thread: Mutex::new(None),
             rx_port: 0,
@@ -389,6 +407,7 @@ impl OscSender {
         let control = self.control.clone();
         let host_handler = self.host_handler.clone();
         let force_full_next = Arc::clone(&self.force_full_next);
+        let instance_epoch = self.instance_epoch;
         let stop = Arc::clone(&self.listener_stop);
 
         if let Some(handle) = self.listener_thread.lock().unwrap().take() {
@@ -511,9 +530,11 @@ impl OscSender {
                                     } else {
                                         "/omniphony/heartbeat/unknown"
                                     };
+                                    // Echo this instance's epoch so the client can
+                                    // detect a producer swap behind the same port.
                                     let reply = OscMessage {
                                         addr: reply_addr.to_string(),
-                                        args: vec![],
+                                        args: vec![rosc::OscType::Int(instance_epoch)],
                                     };
                                     match rosc::encoder::encode(&OscPacket::Message(reply)) {
                                         Ok(bytes) => {

--- a/omniphony-renderer/orender_engine/src/osc/client_registry.rs
+++ b/omniphony-renderer/orender_engine/src/osc/client_registry.rs
@@ -86,13 +86,23 @@ impl OscClientRegistry {
 
     pub(crate) fn heartbeat(&self, addr: SocketAddr) -> bool {
         let mut clients = self.clients.lock().unwrap();
-        if let Some(entry) = clients.get_mut(&addr) {
-            if entry.last_seen.is_some() {
+        match clients.get_mut(&addr) {
+            // Actively-registered client: refresh its liveness and ack.
+            Some(entry) if entry.last_seen.is_some() => {
                 entry.last_seen = Some(Instant::now());
+                true
             }
-            true
-        } else {
-            false
+            // Known only as a config-seeded *permanent* target that has never
+            // actively registered (`last_seen == None`). Report it as unknown so
+            // the heartbeat is answered with `/heartbeat/unknown`, forcing a
+            // re-`register`. This is what makes a producer swap visible to the
+            // client: when a fresh instance takes over the RX port (CLI⇄mpv),
+            // its registry holds this address only as the permanent seed, so the
+            // client re-registers and receives a new capabilities bundle, a full
+            // object resend (names) and the metering subscription — instead of
+            // being silently acked into a stale connection. Pure listeners that
+            // never heartbeat are unaffected (broadcasts still reach them).
+            _ => false,
         }
     }
 
@@ -278,5 +288,36 @@ mod tests {
 
         reg.set_metering_for_permanent(false);
         assert!(!reg.is_any_metering_live());
+    }
+
+    #[test]
+    fn permanent_seed_is_unknown_until_it_registers() {
+        // Regression guard for the CLI⇄mpv swap: a fresh producer instance seeds
+        // the config default target as a *permanent* client. Its heartbeat must
+        // be reported unknown (→ client re-registers and re-handshakes) instead
+        // of being silently acked, which would mask the producer change.
+        let reg = OscClientRegistry::new(Duration::from_secs(5));
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        reg.insert_permanent(addr);
+
+        // Seeded but never actively registered → heartbeat is unknown.
+        assert!(
+            !reg.heartbeat(addr),
+            "permanent-only seed must not be acked"
+        );
+
+        // Registering reuses the permanent slot (so `is_new` is false — the live
+        // bundle is sent regardless), promotes it to a live client (`last_seen`
+        // set), and from then on its heartbeats are acked.
+        let (is_new, _) = reg.register(addr);
+        assert!(!is_new, "permanent seed already occupies the slot");
+        assert!(reg.heartbeat(addr), "registered client must be acked");
+    }
+
+    #[test]
+    fn unknown_address_heartbeat_is_unknown() {
+        let reg = OscClientRegistry::new(Duration::from_secs(5));
+        let addr: SocketAddr = "127.0.0.1:9100".parse().unwrap();
+        assert!(!reg.heartbeat(addr));
     }
 }

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -480,6 +480,12 @@ pub struct AppState {
     pub producer_capabilities: Option<serde_json::Value>,
     #[serde(rename = "producerSession")]
     pub producer_session: Option<serde_json::Value>,
+    /// Instance epoch from the last `/omniphony/heartbeat/ack`. A change means a
+    /// different renderer instance now answers on the RX port (a CLI⇄mpv swap)
+    /// → force a re-handshake. Internal detection state, never sent to the UI,
+    /// and cleared by `reset_runtime_state` so it re-latches on each connection.
+    #[serde(skip)]
+    pub producer_epoch: Option<i32>,
     #[serde(rename = "oscMeteringEnabled")]
     pub osc_metering_enabled: Option<u8>,
     #[serde(rename = "logLevel")]
@@ -737,6 +743,7 @@ impl Default for AppState {
             osc_status: Some("initializing".to_string()),
             producer_capabilities: None,
             producer_session: None,
+            producer_epoch: None,
             osc_metering_enabled: Some(0),
             log_level: Some("info".to_string()),
             last_spatial_sample_pos: None,

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -826,6 +826,33 @@ fn emit_osc_status(app: &AppHandle, state: &Arc<Mutex<AppState>>, status: &str) 
     let _ = app.emit("osc:status", serde_json::json!({ "status": status }));
 }
 
+/// Inspect a `/heartbeat/ack` payload for the renderer's instance epoch and
+/// update the latched value. Returns `true` only when it *changed* from a
+/// previously latched epoch — i.e. a different renderer instance now answers on
+/// the RX port (a CLI⇄mpv swap) behind an otherwise unbroken connection — so the
+/// caller can force a full re-handshake. A first observation (fresh connection)
+/// or an ack from an older renderer that carries no epoch is not a change.
+fn producer_epoch_changed(state: &Arc<Mutex<AppState>>, args: &[OscType]) -> bool {
+    let Some(epoch) = args.iter().find_map(|a| match a {
+        OscType::Int(i) => Some(*i),
+        _ => None,
+    }) else {
+        return false;
+    };
+    let mut s = state.lock().unwrap();
+    match s.producer_epoch {
+        None => {
+            s.producer_epoch = Some(epoch);
+            false
+        }
+        Some(prev) if prev == epoch => false,
+        Some(_) => {
+            s.producer_epoch = Some(epoch);
+            true
+        }
+    }
+}
+
 // ── public spawn function ─────────────────────────────────────────────────
 
 pub fn spawn_osc_task(
@@ -1208,7 +1235,16 @@ fn handle_packet(
             match is_heartbeat_address(&msg.addr) {
                 HeartbeatResponse::Ack => {
                     *last_ack_at = Instant::now();
-                    if !*is_connected {
+                    if producer_epoch_changed(state, &msg.args) {
+                        // A different renderer instance now answers on this port
+                        // (a CLI⇄mpv swap behind an unbroken link). Re-handshake
+                        // so capabilities, the object snapshot (names) and the
+                        // metering subscription are refreshed for the new producer.
+                        send_register(socket, host, osc_rx_port, listen_port);
+                        send_metering_enabled(socket, host, osc_rx_port, metering_enabled);
+                        *is_connected = false;
+                        emit_osc_status(app, state, "reconnecting");
+                    } else if !*is_connected {
                         *is_connected = true;
                         emit_osc_status(app, state, "connected");
                     }
@@ -1252,7 +1288,15 @@ fn handle_packet(
                         match is_heartbeat_address(&msg.addr) {
                             HeartbeatResponse::Ack => {
                                 *last_ack_at = Instant::now();
-                                if !*is_connected {
+                                if producer_epoch_changed(state, &msg.args) {
+                                    // Producer swap behind an unbroken link → re-handshake.
+                                    send_register(socket, host, osc_rx_port, listen_port);
+                                    send_metering_enabled(
+                                        socket, host, osc_rx_port, metering_enabled,
+                                    );
+                                    *is_connected = false;
+                                    emit_osc_status(app, state, "reconnecting");
+                                } else if !*is_connected {
                                     *is_connected = true;
                                     emit_osc_status(app, state, "connected");
                                 }

--- a/omniphony-studio/src/controls/osc.js
+++ b/omniphony-studio/src/controls/osc.js
@@ -10,7 +10,7 @@
  *     functions (launchOrenderFromPanel, installOrenderServiceFromPanel, etc.)
  */
 
-import { app, dirty, isLinux, producerHost, producerVariant, isEmbeddedProducer } from '../state.js';
+import { app, dirty, isLinux, producerHost, producerVariant, isEmbeddedProducer, sourceNames } from '../state.js';
 import { t, tf } from '../i18n.js';
 import { scheduleUIFlush } from '../flush.js';
 import { pushLog, normalizeLogError, normalizeLogLevel, logState } from '../log.js';
@@ -280,6 +280,12 @@ export function setOscStatus(next) {
   const disconnected = previous === 'connected' && next !== 'connected';
   if (disconnected) {
     clearOscLaunchPending();
+    // Drop cached object identities on a drop/producer swap so a renderer that
+    // takes over the port (CLI⇄mpv) can't inherit stale names: the re-handshake
+    // re-sends every object's name via the renderer's forced full frame. Without
+    // this, an id the new stream reuses with an empty name would keep showing the
+    // previous producer's label.
+    sourceNames.clear();
   }
   updateConfigSavedUI();
   renderOscStatus();


### PR DESCRIPTION
## Problem

Closing mpv on an Atmos title and reopening mpv on an Atmos track left Studio in a broken state, **often**:

- status stuck on **`connected · cli`** instead of `mpv`;
- objects move correctly but lose their names in the list (numeric `0..N`);
- **metering stays dead** until it is toggled off/on;
- audio is fine.

## Root cause

Studio's connection identity was **port-liveness only** — "connected" just means *something* answers heartbeats on the RX port. Every renderer instance (`OscSender::new`) seeds the configured default OSC target (Studio's address) as a **permanent** client, and the registry acked that address' heartbeats even though it had never actively registered.

So when a fresh instance (the mpv-embedded host) takes over the port from a standby CLI renderer, it immediately acks Studio's heartbeats. Studio never sees a disconnect → never resets `osc_snapshot_ready` → never re-registers → never receives the new **capabilities** (label), the register-triggered **full object resend** (names) or the **metering subscription**. It still receives broadcast object deltas, so objects keep moving. The yield handover frees the port for only ~50–250 ms, far below Studio's 10 s ack timeout, which is why it was effectively deterministic.

## Fix

Make the producer swap observable and force a clean re-handshake:

- **registry (A):** a permanent seed that never actively registered (`last_seen == None`) now answers heartbeats as **unknown**, forcing a re-`register`. Fixes the CLI → mpv direction deterministically. Pure listeners that never heartbeat are unaffected (broadcasts still reach them).
- **producer epoch (B):** `OscSender` carries a per-instance id echoed in every `/heartbeat/ack`. Studio latches it and re-handshakes on any change — covers the mpv → CLI-resume direction (where the resumed instance still knows the client and would otherwise ack) and any future transport that inherits the registry. Zero hot-path cost (5 s cadence).
- **Studio (C):** clears cached object identities (`sourceNames`) on disconnect so a new producer can't inherit stale names.

A fourth idea (resend object names when only the name changes) was dropped: `ObjectSnapshot::matches_position` already compares the name, so that path is already covered.

## Tests

- `cargo test -p orender_engine`: 65 green, incl. 2 new registry tests for the heartbeat behaviour.
- `cargo check` green for the renderer and the Studio `src-tauri` backend; `cargo fmt --check` clean; `node --check` clean for the JS change.

⚠️ Runtime verification with an actual mpv↔CLI swap is still pending (requires building this workflow's `liborender.so` + Studio and launching mpv against it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)