### PR TITLE
feat(studio): nature flyouts on scene-fx Objects/Trails buttons

### DIFF
--- a/omniphony-studio/src/controls/scene-effects-bar.js
+++ b/omniphony-studio/src/controls/scene-effects-bar.js
@@ -4,17 +4,35 @@
 // and state update runs exactly as if the panel checkbox were clicked) and
 // reflects that checkbox's state with an `.active` style. No effect logic lives
 // here — this is purely a convenience surface over the existing controls.
+//
+// Two buttons (Objects, Trails) additionally carry a "nature" flyout: a small
+// vertical menu, opened from a caret or a right-click, that drives the existing
+// panel <select> (objectDisplayModeSelect / trailModeSelect) the same way — by
+// setting its value and dispatching `change`. Still no rendering/persistence
+// logic here; the panel handlers do all the work.
 
 // Button id -> source checkbox id. Order defines left-to-right layout.
+// `flyout` (optional) links a button to a nature menu defined in FX_FLYOUTS.
 const SCENE_FX = [
   { btn: 'fxGridBtn', src: 'vbapCartesianGridToggleBtn' },
-  { btn: 'fxObjectsBtn', src: 'showObjectsToggle' },
+  { btn: 'fxObjectsBtn', src: 'showObjectsToggle', flyout: 'object' },
   { btn: 'fxLabelsBtn', src: 'objectLabelsToggle' },
-  { btn: 'fxTrailsBtn', src: 'trailToggle' },
+  { btn: 'fxTrailsBtn', src: 'trailToggle', flyout: 'trail' },
   { btn: 'fxFieldBtn', src: 'objectEnergyHeatmapToggle' },
   { btn: 'fxHeatmapBtn', src: 'speakerHeatmapVolumeToggle' },
   { btn: 'fxMpvBtn', src: 'mpvOverlayToggle' },
 ];
+
+// Nature flyouts. `menu` is the popup container, `select` the panel <select>
+// the menu items map onto (item.dataset.value === one of its <option> values),
+// and `visToggle` the visibility checkbox to enable when a nature is picked.
+const FX_FLYOUTS = {
+  object: { menu: 'fxObjectsMenu', select: 'objectDisplayModeSelect', visToggle: 'showObjectsToggle' },
+  trail: { menu: 'fxTrailsMenu', select: 'trailModeSelect', visToggle: 'trailToggle' },
+};
+
+// The single currently-open flyout, or null. { menu, btn }.
+let openFlyout = null;
 
 function reflect(entry) {
   const btn = document.getElementById(entry.btn);
@@ -25,10 +43,67 @@ function reflect(entry) {
   btn.setAttribute('aria-pressed', on ? 'true' : 'false');
 }
 
-/** Re-read every source checkbox and update its button. Safe to call any time
- *  (e.g. after the display panel is re-rendered from persisted state). */
+/** Mark the menu item matching the panel <select>'s current value. Read at open
+ *  time, so the menu always shows the live mode regardless of where it changed. */
+function reflectFlyoutSelection(cfg) {
+  const menu = document.getElementById(cfg.menu);
+  const select = document.getElementById(cfg.select);
+  if (!menu || !select) return;
+  const current = select.value;
+  menu.querySelectorAll('.fx-flyout-item').forEach((item) => {
+    const on = item.dataset.value === current;
+    item.classList.toggle('selected', on);
+    item.setAttribute('aria-checked', on ? 'true' : 'false');
+  });
+}
+
+function closeFlyout() {
+  if (!openFlyout) return;
+  openFlyout.menu.hidden = true;
+  openFlyout.btn.setAttribute('aria-expanded', 'false');
+  openFlyout = null;
+}
+
+function showFlyout(cfg, btn) {
+  const menu = document.getElementById(cfg.menu);
+  if (!menu) return;
+  closeFlyout();
+  reflectFlyoutSelection(cfg);
+  menu.hidden = false;
+  btn.setAttribute('aria-expanded', 'true');
+  openFlyout = { menu, btn };
+}
+
+function toggleFlyout(cfg, btn) {
+  if (openFlyout && openFlyout.btn === btn) closeFlyout();
+  else showFlyout(cfg, btn);
+}
+
+/** Apply a chosen nature by driving the panel <select> (and enabling the layer
+ *  if it is currently hidden) — reusing every existing change handler. */
+function chooseFlyoutValue(cfg, value) {
+  const select = document.getElementById(cfg.select);
+  if (!select) return;
+  // Picking a nature implies you want to see the layer: enable it if hidden.
+  const vis = document.getElementById(cfg.visToggle);
+  if (vis && !vis.checked) {
+    vis.checked = true;
+    vis.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+  if (select.value !== value) {
+    select.value = value;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}
+
+/** Re-read every source checkbox and update its button (and any flyout's checked
+ *  item). Safe to call any time (e.g. after the display panel is re-rendered
+ *  from persisted state). */
 export function syncSceneEffectsBar() {
-  for (const e of SCENE_FX) reflect(e);
+  for (const e of SCENE_FX) {
+    reflect(e);
+    if (e.flyout) reflectFlyoutSelection(FX_FLYOUTS[e.flyout]);
+  }
 }
 
 /** Wire the bar's buttons to their source checkboxes. Call after the renderer/
@@ -39,7 +114,13 @@ export function initSceneEffectsBar() {
     const btn = document.getElementById(entry.btn);
     const src = document.getElementById(entry.src);
     if (!btn || !src) continue;
-    btn.addEventListener('click', () => {
+    const cfg = entry.flyout ? FX_FLYOUTS[entry.flyout] : null;
+    btn.addEventListener('click', (e) => {
+      // A click on the caret opens the nature menu instead of toggling.
+      if (cfg && e.target.closest('.fx-caret')) {
+        toggleFlyout(cfg, btn);
+        return;
+      }
       src.checked = !src.checked;
       src.dispatchEvent(new Event('change', { bubbles: true }));
       reflect(entry);
@@ -48,5 +129,33 @@ export function initSceneEffectsBar() {
     // dispatched event above also lands here, which is harmless/idempotent).
     src.addEventListener('change', () => reflect(entry));
     reflect(entry);
+
+    if (cfg) {
+      // Right-click anywhere on the button is an alias for opening the menu.
+      btn.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        toggleFlyout(cfg, btn);
+      });
+      const menu = document.getElementById(cfg.menu);
+      if (menu) {
+        menu.addEventListener('click', (e) => {
+          const item = e.target.closest('.fx-flyout-item');
+          if (!item) return;
+          chooseFlyoutValue(cfg, item.dataset.value);
+          closeFlyout();
+        });
+      }
+    }
   }
+
+  // Dismiss an open flyout on outside click or Escape. A click on the owning
+  // button (caret/toggle) is handled there, so ignore it here.
+  document.addEventListener('click', (e) => {
+    if (!openFlyout) return;
+    if (openFlyout.menu.contains(e.target) || openFlyout.btn.contains(e.target)) return;
+    closeFlyout();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeFlyout();
+  });
 }

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -677,15 +677,40 @@
         <button id="fxGridBtn" type="button" class="scene-fx-btn" aria-pressed="false" data-i18n-title="sceneFx.grid" title="Grid">
           <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg>
         </button>
-        <button id="fxObjectsBtn" type="button" class="scene-fx-btn" aria-pressed="false" data-i18n-title="sceneFx.objects" title="Objects">
-          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="2.6" fill="currentColor" stroke="none"/></svg>
-        </button>
+        <div class="scene-fx-slot">
+          <button id="fxObjectsBtn" type="button" class="scene-fx-btn has-flyout" aria-pressed="false" aria-haspopup="menu" aria-expanded="false" data-i18n-title="sceneFx.objects" title="Objects">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="2.6" fill="currentColor" stroke="none"/></svg>
+            <span class="fx-caret" aria-hidden="true"><svg viewBox="0 0 12 8" width="10" height="7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 6l4-4 4 4"/></svg></span>
+          </button>
+          <div id="fxObjectsMenu" class="scene-fx-flyout" role="menu" aria-label="Object appearance" hidden>
+            <button type="button" class="fx-flyout-item" role="menuitemradio" data-value="circle" data-i18n-title="display.objectDisplayMode.circle" data-i18n-aria-label="display.objectDisplayMode.circle" title="Circle" aria-label="Circle">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/></svg>
+            </button>
+            <button type="button" class="fx-flyout-item" role="menuitemradio" data-value="transparent-sphere" data-i18n-title="display.objectDisplayMode.transparentSphere" data-i18n-aria-label="display.objectDisplayMode.transparentSphere" title="Transparent sphere" aria-label="Transparent sphere">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/><ellipse cx="12" cy="12" rx="3.4" ry="8"/><ellipse cx="12" cy="12" rx="8" ry="3.4"/></svg>
+            </button>
+            <button type="button" class="fx-flyout-item" role="menuitemradio" data-value="diffuse-sphere" data-i18n-title="display.objectDisplayMode.diffuseSphere" data-i18n-aria-label="display.objectDisplayMode.diffuseSphere" title="Diffuse sphere" aria-label="Diffuse sphere">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="8" stroke-dasharray="1.6 2.6"/></svg>
+            </button>
+          </div>
+        </div>
         <button id="fxLabelsBtn" type="button" class="scene-fx-btn" aria-pressed="false" data-i18n-title="sceneFx.labels" title="Labels">
           <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" stroke="none"/></svg>
         </button>
-        <button id="fxTrailsBtn" type="button" class="scene-fx-btn" aria-pressed="false" data-i18n-title="sceneFx.trails" title="Trails">
-          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg>
-        </button>
+        <div class="scene-fx-slot">
+          <button id="fxTrailsBtn" type="button" class="scene-fx-btn has-flyout" aria-pressed="false" aria-haspopup="menu" aria-expanded="false" data-i18n-title="sceneFx.trails" title="Trails">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="19" r="3"/><path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15"/><circle cx="18" cy="5" r="3"/></svg>
+            <span class="fx-caret" aria-hidden="true"><svg viewBox="0 0 12 8" width="10" height="7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 6l4-4 4 4"/></svg></span>
+          </button>
+          <div id="fxTrailsMenu" class="scene-fx-flyout" role="menu" aria-label="Trails mode" hidden>
+            <button type="button" class="fx-flyout-item" role="menuitemradio" data-value="diffuse" data-i18n-title="trail.mode.diffuse" data-i18n-aria-label="trail.mode.diffuse" title="Diffuse" aria-label="Diffuse">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="none" aria-hidden="true"><circle cx="5" cy="15" r="1.2" fill="currentColor" opacity="0.4"/><circle cx="10" cy="13" r="1.8" fill="currentColor" opacity="0.62"/><circle cx="15" cy="11" r="2.4" fill="currentColor" opacity="0.82"/><circle cx="20" cy="9" r="3" fill="currentColor"/></svg>
+            </button>
+            <button type="button" class="fx-flyout-item" role="menuitemradio" data-value="line" data-i18n-title="trail.mode.line" data-i18n-aria-label="trail.mode.line" title="Line" aria-label="Line">
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 18Q9 4 12 11T21 6"/></svg>
+            </button>
+          </div>
+        </div>
         <button id="fxFieldBtn" type="button" class="scene-fx-btn" aria-pressed="false" data-i18n-title="sceneFx.energyField" title="Object energy field">
           <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"/><path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"/><circle cx="12" cy="12" r="2" fill="currentColor" stroke="none"/><path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"/><path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"/></svg>
         </button>

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -2549,3 +2549,101 @@ body:not(.output-binaural) .speakers-title-binaural {
   background: rgba(82, 226, 162, 0.24);
   color: #aef5d8;
 }
+
+/* Objects/Trails "nature" flyout. The slot only wraps the button + its popup so
+   the absolutely-positioned menu anchors to the button without affecting the
+   bar layout or the renderer canvas geometry. */
+.scene-fx-slot {
+  position: relative;
+  display: inline-flex;
+}
+
+.scene-fx-btn.has-flyout {
+  position: relative;
+}
+
+.fx-caret {
+  position: absolute;
+  top: 2px;
+  right: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 10px;
+  border-radius: 3px;
+  color: rgba(223, 232, 243, 0.38);
+  transition: background 0.13s ease, color 0.13s ease;
+}
+
+.scene-fx-btn:hover .fx-caret {
+  color: rgba(223, 232, 243, 0.75);
+}
+
+.fx-caret:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+}
+
+.scene-fx-btn.active .fx-caret {
+  color: rgba(122, 240, 192, 0.8);
+}
+
+.scene-fx-flyout {
+  position: absolute;
+  bottom: calc(100% + 9px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 5px;
+  background: rgba(18, 22, 28, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 11px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  z-index: 80;
+}
+
+.scene-fx-flyout[hidden] {
+  display: none;
+}
+
+/* Small pointer tail bridging the menu down to the button. */
+.scene-fx-flyout::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: rgba(18, 22, 28, 0.92);
+}
+
+.fx-flyout-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: rgba(223, 232, 243, 0.6);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.fx-flyout-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+.fx-flyout-item.selected {
+  background: rgba(82, 226, 162, 0.16);
+  border-color: rgba(82, 226, 162, 0.5);
+  color: #aef5d8;
+}


### PR DESCRIPTION
## Summary

Adds a small **vertical icon flyout** above the **Objects** and **Trails** buttons in the bottom scene-effects bar (`#sceneEffectBar`), letting you pick the visualization *nature* without opening the Display panel:

- **Objects**: circle / transparent sphere / diffuse sphere
- **Trails**: diffuse / line

## How it works

The flyout is a **convenience surface over the existing panel `<select>`s** (`objectDisplayModeSelect` / `trailModeSelect`) — same philosophy as the rest of `controls/scene-effects-bar.js`. Selecting an item sets the select's value and dispatches a `change` event, so **all existing rendering, localStorage persistence and mpv-overlay-push logic runs unchanged**. No new state, no new OSC/IPC messages.

Behaviour:
- **Open**: click the caret on the icon, or right-click the icon. Clicking the icon body keeps the existing on/off toggle.
- **Pick a nature** while the layer is hidden → the layer is auto-enabled, then the mode applied.
- **Close**: outside click, `Escape`, or selection. Opening one flyout closes the other.
- Items are **icon-only**; the existing i18n strings are kept as `title` / `aria-label` (reused keys, no new locale strings).

## Files
- `omniphony-studio/src/index.html` — caret + vertical flyout markup on the two buttons.
- `omniphony-studio/src/controls/scene-effects-bar.js` — flyout open/close/select logic driving the existing selects.
- `omniphony-studio/src/styles/app.css` — flyout/caret styling; absolutely positioned, so it does **not** affect the 3D viewport geometry.

## Verification
- `npm run build` (vite) ✅
- `npm run i18n:check` ✅ (0 missing / 0 orphaned)
- Validated live in Studio: caret/right-click open, modes apply and mirror the Display-panel selects, auto-enable, close behaviours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)