### PR TITLE
fix(studio): pre-release polish — 2D-sources panel + bed object order

### DIFF
--- a/omniphony-studio/src/app.js
+++ b/omniphony-studio/src/app.js
@@ -51,6 +51,7 @@ import {
   setRendererSectionOpen,
   setDisplaySectionOpen,
   setDrcSectionOpen,
+  setTwoDSourcesSectionOpen,
   setAutoGainSectionOpen
 } from './modals.js';
 
@@ -238,6 +239,7 @@ setInputSectionOpen(false);
 setRendererSectionOpen(false);
 setDisplaySectionOpen(false);
 setDrcSectionOpen(false);
+setTwoDSourcesSectionOpen(false);
 setAutoGainSectionOpen(false);
 
 // Register UI event listeners

--- a/omniphony-studio/src/controls/audio.js
+++ b/omniphony-studio/src/controls/audio.js
@@ -309,6 +309,7 @@ export function applyChannelRenderModeNow() {
   if (surroundRow) surroundRow.style.display = el.checked ? 'flex' : 'none';
   syncVirtualBedObjects(true);
   renderChannelEditor(true);
+  updateTwoDSourcesSummary();
   invoke('control_channel_render_mode', { value: requested });
 }
 
@@ -320,6 +321,23 @@ export function updateSurroundPlacementUI() {
   const backBtn = document.getElementById('surroundPlacementBack');
   if (sideBtn) sideBtn.classList.toggle('active', placement === 'side');
   if (backBtn) backBtn.classList.toggle('active', placement === 'back');
+  updateTwoDSourcesSummary();
+}
+
+// Header summary shown while the 2D-sources panel is collapsed: whether flat 2D
+// beds are spatialised (with the rear-channel placement) or passed through to the
+// player. Reads `channelRenderMode` and `surroundPlacement` from app state.
+export function updateTwoDSourcesSummary() {
+  const summaryEl = document.getElementById('twoDSourcesSummary');
+  if (!summaryEl) return;
+  if (app.channelRenderMode !== 'host') {
+    const placement = app.surroundPlacement === 'back'
+      ? t('twoDSources.surroundBack')
+      : t('twoDSources.surroundSide');
+    summaryEl.textContent = `${t('twoDSources.summary.spatialized')} · ${placement}`;
+  } else {
+    summaryEl.textContent = t('twoDSources.summary.passthrough');
+  }
 }
 
 // Commit a Side/Back choice: update state + the active button and push it to the

--- a/omniphony-studio/src/controls/virtual-bed.js
+++ b/omniphony-studio/src/controls/virtual-bed.js
@@ -64,6 +64,17 @@ export function canonicalChannelName(name) {
   return null;
 }
 
+// Canonical 5.1/7.1 channel order (L, R, C, LFE, Ls, Rs, Lb, Rb).
+const CANONICAL_CHANNEL_ORDER = CANONICAL_BED.map((c) => c.name);
+
+// Rank of a channel (by any alias) in the canonical order, or -1 if it is not a
+// bed channel. Used to order the objects list for bed sources by the classic
+// 5.1/7.1 channel order instead of alphabetically.
+export function canonicalChannelOrder(name) {
+  const key = canonicalChannelName(name);
+  return key ? CANONICAL_CHANNEL_ORDER.indexOf(key) : -1;
+}
+
 // ---------------------------------------------------------------------------
 // Model: the editable channel set
 // ---------------------------------------------------------------------------

--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "Hintere Kanäle (4.x/5.x)",
   "twoDSources.surroundSide": "Seite",
   "twoDSources.surroundBack": "Hinten",
+  "twoDSources.summary.spatialized": "Räumlich",
+  "twoDSources.summary.passthrough": "Player-Passthrough",
   "virtualBed.virtual": "Virtuell",
   "virtualBed.direct": "Direkt",
   "virtualBed.reset": "Kanal-Layout zurücksetzen",

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "Rear channels (4.x/5.x)",
   "twoDSources.surroundSide": "Side",
   "twoDSources.surroundBack": "Back",
+  "twoDSources.summary.spatialized": "Spatialized",
+  "twoDSources.summary.passthrough": "Player passthrough",
   "virtualBed.virtual": "Virtual",
   "virtualBed.direct": "Direct",
   "virtualBed.reset": "Reset channel layout",

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "Canales traseros (4.x/5.x)",
   "twoDSources.surroundSide": "Lateral",
   "twoDSources.surroundBack": "Trasero",
+  "twoDSources.summary.spatialized": "Espacializado",
+  "twoDSources.summary.passthrough": "Paso directo del reproductor",
   "virtualBed.virtual": "Virtual",
   "virtualBed.direct": "Directo",
   "virtualBed.reset": "Restablecer disposición de canales",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "Canaux arrière (4.x/5.x)",
   "twoDSources.surroundSide": "Côté",
   "twoDSources.surroundBack": "Arrière",
+  "twoDSources.summary.spatialized": "Spatialisé",
+  "twoDSources.summary.passthrough": "Passthrough lecteur",
   "virtualBed.virtual": "Virtuel",
   "virtualBed.direct": "Direct",
   "virtualBed.reset": "Réinitialiser la disposition",

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "Canali posteriori (4.x/5.x)",
   "twoDSources.surroundSide": "Laterale",
   "twoDSources.surroundBack": "Posteriore",
+  "twoDSources.summary.spatialized": "Spazializzato",
+  "twoDSources.summary.passthrough": "Passthrough del lettore",
   "virtualBed.virtual": "Virtuale",
   "virtualBed.direct": "Diretto",
   "virtualBed.reset": "Reimposta disposizione canali",

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "リアチャンネル（4.x/5.x）",
   "twoDSources.surroundSide": "サイド",
   "twoDSources.surroundBack": "バック",
+  "twoDSources.summary.spatialized": "空間化",
+  "twoDSources.summary.passthrough": "プレーヤー直通",
   "virtualBed.virtual": "仮想",
   "virtualBed.direct": "ダイレクト",
   "virtualBed.reset": "チャンネル配置をリセット",

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "Canais traseiros (4.x/5.x)",
   "twoDSources.surroundSide": "Lateral",
   "twoDSources.surroundBack": "Traseiro",
+  "twoDSources.summary.spatialized": "Espacializado",
+  "twoDSources.summary.passthrough": "Passthrough do player",
   "virtualBed.virtual": "Virtual",
   "virtualBed.direct": "Direto",
   "virtualBed.reset": "Redefinir disposição de canais",

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -275,6 +275,8 @@
   "twoDSources.surroundLabel": "后置声道（4.x/5.x）",
   "twoDSources.surroundSide": "侧面",
   "twoDSources.surroundBack": "后方",
+  "twoDSources.summary.spatialized": "空间化",
+  "twoDSources.summary.passthrough": "播放器直通",
   "virtualBed.virtual": "虚拟",
   "virtualBed.direct": "直接",
   "virtualBed.reset": "重置声道布局",

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -102,18 +102,19 @@
       </div>
       </div>
       <div id="audioInputPanelMount"></div>
-      <div id="twoDSourcesPanelRoot" class="info-section">
+      <div id="twoDSourcesPanelRoot" class="info-section section-collapsed">
         <div class="panel-header">
           <div class="panel-header-main">
             <div class="panel-title-wrap">
               <div class="info-title panel-title" data-i18n="section.twoDSources" data-help-i18n="help.twoDSources">2D sources</div>
+              <div id="twoDSourcesSummary" class="panel-summary" style="display:block;flex:0 1 auto">—</div>
             </div>
           </div>
           <div style="display:flex;align-items:center;gap:0.35rem">
-            <button id="twoDSourcesToggleBtn" type="button" class="panel-toggle-btn" data-i18n-title="section.twoDSources" title="2D sources">▾</button>
+            <button id="twoDSourcesToggleBtn" type="button" class="panel-toggle-btn" data-i18n-title="section.twoDSources" title="2D sources">▸</button>
           </div>
         </div>
-        <div id="twoDSourcesBody" style="display:grid;gap:0.35rem;padding:0.1rem 0.1rem 0.2rem">
+        <div id="twoDSourcesBody" style="display:none;gap:0.35rem;padding:0.1rem 0.1rem 0.2rem">
           <label class="switch-row" style="font-size:13px;cursor:pointer">
             <span data-i18n="twoDSources.spatializeLabel" data-help-i18n="help.twoDSources" data-help-anchor=".switch-row">Spatialize 2D sources</span>
             <input id="channelSpatializeToggle" type="checkbox" />

--- a/omniphony-studio/src/listeners/modal-and-toggle-listeners.js
+++ b/omniphony-studio/src/listeners/modal-and-toggle-listeners.js
@@ -10,7 +10,7 @@ import {
   setInputClockInfoModalOpen, setInputLfeInfoModalOpen,
   setDrcInfoModalOpen, setHeatmapInfoModalOpen,
   setTelemetryGaugesOpen,
-  setDisplaySectionOpen, setDrcSectionOpen, setAudioOutputSectionOpen, setInputSectionOpen, setRendererSectionOpen,
+  setDisplaySectionOpen, setDrcSectionOpen, setTwoDSourcesSectionOpen, setAudioOutputSectionOpen, setInputSectionOpen, setRendererSectionOpen,
   setAutoGainSectionOpen
 } from '../modals.js';
 import { closeAutoTuneWizardOnEscape } from '../auto-tune/wizard-ui.js';
@@ -270,15 +270,11 @@ export function setupModalAndToggleListeners() {
     });
   }
 
-  // 2D sources: a small self-contained collapse (no persisted state needed).
+  // 2D sources: collapsed by default, with a header summary while collapsed.
   const twoDSourcesToggleBtnEl = document.getElementById('twoDSourcesToggleBtn');
   if (twoDSourcesToggleBtnEl) {
     twoDSourcesToggleBtnEl.addEventListener('click', () => {
-      const root = document.getElementById('twoDSourcesPanelRoot');
-      const body = document.getElementById('twoDSourcesBody');
-      const collapsed = root?.classList.toggle('section-collapsed');
-      if (body) body.style.display = collapsed ? 'none' : 'grid';
-      twoDSourcesToggleBtnEl.textContent = collapsed ? '▸' : '▾';
+      setTwoDSourcesSectionOpen(!app.twoDSourcesSectionOpen);
     });
   }
 

--- a/omniphony-studio/src/modals.js
+++ b/omniphony-studio/src/modals.js
@@ -35,6 +35,10 @@ function getDrcSectionContentEl() { return document.getElementById('drcSectionCo
 function getDrcSummaryEl() { return document.getElementById('drcSummary'); }
 function getDrcSectionToggleBtnEl() { return document.getElementById('drcSectionToggleBtn'); }
 function getDrcSectionEl() { return document.getElementById('drcSection'); }
+function getTwoDSourcesPanelRootEl() { return document.getElementById('twoDSourcesPanelRoot'); }
+function getTwoDSourcesBodyEl() { return document.getElementById('twoDSourcesBody'); }
+function getTwoDSourcesSummaryEl() { return document.getElementById('twoDSourcesSummary'); }
+function getTwoDSourcesToggleBtnEl() { return document.getElementById('twoDSourcesToggleBtn'); }
 function getAudioOutputSectionContentEl() { return document.getElementById('audioOutputSectionContent'); }
 function getAudioOutputSummaryEl() { return document.getElementById('audioOutputSummary'); }
 function getAudioOutputSectionToggleBtnEl() { return document.getElementById('audioOutputSectionToggleBtn'); }
@@ -236,6 +240,27 @@ export function setDrcSectionOpen(open) {
     drcSectionEl.classList.toggle('section-collapsed', !app.drcSectionOpen);
   }
   emitOverlayLayoutChanged('drc-section-toggle');
+}
+
+export function setTwoDSourcesSectionOpen(open) {
+  const rootEl = getTwoDSourcesPanelRootEl();
+  const bodyEl = getTwoDSourcesBodyEl();
+  const summaryEl = getTwoDSourcesSummaryEl();
+  const toggleBtnEl = getTwoDSourcesToggleBtnEl();
+  app.twoDSourcesSectionOpen = Boolean(open);
+  if (rootEl) {
+    rootEl.classList.toggle('section-collapsed', !app.twoDSourcesSectionOpen);
+  }
+  if (bodyEl) {
+    bodyEl.style.display = app.twoDSourcesSectionOpen ? 'grid' : 'none';
+  }
+  if (summaryEl) {
+    summaryEl.style.display = app.twoDSourcesSectionOpen ? 'none' : 'block';
+  }
+  if (toggleBtnEl) {
+    toggleBtnEl.textContent = app.twoDSourcesSectionOpen ? '▾' : '▸';
+  }
+  emitOverlayLayoutChanged('twoD-sources-toggle');
 }
 
 export function setAudioOutputSectionOpen(open) {

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -112,7 +112,7 @@ import {
   arcLabelAngles
 } from './scene/gizmos.js';
 
-import { renderChannelEditor, canonicalChannelName, channelPlacement } from './controls/virtual-bed.js';
+import { renderChannelEditor, canonicalChannelName, canonicalChannelOrder, channelPlacement } from './controls/virtual-bed.js';
 import { t, tf } from './i18n.js';
 import { pushLog } from './log.js';
 import { scheduleUIFlush } from './flush.js';
@@ -1523,7 +1523,18 @@ export function renderObjectsList() {
   const objectsListEl = getObjectsListEl();
   if (!objectsListEl) return;
 
+  // Order bed channels (L, R, C, LFE, Ls, Rs, Lb, Rb) by the canonical channel
+  // order, keyed on the object's *name* so it holds both at rest (synthetic bed,
+  // id = channel name) and during playback of a 5.1/7.1 bed (e.g. a DTS track,
+  // where the live object has a numeric id but a channel name like "L"). Dynamic
+  // (non-bed) objects keep their numeric-id order, then anything else by locale.
+  const channelRank = (id) => canonicalChannelOrder(sourceNames.get(String(id)) ?? id);
   const ids = [...sourceMeshes.keys()].sort((a, b) => {
+    const aOrd = channelRank(a);
+    const bOrd = channelRank(b);
+    if (aOrd !== -1 && bOrd !== -1) return aOrd - bOrd;
+    if (aOrd !== -1) return -1;
+    if (bOrd !== -1) return 1;
     const aNum = Number(a);
     const bNum = Number(b);
     const aIsNum = Number.isFinite(aNum);

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -350,6 +350,7 @@ export const app = {
   rendererSectionOpen: false,
   displaySectionOpen: false,
   drcSectionOpen: false,
+  twoDSourcesSectionOpen: false,
   autoGainSectionOpen: false,
 
   // Selection & drag


### PR DESCRIPTION
Pre-release pass of small Studio fixes.

## 1. 2D-sources panel collapsed by default, with a header summary
The panel was open by default and showed no summary in its title when collapsed,
unlike the other left-overlay panels. It now follows the established panel idiom
(DRC / Room Geometry): a proper `setTwoDSourcesSectionOpen()` setter, collapsed
at startup, with a header summary reflecting the live state while collapsed —
`Spatialized · Side/Back` when 2D beds are spatialised, `Player passthrough` in
host mode. Two summary i18n keys added across all 8 locales.

## 2. Objects list ordered by the canonical 5.1/7.1 channel order
The list sorted named entries alphabetically (C, L, LFE, Lb, Ls, …), so a
5.1/7.1 bed appeared in a strange order. Bed channels are now ordered by the
canonical channel order (L, R, C, LFE, Ls, Rs, Lb, Rb), keyed on the object's
name so it holds both at rest (synthetic bed, id = channel name) and during
playback of a live bed (e.g. a DTS track: numeric id, name = "L"). Dynamic
(non-bed) objects keep their numeric-id order.

## Verification
- `node --check` on all edited JS files.
- `node scripts/check-i18n.mjs`: 0 missing / 0 orphaned for the new keys across
  all 8 locales (pre-existing `audio.formatCaf` leftovers unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)