### PR TITLE
fix(studio): objects list canonical channel order across track changes

### DIFF
--- a/omniphony-studio/src/sources.js
+++ b/omniphony-studio/src/sources.js
@@ -1043,15 +1043,19 @@ export function updateSource(id, position) {
   }
 
   updateSourceDecorations(id);
+  const key = String(id);
+  const prevName = sourceNames.get(key);
   if (position && typeof position.name === 'string' && position.name.trim()) {
-    sourceNames.set(String(id), position.name.trim());
+    sourceNames.set(key, position.name.trim());
   }
   const label = sourceLabels.get(id);
   if (label) {
-    setLabelSpriteText(label, formatObjectLabel(String(id)));
+    setLabelSpriteText(label, formatObjectLabel(key));
   }
-  const key = String(id);
-  if (!objectItems.has(key)) {
+  // Re-sort the list on a new object OR when an existing id's name changes:
+  // switching tracks reuses object ids with different channels (DTS↔AC-3↔DTS:X),
+  // so an in-place relabel alone would leave the list stuck in the old order.
+  if (!objectItems.has(key) || sourceNames.get(key) !== prevName) {
     sourceCallbacks.renderObjectsList?.();
   } else {
     sourceCallbacks.updateObjectPositionUI?.(key, raw);

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -1524,11 +1524,12 @@ export function renderObjectsList() {
   if (!objectsListEl) return;
 
   // Order bed channels (L, R, C, LFE, Ls, Rs, Lb, Rb) by the canonical channel
-  // order, keyed on the object's *name* so it holds both at rest (synthetic bed,
-  // id = channel name) and during playback of a 5.1/7.1 bed (e.g. a DTS track,
-  // where the live object has a numeric id but a channel name like "L"). Dynamic
-  // (non-bed) objects keep their numeric-id order, then anything else by locale.
-  const channelRank = (id) => canonicalChannelOrder(sourceNames.get(String(id)) ?? id);
+  // order, keyed on the object's *displayed label* (`formatObjectLabel` strips
+  // technical prefixes — the raw OSC name is e.g. "v_C"/"a_FL", which
+  // canonicalChannelName wouldn't match, leaving the bed in the decoder's native
+  // order: DTS C,L,R,…; AC-3 L,C,R,…). Holds at rest (synthetic bed, id = label)
+  // and during playback. Dynamic objects keep their numeric-id order, then locale.
+  const channelRank = (id) => canonicalChannelOrder(formatObjectLabel(id));
   const ids = [...sourceMeshes.keys()].sort((a, b) => {
     const aOrd = channelRank(a);
     const bOrd = channelRank(b);


### PR DESCRIPTION
Follow-up to #121: the objects (virtual bed) list still showed bed channels in
the **decoder's native order** (DTS `C,L,R,…`; AC-3 `L,C,R,…`; DTS:X `C,L,R,…,Lb,Rb`)
instead of canonical `L,R,C,LFE,Ls,Rs`. Two causes:

1. **`speakers.js`** — `renderObjectsList` ranked objects by the *raw* OSC name,
   which carries a technical prefix (`v_`/`a_`); `canonicalChannelName` didn't
   match it, so every object fell back to the numeric (decoder) id order. Rank by
   `formatObjectLabel(id)` — the normalized, displayed label — instead.
2. **`sources.js`** — `updateSource` only re-sorted (`renderObjectsList`) when a
   **new** object id appeared. Switching tracks reuses object ids with different
   channels, so it relabeled in place without re-sorting → the list stayed in the
   old (decoder) order. Now it re-sorts when an existing id's name changes too.

## Verification
Live in the integration dev build: the bed lists as `L, R, C, LFE, Ls, Rs`
(+`Lb, Rb`) for DTS, AC-3 and DTS:X, and **stays sorted across track changes**.
`node --check` on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)