### PR TITLE
feat(studio): dynamic red→blue gradient for per-band gain bars

### DIFF
--- a/omniphony-studio/src/scene/speaker-band-bars.js
+++ b/omniphony-studio/src/scene/speaker-band-bars.js
@@ -33,9 +33,10 @@ function logPos(freq) {
   return (Math.log(f) - LOG_MIN) / LOG_SPAN; // 0 at FMIN (bottom), 1 at FMAX (top)
 }
 
-// One solid, well-separated colour per band index, ordered low→high (warm→cool).
-// Not proportional to frequency — just distinct so different bands pop.
-function bandColor(index, count) {
+// One solid, well-separated colour per band index, ordered low→high
+// (warm→cool: red for the lowest band, blue for the highest). Shared with the
+// per-object band bars in the objects list so both read the same palette.
+export function bandColor(index, count) {
   if (count <= 1) return FULL_BAND_COLOR;
   const hue = 8 + (248 * index) / (count - 1); // ~red (low) → ~blue (high)
   return `hsl(${hue.toFixed(0)}, 68%, 56%)`;

--- a/omniphony-studio/src/sources.js
+++ b/omniphony-studio/src/sources.js
@@ -70,7 +70,7 @@ import {
   setLabelSpriteText,
   updateSpeakerLabelsFromSelection
 } from './scene/labels.js';
-import { disposeSpeakerBandBar } from './scene/speaker-band-bars.js';
+import { disposeSpeakerBandBar, bandColor } from './scene/speaker-band-bars.js';
 import { createTrailRenderable } from './trails.js';
 import { shouldAppendTrailPoint, recordTrailPoint, shouldRebuildTrailGeometry } from './trails.js';
 import {
@@ -680,7 +680,12 @@ function updateObjectBandBars(entry, id) {
     if (labelEl) {
       labelEl.textContent = labels?.[b] ?? (contributions.length === 1 ? 'Full band' : `Band ${b}`);
     }
-    if (bar) bar.style.setProperty('--level', `${Math.min(100, gain * 100).toFixed(1)}%`);
+    if (bar) {
+      bar.style.setProperty('--level', `${Math.min(100, gain * 100).toFixed(1)}%`);
+      // Red (lowest band) → blue (highest), computed dynamically so any number
+      // of crossover bands gets a colour. Same palette as the 3D speaker gauges.
+      bar.style.setProperty('--band-color', bandColor(b, contributions.length));
+    }
     if (dbEl) dbEl.textContent = linearToDb(gain);
   });
 

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -97,7 +97,7 @@ import {
 import { updateHeadphoneMeter, updateHeadphoneControlsUI } from './controls/headphone-meter.js';
 
 import { createLabelSprite, setLabelSpriteText, updateSpeakerLabelsFromSelection } from './scene/labels.js';
-import { createSpeakerBandBar, updateSpeakerBandBar } from './scene/speaker-band-bars.js';
+import { createSpeakerBandBar, updateSpeakerBandBar, bandColor } from './scene/speaker-band-bars.js';
 import { syncSpeakerHeatmapBandSelect } from './scene/speaker-band-select.js';
 import { refreshGaintableSubscription } from './scene/speaker-gaintable.js';
 
@@ -973,7 +973,12 @@ export function updateSpeakerBandBars(entry, speakerIndex) {
     if (labelEl) {
       labelEl.textContent = labels?.[b] ?? (contributions.length === 1 ? 'Full band' : `Band ${b}`);
     }
-    if (bar) bar.style.setProperty('--level', `${Math.min(100, gain * 100).toFixed(1)}%`);
+    if (bar) {
+      bar.style.setProperty('--level', `${Math.min(100, gain * 100).toFixed(1)}%`);
+      // Red (lowest band) → blue (highest), computed dynamically for any number
+      // of crossover bands. Same palette as the object band bars and 3D gauges.
+      bar.style.setProperty('--band-color', bandColor(b, contributions.length));
+    }
     if (dbEl) dbEl.textContent = linearToDb(gain);
   });
 

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -2245,12 +2245,10 @@
         position: absolute;
         inset: 0;
         clip-path: inset(0 calc(100% - var(--level, 0%)) 0 0);
+        /* Colour set per band in JS (bandColor): red = lowest band → blue =
+           highest, computed for any number of crossover bands. */
+        background: var(--band-color, #8ec8ff);
       }
-
-      .band-bar[data-band="0"]::after { background: #4dd7ff; }
-      .band-bar[data-band="1"]::after { background: #7bff6a; }
-      .band-bar[data-band="2"]::after { background: #ffd13a; }
-      .band-bar[data-band="3"]::after { background: #ff5d5d; }
 
       .band-db {
         font-size: 9px;


### PR DESCRIPTION
## Problem
The per-band gain bars (objects list when a speaker is selected; speakers list
when an object is selected) only had hardcoded fill colours for band indices
`0-3` via CSS `data-band` rules. Layouts with more crossover bands (e.g. this
rig has 6) left the extra bars **invisible** — the dB value showed but no bar.

## Change
Colour each band bar **dynamically** via the shared `bandColor(index, count)`
(exported from the 3D speaker gauges, `scene/speaker-band-bars.js`):
**red = lowest band → blue = highest**, for any number of crossover bands.

- `updateObjectBandBars` (`sources.js`) and `updateSpeakerBandBars`
  (`speakers.js`) set a `--band-color` custom property.
- CSS `.band-bar::after` consumes `var(--band-color, …)`; the fixed `data-band`
  palette (0-3 only) is removed.
- Objects list, speakers list and the 3D speaker gauges now share one palette.

## Verification
- Select a speaker → object band bars show a red→blue gradient across all bands.
- Select an object → speaker band bars show the same gradient.
- `node --check` on the three JS files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)