### PR TITLE
fix(virtual-bed): cartesian-corner fallback + persist the editor's bed to config

### DIFF
--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -330,32 +330,39 @@ fn label_aliases(label: RChannelLabel, use_7_1: bool) -> Option<&'static [&'stat
     }
 }
 
+/// Last-resort bed pose as a **normalized cartesian** corner position, used only
+/// when neither the live `virtual_bed` config nor an on-disk layout resolves the
+/// channel. These mirror the canonical `layouts/legacy/5.1.yaml`/`7.1.yaml` and
+/// Studio's `CANONICAL_BED`, so a corner channel lands exactly in its corner after
+/// the room warp — cartesian, not polar/distance, which used to pull the corners
+/// inward. Floor row at `z = 0`, height row at the ceiling `z = 1`. `use_7_1` no
+/// longer changes these (the corners are layout-independent); the surround pair is
+/// finalised by [`surround_placement_override`] for 4.x/5.x sources.
 fn fallback_virtual_bed_pose(
     label: RChannelLabel,
-    use_7_1: bool,
+    _use_7_1: bool,
 ) -> Option<(String, f32, f32, f32)> {
-    let (name, az, el, dist) = match label {
-        RChannelLabel::L => ("FL", if use_7_1 { -26.0 } else { -30.0 }, 0.0, 2.0),
-        RChannelLabel::R => ("FR", if use_7_1 { 26.0 } else { 30.0 }, 0.0, 2.0),
-        RChannelLabel::C => ("C", 0.0, 0.0, 2.0),
-        RChannelLabel::LFE | RChannelLabel::LFE2 => ("LFE", 0.0, 0.0, 1.0),
-        RChannelLabel::Ls => ("SL", if use_7_1 { -100.0 } else { -110.0 }, 0.0, 1.0),
-        RChannelLabel::Rs => ("SR", if use_7_1 { 100.0 } else { 110.0 }, 0.0, 1.0),
-        RChannelLabel::Lb => ("BL", -142.5, 0.0, 1.0),
-        RChannelLabel::Rb => ("BR", 142.5, 0.0, 1.0),
-        RChannelLabel::Cb => ("BC", 180.0, 0.0, 1.0),
-        // Height layer (≈45° elevation), e.g. a 7.1.4 input bed. Azimuths mirror
-        // the matching floor pair; the top-side pair sits overhead to the side.
-        RChannelLabel::Tfl => ("TFL", -45.0, 45.0, 1.0),
-        RChannelLabel::Tfr => ("TFR", 45.0, 45.0, 1.0),
-        RChannelLabel::Tbl => ("TBL", -135.0, 45.0, 1.0),
-        RChannelLabel::Tbr => ("TBR", 135.0, 45.0, 1.0),
-        RChannelLabel::Tsl => ("TSL", -90.0, 45.0, 1.0),
-        RChannelLabel::Tsr => ("TSR", 90.0, 45.0, 1.0),
-        RChannelLabel::Tfc => ("TFC", 0.0, 45.0, 1.0),
+    let (name, x, y, z) = match label {
+        RChannelLabel::L => ("FL", -1.0, 1.0, 0.0),
+        RChannelLabel::R => ("FR", 1.0, 1.0, 0.0),
+        RChannelLabel::C => ("C", 0.0, 1.0, 0.0),
+        RChannelLabel::LFE | RChannelLabel::LFE2 => ("LFE", 0.0, 1.0, 0.0),
+        RChannelLabel::Ls => ("SL", -1.0, 0.0, 0.0),
+        RChannelLabel::Rs => ("SR", 1.0, 0.0, 0.0),
+        RChannelLabel::Lb => ("BL", -1.0, -1.0, 0.0),
+        RChannelLabel::Rb => ("BR", 1.0, -1.0, 0.0),
+        RChannelLabel::Cb => ("BC", 0.0, -1.0, 0.0),
+        // Height layer at the ceiling (z = 1), mirroring the floor corners.
+        RChannelLabel::Tfl => ("TFL", -1.0, 1.0, 1.0),
+        RChannelLabel::Tfr => ("TFR", 1.0, 1.0, 1.0),
+        RChannelLabel::Tbl => ("TBL", -1.0, -1.0, 1.0),
+        RChannelLabel::Tbr => ("TBR", 1.0, -1.0, 1.0),
+        RChannelLabel::Tsl => ("TSL", -1.0, 0.0, 1.0),
+        RChannelLabel::Tsr => ("TSR", 1.0, 0.0, 1.0),
+        RChannelLabel::Tfc => ("TFC", 0.0, 1.0, 1.0),
         _ => return None,
     };
-    Some((name.to_string(), az, el, dist))
+    Some((name.to_string(), x, y, z))
 }
 
 /// For a 4.x/5.x source (no back channels) the surround pair (`Ls`/`Rs`) has no
@@ -483,18 +490,17 @@ fn resolve_virtual_bed_pose_raw(
         }
     }
 
-    fallback_virtual_bed_pose(label, use_7_1).map(|(name, az_deg, el_deg, dist_m)| {
-        let (sx, sy, sz) = renderer::spatial_vbap::spherical_to_adm(az_deg, el_deg, dist_m);
-        let (x, y, z) = inverse_room_ratio_map_for_virtual_object(
-            sx,
-            sy,
-            sz,
-            room_ratio,
-            room_ratio_rear,
-            room_ratio_lower,
-            room_ratio_center_blend,
-        );
-        (name, x, y, z)
+    // Cartesian corner fallback: use x/y/z directly (clamped), exactly like the
+    // cartesian branch of `speaker_pose_to_normalized`. No `spherical_to_adm` +
+    // inverse-room-warp round-trip, which previously pulled corner channels off
+    // their corner (the FL/FR-not-in-the-corner bug under hosts with no layout).
+    fallback_virtual_bed_pose(label, use_7_1).map(|(name, x, y, z)| {
+        (
+            name,
+            x.clamp(-1.0, 1.0),
+            y.clamp(-1.0, 1.0),
+            z.clamp(-1.0, 1.0),
+        )
     })
 }
 
@@ -963,6 +969,31 @@ mod tests {
             assert!((pos[0] - obj.x as f64).abs() < 1e-6);
             assert!((pos[1] - obj.y as f64).abs() < 1e-6);
             assert!((pos[2] - obj.z as f64).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn fallback_pose_is_cartesian_corners() {
+        // The last-resort fallback (no live bed, no on-disk layout) must place the
+        // bed channels at the exact cartesian corners, not a polar/distance
+        // approximation that gets pulled inward by the room warp — so a host with
+        // no layout (e.g. mpv with a non-workspace cwd) still shows FL/FR in the
+        // corners and matches the editor.
+        for (label, expect) in [
+            (RChannelLabel::L, (-1.0_f32, 1.0_f32, 0.0_f32)),
+            (RChannelLabel::R, (1.0, 1.0, 0.0)),
+            (RChannelLabel::C, (0.0, 1.0, 0.0)),
+            (RChannelLabel::Ls, (-1.0, 0.0, 0.0)),
+            (RChannelLabel::Rs, (1.0, 0.0, 0.0)),
+            (RChannelLabel::Lb, (-1.0, -1.0, 0.0)),
+            (RChannelLabel::Rb, (1.0, -1.0, 0.0)),
+        ] {
+            // use_7_1 must not change the corner.
+            for use_7_1 in [false, true] {
+                let (_n, x, y, z) = fallback_virtual_bed_pose(label, use_7_1)
+                    .unwrap_or_else(|| panic!("fallback pose for {label:?}"));
+                assert_eq!((x, y, z), expect, "{label:?} (use_7_1={use_7_1})");
+            }
         }
     }
 

--- a/omniphony-studio/src/controls/virtual-bed.js
+++ b/omniphony-studio/src/controls/virtual-bed.js
@@ -325,6 +325,15 @@ export function resetVirtualBed() {
   renderChannelEditor(true);
 }
 
+// Materialise the canonical bed into the renderer/config the first time we learn
+// the renderer has no saved bed, so the editor's values live in config.yaml (like
+// the speaker layout's `current_layout`) and are used in priority — rather than
+// the renderer falling back to a built-in default. Same explicit cartesian push
+// as the manual Reset; the one-shot guard lives in the caller.
+export function materializeDefaultVirtualBed() {
+  resetVirtualBed();
+}
+
 // ---------------------------------------------------------------------------
 // Synthetic virtual objects (visible/editable at rest)
 // ---------------------------------------------------------------------------

--- a/omniphony-studio/src/runtime-audio-state.js
+++ b/omniphony-studio/src/runtime-audio-state.js
@@ -11,6 +11,7 @@ import {
   updateResampleRatioDisplay
 } from './controls/latency.js';
 import { updateAudioFormatDisplay } from './controls/audio.js';
+import { materializeDefaultVirtualBed } from './controls/virtual-bed.js';
 
 function normalizeAudioOutputDevices(values) {
   return Array.isArray(values)
@@ -122,6 +123,14 @@ export function applyRuntimeAudioStateSnapshot(payload) {
     // configured/live bed. The editor seeds defaults when this is null.
     app.virtualBed =
       payload.virtualBed && typeof payload.virtualBed === 'object' ? payload.virtualBed : null;
+    // First authoritative snapshot reporting no saved bed (and not in host mode):
+    // materialise the canonical cartesian bed so the editor's values persist to
+    // config.yaml (like `current_layout`) and are used in priority, instead of
+    // relying on a built-in default. One-shot; once a bed exists this is skipped.
+    if (!app.virtualBed && !app.virtualBedMaterialized && app.channelRenderMode !== 'host') {
+      app.virtualBedMaterialized = true;
+      materializeDefaultVirtualBed();
+    }
   }
   if (typeof payload.audioOutputDevice === 'string') {
     app.audioOutputDevice = payload.audioOutputDevice.trim() || null;

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -240,6 +240,9 @@ export const app = {
   // Parametrable virtual bed for 2D sources (a SpeakerLayout-shaped object, or
   // null = built-in canonical poses). Edited by the virtual-bed editor.
   virtualBed: null,
+  // One-shot guard: once we've materialised the canonical bed into the
+  // renderer/config (when none was saved), don't push it again this session.
+  virtualBedMaterialized: false,
   audioOutputDevice: null,
   audioOutputDeviceEffective: null,
   audioOutputDevices: [],


### PR DESCRIPTION
## Problem
Playing channel content (DTS/DTS-X) in **mpv/FFI mode**, the virtual-bed objects
FL/FR were drawn **off-corner**, even though the channel editor showed the correct
cartesian coordinates (`-1,1,0` / `1,1,0`). The editor reads Studio's own model
(`CANONICAL_BED`, cartesian corners); the 3D mesh is placed from the renderer's live
broadcast (`resolve_virtual_bed_pose`) — a different source.

## Root cause
- The renderer's last-resort `fallback_virtual_bed_pose` was **polar** (az/dist) run
  through `spherical_to_adm` + the inverse room-warp, which pulls corner channels
  inward. In mpv the bed layout files aren't found (mpv cwd is not the workspace; no
  `CARGO_MANIFEST_DIR/layouts`, no `/usr/.../orender/layouts`) and the config has no
  `virtual_bed`, so this polar fallback was the active path. (CLI/PipeWire's cwd is
  the workspace, so the files load → correct there.)
- The editor's bed lived only on the Studio side; the **default bed was never
  materialised**, so `config.virtual_bed` stayed absent and `live.virtual_bed = None`.

## Fix
**Renderer** (`orender_engine/src/virtual_bed.rs`):
- `fallback_virtual_bed_pose` returns the standard **cartesian** corners (mirroring
  `layouts/legacy/*.yaml` and Studio's `CANONICAL_BED`: L`-1,1,0` R`1,1,0` C`0,1,0`
  SL/SR/BL/BR/BC, height row at `z=1`); `resolve_virtual_bed_pose_raw` consumes them
  directly (clamped), dropping the `spherical_to_adm` + inverse-room-warp round-trip.
- Priority order is unchanged: live/config `virtual_bed` → on-disk layout → this
  cartesian fallback. New deterministic test `fallback_pose_is_cartesian_corners`.

**Studio** (persist the editor's bed to `config.yaml`, used in priority):
- `runtime-audio-state.js`: on the first authoritative snapshot reporting **no saved
  bed** (and not host mode), materialise the canonical bed once → sets
  `live.virtual_bed` (resolve step 1) and persists to `config.yaml` like
  `current_layout`. `controls/virtual-bed.js`: `materializeDefaultVirtualBed()`
  (reuses the explicit-cartesian push). `state.js`: one-shot guard.

## Verification
- `cargo test -p orender_engine` → **66/66 + 2** green; rustfmt clean.
- mpv/FFI (relaunched with the rebuilt `liborender.so`): FL/FR sit exactly in the
  corners, matching the editor; saving in Studio writes `render.virtual_bed` to
  `config.yaml`. CLI/PipeWire unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)