### PR TITLE
chore(release): bump Omniphony to 0.4.1

### DIFF
--- a/omniphony-studio/package.json
+++ b/omniphony-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniphony-studio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Visualisation 3D d'objets audio spatialisés via OSC",
   "scripts": {
     "dev": "vite",

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "omniphony-studio"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "flate2",
  "image",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omniphony-studio"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [[bin]]

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fr.omniphony.studio",
   "productName": "Omniphony Studio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",


### PR DESCRIPTION
Version bump for the 0.4.1 release (first public 0.4.x; v0.4.0 was never published).

Bumps `0.4.0 → 0.4.1` in `omniphony-studio` (`tauri.conf.json`, `src-tauri/Cargo.toml`,
`package.json`, `Cargo.lock`). Renderer crate versions are intentionally untouched
(separate version line).

After merge: promote `main → release` and tag `v0.4.1` + `liborender-v0.4.1` on `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)