### PR TITLE
fix(osc): let an explicit null clear a per-speaker crossover cutoff

### DIFF
--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -59,6 +59,23 @@ pub struct ControlEffects {
 // AdaptiveResamplingPatch / AudioConfigPatch / LiveInputPatch / InputConfigPatch
 // moved to the `host_audio` crate alongside their dispatch handlers.
 
+/// Deserialize an `Option<Option<T>>` so an explicit JSON `null` means "clear"
+/// (`Some(None)`) while an absent field leaves the value untouched (`None`).
+///
+/// Plain `#[serde(default)]` can't express this: serde_json folds `null` into
+/// the *outer* `None`, making an explicit "remove this cutoff" request from the
+/// editor indistinguishable from "field not sent" — so a per-speaker crossover
+/// cutoff could be changed but never blanked. Pair with
+/// `#[serde(default, deserialize_with = "double_option")]`: `default` covers the
+/// absent case (the helper is only called when the field is present).
+fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Some)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct LayoutSpeakerPatch {
@@ -72,9 +89,9 @@ struct LayoutSpeakerPatch {
     elevation: Option<f32>,
     distance: Option<f32>,
     spatialize: Option<bool>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     freq_low: Option<Option<f32>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     freq_high: Option<Option<f32>>,
 }
 
@@ -91,9 +108,9 @@ struct LayoutAddSpeakerPatch {
     distance: Option<f32>,
     spatialize: Option<bool>,
     delay_ms: Option<f32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     freq_low: Option<Option<f32>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     freq_high: Option<Option<f32>>,
 }
 
@@ -1690,4 +1707,69 @@ pub fn apply_simple_osc_control(
     }
 
     None
+}
+
+#[cfg(test)]
+mod freq_cutoff_clear_tests {
+    use super::*;
+
+    fn speaker_patch(json: &str) -> LayoutSpeakerPatch {
+        serde_json::from_str(json).expect("valid LayoutSpeakerPatch")
+    }
+
+    /// The editor sends `freqLow: null` to remove a cutoff; an unrelated edit
+    /// omits the field entirely. These must be distinguishable, which plain
+    /// `Option<Option<f32>>` + `#[serde(default)]` was not (`null` collapsed to
+    /// the outer `None`, so a clear was silently dropped).
+    #[test]
+    fn double_option_distinguishes_absent_null_and_value() {
+        // Absent → leave untouched.
+        assert_eq!(speaker_patch(r#"{"id":0}"#).freq_low, None);
+        // Explicit null → clear the cutoff.
+        assert_eq!(
+            speaker_patch(r#"{"id":0,"freqLow":null}"#).freq_low,
+            Some(None)
+        );
+        // A value → set the cutoff.
+        assert_eq!(
+            speaker_patch(r#"{"id":0,"freqLow":80.0}"#).freq_low,
+            Some(Some(80.0))
+        );
+        // freq_high follows the same rule.
+        assert_eq!(
+            speaker_patch(r#"{"id":0,"freqHigh":null}"#).freq_high,
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn explicit_null_clears_an_existing_cutoff() {
+        let mut speaker =
+            renderer::speaker_layout::Speaker::from_polar("FL", 30.0, 0.0, 1.0, true, 0.0)
+                .with_freq_low(120.0)
+                .with_freq_high(18_000.0);
+        assert_eq!(speaker.freq_low, Some(120.0));
+
+        let changed =
+            apply_layout_speaker_patch(&mut speaker, &speaker_patch(r#"{"id":0,"freqLow":null}"#));
+        assert!(changed, "clearing a set cutoff is a change");
+        assert_eq!(
+            speaker.freq_low, None,
+            "explicit null must blank the cutoff"
+        );
+        // freq_high was absent from the patch → left untouched.
+        assert_eq!(speaker.freq_high, Some(18_000.0));
+    }
+
+    #[test]
+    fn absent_cutoff_field_leaves_value_untouched() {
+        let mut speaker =
+            renderer::speaker_layout::Speaker::from_polar("FL", 30.0, 0.0, 1.0, true, 0.0)
+                .with_freq_low(120.0);
+        apply_layout_speaker_patch(
+            &mut speaker,
+            &speaker_patch(r#"{"id":0,"spatialize":true}"#),
+        );
+        assert_eq!(speaker.freq_low, Some(120.0));
+    }
 }


### PR DESCRIPTION
## Problem

Per-speaker crossover cutoffs (`freq_low` / `freq_high` in the speaker editor) can be **set and changed** but never **cleared**. Blanking the field in Studio sends `freqLow: null`, yet the cutoff sticks.

## Root cause

The patch fields are typed `Option<Option<f32>>` with plain `#[serde(default)]`, intending "explicit `null` = clear". But serde_json folds a JSON `null` into the **outer** `None`, so `null` (clear) is indistinguishable from an absent field (leave untouched). `apply_layout_speaker_patch` then does `if let Some(freq_low) = patch.freq_low { … }`, which is skipped for `null`, leaving the old cutoff in place.

```
Option<Option<f32>> from `null`  =>  None        (wrong: should be Some(None))
Option<Option<f32>> from absent  =>  None
Option<Option<f32>> from `80.0`  =>  Some(Some(80.0))
```

## Fix

Add a `double_option` `deserialize_with` helper and apply it to the `freq_low`/`freq_high` fields of `LayoutSpeakerPatch` and `LayoutAddSpeakerPatch`:

- absent → `None` (untouched, via `default` — the helper isn't called)
- `null` → `Some(None)` (clear)
- value → `Some(Some(v))` (set)

The replace/add-speaker paths are unaffected (a freshly built speaker defaults freq to `None` regardless); the per-speaker **edit** path can now blank a cutoff. This only changes how the cutoff value is *transported* — it does not alter how/where crossovers are applied.

## Test

New `freq_cutoff_clear_tests` in `runtime_control::osc`:
- `double_option` distinguishes absent / `null` / value.
- An explicit `null` blanks an existing cutoff via `apply_layout_speaker_patch`, leaving unrelated fields untouched.
- An absent cutoff field leaves the value untouched.

`cargo test -p runtime_control` green; `cargo fmt --check -p runtime_control` clean; cdylib + CLI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)