### PR TITLE
docs: demo-first, runnable QUICKSTART + renderer README

### DIFF
--- a/omniphony-renderer/QUICKSTART.md
+++ b/omniphony-renderer/QUICKSTART.md
@@ -1,8 +1,30 @@
 # Quickstart
 
-This file gives the shortest path to a working `omniphony-renderer` setup.
+The shortest path to *hearing* `omniphony-renderer` work — then to running it on
+your own input.
 
-## 1. Build
+## 1. Hear the demo (one command)
+
+From a fresh checkout, with no audio file to find and no decoder to install:
+
+```bash
+cd omniphony-renderer
+./scripts/demo.sh            # builds the engine + reference bridge, then plays the demo
+```
+
+This binaurally renders `assets/demo/spatial-demo.wav` — a source sweeping around
+you with an overhead tone — straight to your headphones, with no media player and
+no proprietary decoder. Other modes:
+
+```bash
+./scripts/demo.sh speakers   # 7.1.4 speaker render instead of binaural
+./scripts/demo.sh file       # no audio device? pipe raw float to ffplay
+```
+
+Everything below explains what that script does and how to run the engine on your
+own input. The commands assume you are in `omniphony-renderer/`.
+
+## 2. Build
 
 Minimal build:
 
@@ -23,11 +45,9 @@ export SAF_ROOT="/path/to/Spatial_Audio_Framework"
 cargo build --release --features saf_vbap
 ```
 
-`saf_vbap` enables runtime
-VBAP generation via
+`saf_vbap` enables runtime VBAP generation via
 [`Spatial_Audio_Framework` (SAF)](https://github.com/leomccormack/Spatial_Audio_Framework),
-not the separate
-[`SPARTA`](https://leomccormack.github.io/sparta-site/) plug-in suite.
+not the separate [`SPARTA`](https://leomccormack.github.io/sparta-site/) plug-in suite.
 
 Windows with ASIO:
 
@@ -35,103 +55,115 @@ Windows with ASIO:
 cargo build --release --features asio
 ```
 
-## 2. Prepare a Bridge Plugin
+## 3. The bridge model
 
-`orender` requires a bridge plugin.
+`orender` does not decode formats in the binary itself: it loads a **bridge
+plugin** at runtime that turns your input into PCM + object metadata. Bridge
+lookup order:
 
-You can provide it explicitly:
+1. `--bridge-path <FILE>`
+2. `render.bridge_path` in the config file
+3. the first `lib*_bridge.{so,dll,dylib}` next to the executable
 
-```bash
-./target/release/orender input.bin \
-  --bridge-path ./libformat_bridge.so
-```
+The repo ships a **reference bridge** (`reference_bridge/`) that reads a plain
+multichannel WAV — it is what the demo uses, and the smallest example for writing
+your own (see [BRIDGE_API.md](BRIDGE_API.md)). The release build produces
+`target/release/libreference_bridge.so`. For other formats, point `--bridge-path`
+at the matching bridge instead (e.g. a separately-packaged decoder bridge).
 
-Or place a matching bridge next to the executable:
+## 4. Decode a file
 
-- `lib*_bridge.so`
-- `lib*_bridge.dll`
-- `lib*_bridge.dylib`
-
-## 3. Realtime Decode
-
-Use the default runtime path:
-
-```bash
-./target/release/orender input.bin \
-  --bridge-path ./libformat_bridge.so
-```
-
-Read from stdin:
+Render the demo clip explicitly (this is what `demo.sh speakers` runs):
 
 ```bash
-cat input.bin | ./target/release/orender - \
-  --bridge-path ./libformat_bridge.so
-```
-
-## 4. Enable VBAP
-
-Use a standard speaker layout:
-
-```bash
-./target/release/orender input.bin \
-  --bridge-path ./libformat_bridge.so \
+./target/release/orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
   --enable-vbap \
   --speaker-layout ../layouts/7.1.4.yaml
 ```
 
-Or precompute a VBAP table:
+Read from stdin instead of a file:
+
+```bash
+cat assets/demo/spatial-demo.wav | ./target/release/orender - \
+  --bridge-path target/release/libreference_bridge.so \
+  --enable-vbap --speaker-layout ../layouts/7.1.4.yaml
+```
+
+Swap in your own WAV (or your own input + bridge) the same way.
+
+## 5. Binaural headphones
+
+Add a config that enables the binaural stage (the demo ships one,
+`assets/demo/demo.yaml`):
+
+```bash
+./target/release/orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
+  --enable-vbap --speaker-layout ../layouts/7.1.4.yaml \
+  --config assets/demo/demo.yaml \
+  --output-backend pipewire
+```
+
+See [BINAURAL.md](BINAURAL.md) for HRTF/SOFA, externalization and live head tracking.
+
+## 6. Precompute a VBAP table
 
 ```bash
 ./target/release/orender generate-vbap \
   --speaker-layout ../layouts/7.1.4.yaml \
   --output 7.1.4.vbap \
-  --az-res 2 \
-  --el-res 2 \
-  --spread-res 0.25
+  --az-res 2 --el-res 2 --spread-res 0.25
 ```
 
-Then reuse it:
+Then reuse it instead of generating at startup:
 
 ```bash
-./target/release/orender input.bin \
-  --bridge-path ./libformat_bridge.so \
-  --enable-vbap \
-  --vbap-table ./7.1.4.vbap
+./target/release/orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
+  --enable-vbap --vbap-table ./7.1.4.vbap
 ```
 
-## 5. Enable OSC
-
-Send metadata to a local OSC client:
+## 7. OSC (metadata + Studio)
 
 ```bash
-./target/release/orender input.bin \
-  --bridge-path ./libformat_bridge.so \
-  --osc \
-  --osc-host 127.0.0.1 \
-  --osc-port 9000
+./target/release/orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
+  --osc --osc-host 127.0.0.1 --osc-port 9000
 ```
 
 See [OSC_PROTOCOL.md](OSC_PROTOCOL.md) for the full message surface.
 
-## 6. Realtime Output
+## 8. Realtime (and file) output
 
 Linux / PipeWire:
 
 ```bash
-./target/release/orender input.bin \
-  --bridge-path ./libformat_bridge.so \
-  --output-backend pipewire \
-  --output-device omniphony_router
+./target/release/orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
+  --enable-vbap --speaker-layout ../layouts/7.1.4.yaml \
+  --output-backend pipewire --output-device omniphony_router
+```
+
+Write to a file or pipe instead of a device (non-realtime):
+
+```bash
+./target/release/orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
+  --enable-vbap --speaker-layout ../layouts/7.1.4.yaml \
+  --output-backend file --output-file out.f32 --output-file-format raw-f32
 ```
 
 Windows / ASIO:
 
 ```powershell
 .\target\release\orender.exe list-asio-devices
-.\target\release\orender.exe input.bin --output-backend asio --output-device "Your ASIO Device"
+.\target\release\orender.exe assets\demo\spatial-demo.wav `
+  --bridge-path target\release\reference_bridge.dll `
+  --output-backend asio --output-device "Your ASIO Device"
 ```
 
-## 7. Configuration File
+## 9. Configuration file
 
 Default config path:
 
@@ -141,17 +173,18 @@ Default config path:
 Save the current effective configuration:
 
 ```bash
-./target/release/orender --config ./config.yaml --save-config input.bin \
-  --bridge-path ./libformat_bridge.so \
-  --enable-vbap \
-  --speaker-layout ../layouts/7.1.4.yaml \
-  --osc
+./target/release/orender --config ./config.yaml --save-config \
+  assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
+  --enable-vbap --speaker-layout ../layouts/7.1.4.yaml --osc
 ```
 
-## 8. Next References
+## Next references
 
 - [README.md](README.md)
 - [BUILD.md](BUILD.md)
 - [BUILDING_WINDOWS.md](BUILDING_WINDOWS.md)
+- [BINAURAL.md](BINAURAL.md)
 - [OSC_PROTOCOL.md](OSC_PROTOCOL.md)
+- [BRIDGE_API.md](BRIDGE_API.md)
 - [../layouts/README.md](../layouts/README.md)

--- a/omniphony-renderer/README.md
+++ b/omniphony-renderer/README.md
@@ -19,6 +19,7 @@ The repository also contains the supporting runtime stack:
 - `audio_output`: PipeWire and ASIO backends
 - `spdif`: IEC61937 / S/PDIF parsing helpers
 - `bridge_api`: ABI-stable interface for external bridge plugins
+- `reference_bridge`: a reference WAV/PCM bridge that powers the bundled demo
 - `sys`: platform integration, including Windows service support
 
 ## Status
@@ -69,6 +70,11 @@ Bridge lookup order:
 
 Without a bridge plugin, `orender` will not start.
 
+The repo ships a **reference bridge** (`reference_bridge/`, built as
+`libreference_bridge.so`) that reads a plain multichannel WAV. It powers the
+one-command demo — `./scripts/demo.sh`, see [QUICKSTART.md](QUICKSTART.md) — and is
+the smallest example for writing your own bridge ([BRIDGE_API.md](BRIDGE_API.md)).
+
 ## Commands
 
 `orender` currently exposes these commands:
@@ -85,18 +91,22 @@ orender --help
 
 ## Typical Usage
 
+The quickest check is `./scripts/demo.sh` (see [QUICKSTART.md](QUICKSTART.md)).
+The examples below use the bundled demo clip + the reference bridge so each one is
+runnable as-is; swap in your own input and bridge the same way.
+
 ```bash
 # Decode from stdin
-cat input.bin | orender - --bridge-path ./libformat_bridge.so
+cat assets/demo/spatial-demo.wav | orender - --bridge-path target/release/libreference_bridge.so
 
 # Linux realtime output via PipeWire
-orender input.bin \
-  --bridge-path ./libformat_bridge.so \
+orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
   --output-backend pipewire
 
 # Enable VBAP rendering and OSC output
-orender input.bin \
-  --bridge-path ./libformat_bridge.so \
+orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
   --enable-vbap \
   --speaker-layout ../layouts/7.1.4.yaml \
   --osc \
@@ -104,8 +114,8 @@ orender input.bin \
   --osc-port 9000
 
 # Select a non-VBAP render backend and its parameters (CLI parity with Studio/OSC)
-orender input.bin \
-  --bridge-path ./libformat_bridge.so \
+orender assets/demo/spatial-demo.wav \
+  --bridge-path target/release/libreference_bridge.so \
   --enable-vbap \
   --render-backend hybrid \
   --hybrid-external-backend vbap --hybrid-internal-backend barycenter \


### PR DESCRIPTION
Follow-up to #134/#135. Aligns the engine docs with the now-shipping reference bridge + demo:

- **QUICKSTART** leads with the one-command `./scripts/demo.sh` payoff, then explains the bridge model using the in-tree `reference_bridge`. Every example uses `assets/demo/spatial-demo.wav` + `libreference_bridge.so`, so it runs on a fresh clone — no more opaque `input.bin` / `libformat_bridge.so`.
- **`omniphony-renderer/README.md`**: adds `reference_bridge` to the stack, notes the demo in the runtime model, and makes the Typical Usage examples runnable.

Docs-only. Generic terminology throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)