### PR TITLE
docs(readme): download buttons under the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 multichannel and object audio and renders it — with VBAP — to any speaker layout
 or to **binaural headphones**, in real time. Open source, GPL-3.0.
 
+[![Download Omniphony](https://img.shields.io/badge/Download-Omniphony-2ea44f?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/latest)
+[![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-2)
+[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-fel-beta.5)
+
 ![Omniphony Studio rendering a spatial mix](Omniphony_capture.png)
 
 - 🎧 **Hear it on headphones** — binaural output (HRTF + ITD + live head-tracking),


### PR DESCRIPTION
Adds a row of badge-style download buttons between the intro paragraph and the hero image:

- **Download Omniphony** → `releases/latest` (Studio bundle; auto-updates)
- **Download mpv-omniphony** → `mpv-v0.4.1-2`
- **Download mpv-omniphony FEL** → `mpv-v0.4.1-fel-beta.5`

All point at the engine repo's download hub. (The two player links are pinned tags — they'll need bumping on new `mpv-v*` releases, unless we automate it from the relocation workflow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)