### PR TITLE
Switch donations from PayPal to GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Enables GitHub's native "Sponsor" button at the top of the repository.
+github: mgth

--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ via `dlopen` and may be licensed separately.
 If Omniphony is useful to you, you can support development with a donation — it
 helps maintain and improve the suite.
 
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=YLGYPSHWTQ5UW&lc=FR&item_name=Omniphony%C2%A4cy_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-mgth-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/mgth)

--- a/docs/mpv-omniphony.md
+++ b/docs/mpv-omniphony.md
@@ -201,4 +201,4 @@ for a ready-to-copy set of bindings.
 If Omniphony is useful to you, you can support development with a donation — it
 helps maintain and improve the suite.
 
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=YLGYPSHWTQ5UW&lc=FR&item_name=Omniphony%C2%A4cy_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-mgth-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/mgth)


### PR DESCRIPTION
PayPal closed donations for individual accounts, so the existing PayPal donate badge no longer works.

- Replace the PayPal donate badge in `README.md` and `docs/mpv-omniphony.md` with a GitHub Sponsors badge linking to https://github.com/sponsors/mgth
- Add `.github/FUNDING.yml` (`github: mgth`) to enable GitHub's native "Sponsor" button at the top of the repository

The native Sponsor button only appears once `FUNDING.yml` is on the default branch, so this lands it on `main` directly (independent of the in-progress `feat/website` work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)