### PR TITLE
Add Ko-fi and Liberapay alongside GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,4 @@
 # Enables GitHub's native "Sponsor" button at the top of the repository.
 github: mgth
+ko_fi: G5X022D1RW
+liberapay: mgth

--- a/README.md
+++ b/README.md
@@ -108,3 +108,5 @@ If Omniphony is useful to you, you can support development with a donation — i
 helps maintain and improve the suite.
 
 [![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-mgth-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/mgth)
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/G5X022D1RW)
+[![Donate using Liberapay](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/mgth/donate)

--- a/docs/mpv-omniphony.md
+++ b/docs/mpv-omniphony.md
@@ -202,3 +202,5 @@ If Omniphony is useful to you, you can support development with a donation — i
 helps maintain and improve the suite.
 
 [![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-mgth-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/mgth)
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/G5X022D1RW)
+[![Donate using Liberapay](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/mgth/donate)


### PR DESCRIPTION
Follow-up to the GitHub Sponsors switch: offer multiple funding options instead of GitHub Sponsors alone.

- Add Ko-fi and Liberapay badges after the GitHub Sponsors badge in `README.md` and `docs/mpv-omniphony.md` (order: GitHub Sponsors → Ko-fi → Liberapay)
- Extend `.github/FUNDING.yml` with `ko_fi` and `liberapay` so the native repository Sponsor button lists all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)