### PR TITLE
docs(readme): point the FEL download button at beta.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ or to **binaural headphones**, in real time. Open source, GPL-3.0.
 
 [![Download Omniphony Studio](https://img.shields.io/badge/Download-Omniphony-2ea44f?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/latest)
 [![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-2)
-[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-fel-beta.5)
+[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-fel-beta.6)
 
 ![Omniphony Studio rendering a spatial mix](Omniphony_capture.png)
 


### PR DESCRIPTION
The **mpv-omniphony FEL** download button under the intro still linked the superseded `mpv-v0.4.1-fel-beta.5`. Bump it to [`mpv-v0.4.1-fel-beta.6`](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-fel-beta.6) — the de-fork build (mpv + libplacebo + ffmpeg upstream master) now published on this repo's releases.

One-line link change; no other README content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)