### PR TITLE
docs(readme): promote the omniphony.mgth.fr website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 multichannel and object audio and renders it — with VBAP — to any speaker layout
 or to **binaural headphones**, in real time. Open source, GPL-3.0.
 
+### 🌐 Website &amp; docs → **[omniphony.mgth.fr](https://omniphony.mgth.fr)**
+
+[![Website & Docs — omniphony.mgth.fr](https://img.shields.io/badge/Website%20%26%20Docs-omniphony.mgth.fr-56c9ff?style=for-the-badge&logo=astro&logoColor=white)](https://omniphony.mgth.fr)
 [![Download Omniphony Studio](https://img.shields.io/badge/Download-Omniphony-2ea44f?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/latest)
 [![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-2)
 [![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-fel-beta.6)


### PR DESCRIPTION
Promotes the new public site at the top of the README, alongside the existing download badges.

- Adds a **🌐 Website & docs** callout right under the tagline.
- Adds a cyan **Website & Docs** shields badge leading the action row (before the download badges), linking to https://omniphony.mgth.fr.

The site hosts the downloads, the getting-started/Studio/speaker-layout/binaural/playback guides, the OSC protocol reference, and the custom-backends (Lua + native) guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)