### PR TITLE
Clip detection and auto-gain in binaural mode

### DIFF
--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -680,10 +680,57 @@ impl SpatialRenderer {
             };
             let gain_l = total_gain * ear(0);
             let gain_r = total_gain * ear(1);
-            if (gain_l - 1.0).abs() > f32::EPSILON || (gain_r - 1.0).abs() > f32::EPSILON {
-                for frame in output.chunks_exact_mut(2) {
-                    frame[0] *= gain_l;
-                    frame[1] *= gain_r;
+            // Apply the ear gains and track the output peak in the same pass
+            // (a whole immersive stream summed onto two channels exceeds full
+            // scale easily, so the stereo bus needs the same overload
+            // handling as the speaker path).
+            let mut peak_sample: f32 = 0.0;
+            let mut peak_ear: usize = 0;
+            for frame in output.chunks_exact_mut(2) {
+                frame[0] *= gain_l;
+                frame[1] *= gain_r;
+                let a_l = frame[0].abs();
+                if a_l > peak_sample {
+                    peak_sample = a_l;
+                    peak_ear = 0;
+                }
+                let a_r = frame[1].abs();
+                if a_r > peak_sample {
+                    peak_sample = a_r;
+                    peak_ear = 1;
+                }
+            }
+
+            // Clipping handling — same policy as the speaker path below:
+            // detection always at 0 dBFS so the UI indicators work with
+            // auto-gain off; the correction (when enabled) folds into the
+            // shared master gain, targeting the configured ceiling. The ear
+            // index reuses the first two speaker param slots, the same slots
+            // Studio's headphone L/R rows already ride for mute/gain.
+            if peak_sample > 1.0 {
+                self.control.note_clip(peak_ear);
+                if live.auto_gain {
+                    let ceiling = 10.0_f32.powf(live.auto_gain_ceiling_db / 20.0);
+                    let required_gain = ceiling / peak_sample;
+                    // Re-reading under the write lock preserves any
+                    // concurrent OSC master change.
+                    let new_master_gain = {
+                        let mut params = self.control.live.write();
+                        params.master_gain *= required_gain;
+                        params.master_gain
+                    };
+                    self.control.mark_dirty();
+                    self.control.bump_live_state();
+                    self.auto_gain_triggered
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                    log::warn!(
+                        "Clipping detected on headphone {} (peak={:.3})! Master gain reduced to {:.4} ({:.1} dB), ceiling {:.1} dBFS",
+                        if peak_ear == 0 { "L" } else { "R" },
+                        peak_sample,
+                        new_master_gain,
+                        20.0 * new_master_gain.log10(),
+                        live.auto_gain_ceiling_db
+                    );
                 }
             }
             return Ok(RenderedFrame {

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -1150,5 +1150,107 @@ fn binaural_ear_mute_uses_first_speaker_slots() {
     assert!(e_r > 1e-6, "right ear should still play: {e_r}");
 }
 
+/// Binaural mode must carry the speaker path's overload policy (issue #149):
+/// the clip flag always fires above 0 dBFS (with the ear in the first two
+/// speaker slots, the same slots the headphone L/R rows ride), and auto-gain
+/// folds the correction into the shared master gain.
+#[test]
+fn binaural_clipping_flags_ear_and_auto_gain_reduces_master() {
+    fn build() -> SpatialRenderer {
+        let layout = SpeakerLayout::preset("7.1.4").unwrap();
+        SpatialRenderer::new(
+            layout,
+            48_000,
+            1,
+            1,
+            0.0,
+            2.0,
+            VbapTableMode::Cartesian {
+                x_size: 21,
+                y_size: 21,
+                z_size: 9,
+                z_neg_size: 9,
+            },
+            false,
+            true,
+            DistanceModel::Linear,
+            false,
+            1.0,
+            1.0,
+            0.0,
+            1.0,
+            false,
+            [1.0, 2.0, 0.5],
+            2.0,
+            0.5,
+            0.0,
+            0.0,
+            false,
+            false,
+            false,
+            1.0,
+            1.0,
+            PreferredEvaluationMode::PrecomputedCartesian,
+            LiveEvaluationMode::PrecomputedCartesian,
+            21,
+            21,
+            9,
+            9,
+        )
+        .unwrap()
+    }
+
+    let pcm: Vec<f32> = (0..40).map(|i| (i * 7 % 13) as f32 / 13.0 - 0.5).collect();
+    let event = vec![SpatialChannelEvent {
+        channel_idx: 0,
+        is_bed: false,
+        gain_db: Some(0),
+        ramp_length: Some(40),
+        size: Some([0.0, 0.0, 0.0]),
+        position: Some([0.5, 1.0, 0.0]),
+        sample_pos: Some(0),
+    }];
+
+    let render = |auto_gain: bool| -> SpatialRenderer {
+        let mut r = build();
+        {
+            let mut live = r.control.live.write();
+            live.binaural.output_mode = crate::live_params::OutputMode::Binaural;
+            // Hot enough that the HRIR-summed stereo bus exceeds 0 dBFS.
+            live.master_gain = 16.0;
+            live.auto_gain = auto_gain;
+        }
+        for i in 0..4 {
+            let ev: &[SpatialChannelEvent] = if i == 0 { &event } else { &[] };
+            r.render_frame(&pcm, 1, ev, Vec::new(), false).unwrap();
+        }
+        r
+    };
+
+    // Auto-gain off: the flag must still fire (UI indicators), the master
+    // gain must stay untouched.
+    let r = render(false);
+    let clip = r.control.take_clip_pending();
+    assert!(
+        matches!(clip, Some(0) | Some(1)),
+        "clip flag not raised for an ear slot: {clip:?}"
+    );
+    assert!(!r.auto_gain_triggered(), "auto-gain fired while disabled");
+    assert_eq!(r.control.live.read().master_gain, 16.0);
+
+    // Auto-gain on: correction folded into the master gain, trigger visible.
+    let r = render(true);
+    assert!(
+        matches!(r.control.take_clip_pending(), Some(0) | Some(1)),
+        "clip flag not raised with auto-gain on"
+    );
+    assert!(r.auto_gain_triggered(), "auto-gain did not trigger");
+    let master = r.control.live.read().master_gain;
+    assert!(
+        master < 16.0,
+        "master gain not reduced by auto-gain: {master}"
+    );
+}
+
 // TODO: Add integration test with real spatial metadata
 // For now, testing is done via real spatial audio content decoding


### PR DESCRIPTION
## Problem

Issue #149: all overload handling (peak detection, `note_clip` for Studio's indicators, auto-gain) lives in the speaker path, after the binaural branch's early return. In headphone mode a 12–16 channel stream HRIR-summed onto two channels can exceed full scale with no flag, no log, and a silently inert `render.auto_gain`. Measured on an 11-channel correlated-noise stressor: output peak 2.50 (+8 dBFS), 7.9 % of samples beyond 0 dBFS.

## Fix

The binaural branch now applies the exact policy of the speaker path on its stereo bus:

- **Peak tracking** folded into the ear-gain pass (the always-run multiply replaces the previous skip-at-unity shortcut — two multiplies per frame are noise next to the per-object convolutions).
- **`note_clip(ear)`** always fires above 0 dBFS, with the ear index in the first two speaker param slots — the same slots Studio's headphone L/R rows already ride for mute/gain, so the existing indicators light up.
- **Auto-gain** (when enabled) folds the correction into the shared master gain targeting the configured ceiling, with the same locking discipline (write lock only on clipping frames) and the same warn log.

## Test

`binaural_clipping_flags_ear_and_auto_gain_reduces_master`: with auto-gain off the flag fires and the master gain stays put; with it on, `auto_gain_triggered()` is visible and the master gain comes down. Full suite: 181 passed.

Part of the binaural-chain audit (#145, #149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)