### PR TITLE
Route LFE beds direct in binaural mode

### DIFF
--- a/omniphony-renderer/BINAURAL.md
+++ b/omniphony-renderer/BINAURAL.md
@@ -20,6 +20,14 @@ position → rotate(head pose) → (azimuth, elevation, distance)
 Measured cost: ~0.09 ms per 40-sample block for a 16-channel Atmos stream
 (~11 % of the realtime budget), reflections included.
 
+One exception: a bed mapped to a **`spatialize: false` speaker** (the LFE)
+keeps its direct-routing intent. Sub-bass carries no usable direction, so the
+channel skips the whole pipeline above and feeds **both ears equally at
+constant power** (−3 dB each), dry and full-range — no HRIR, no ITD, no
+reverb send, and head rotation has no effect on it. Level is unity overall
+(no +10 dB LFE convention), matching the speaker path's untouched one-hot
+routing.
+
 ## Enabling it
 
 Set the output mode in `~/.config/omniphony/config.yaml`:

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -385,6 +385,10 @@ impl BinauralRenderer {
     ///
     /// - `chan_pos[c]`: world (ADM) position of input channel `c`.
     /// - `chan_gain[c]`: linear gain for channel `c` (object mute/gain folded in).
+    /// - `chan_direct[c]`: `true` for channels that keep their direct-routing
+    ///   intent (beds mapped to a `spatialize: false` speaker — the LFE): fed
+    ///   to both ears equally, bypassing HRIR/ITD/air/reflections/reverb.
+    ///   Missing entries read as `false`.
     /// - `out`: must be `sample_length * 2`, pre-zeroed.
     #[allow(clippy::too_many_arguments)]
     pub fn render_frame(
@@ -395,6 +399,7 @@ impl BinauralRenderer {
         params: &BinauralFrameParams,
         chan_pos: &[[f64; 3]],
         chan_gain: &[f32],
+        chan_direct: &[bool],
         out: &mut [f32],
     ) {
         let BinauralFrameParams {
@@ -434,6 +439,30 @@ impl BinauralRenderer {
                     if let Some(bank) = dsp.refl.as_mut() {
                         bank.mute_targets();
                     }
+                }
+                continue;
+            }
+            // Direct (non-spatialized) feed — the LFE policy (issue #156):
+            // sub-bass carries no usable direction, so the channel goes to
+            // both ears at constant power (−3 dB each), dry and full-range —
+            // no HRIR, no ITD, no air, no reflections, no reverb send. Unity
+            // overall (no +10 dB LFE convention), matching the speaker path's
+            // untouched one-hot routing. Head rotation deliberately has no
+            // effect, like real sub-bass.
+            if chan_direct.get(c).copied().unwrap_or(false) {
+                if let Some(Some(dsp)) = self.channels.get_mut(c) {
+                    // Drop a stale reflection bank if the channel just
+                    // switched from the spatialized path (same policy as the
+                    // reflections-disabled branch below).
+                    dsp.refl = None;
+                }
+                for s in 0..sample_length {
+                    let v = input_pcm[s * input_channel_count + c]
+                        * gain
+                        * std::f32::consts::FRAC_1_SQRT_2;
+                    let o = s * 2;
+                    out[o] += v;
+                    out[o + 1] += v;
                 }
                 continue;
             }
@@ -597,7 +626,7 @@ mod tests {
         let mut input = vec![0.0f32; n];
         input[0] = 1.0;
         let mut out = vec![0.0f32; n * 2];
-        r.render_frame(&input, 1, n, &dry_params(), &[pos], &[1.0], &mut out);
+        r.render_frame(&input, 1, n, &dry_params(), &[pos], &[1.0], &[], &mut out);
         let mut el = 0.0f32;
         let mut er = 0.0f32;
         for s in 0..n {
@@ -625,7 +654,7 @@ mod tests {
         let pos = [[0.5, 1.0, 0.0]];
         let render = |r: &mut BinauralRenderer| -> f32 {
             let mut out = vec![0.0f32; n * 2];
-            r.render_frame(&input, 1, n, &dry_params(), &pos, &[1.0], &mut out);
+            r.render_frame(&input, 1, n, &dry_params(), &pos, &[1.0], &[], &mut out);
             out.iter().map(|x| x * x).sum()
         };
 
@@ -676,7 +705,7 @@ mod tests {
 
         let mut dry = vec![0.0f32; n * 2];
         let mut r = BinauralRenderer::new(48_000);
-        r.render_frame(&input, 1, n, &dry_params(), &pos, &[1.0], &mut dry);
+        r.render_frame(&input, 1, n, &dry_params(), &pos, &[1.0], &[], &mut dry);
 
         let wet_params = BinauralFrameParams {
             reflections: BinauralReflections {
@@ -688,7 +717,7 @@ mod tests {
         };
         let mut wet = vec![0.0f32; n * 2];
         let mut r = BinauralRenderer::new(48_000);
-        r.render_frame(&input, 1, n, &wet_params, &pos, &[1.0], &mut wet);
+        r.render_frame(&input, 1, n, &wet_params, &pos, &[1.0], &[], &mut wet);
 
         assert!(tail(&dry) < 1e-9, "dry render must have no late energy");
         assert!(
@@ -709,7 +738,7 @@ mod tests {
 
         let mut dry = vec![0.0f32; n * 2];
         let mut r = BinauralRenderer::new(48_000);
-        r.render_frame(&input, 1, n, &dry_params(), &pos, &[1.0], &mut dry);
+        r.render_frame(&input, 1, n, &dry_params(), &pos, &[1.0], &[], &mut dry);
         assert!(tail(&dry) < 1e-9, "dry render must have no tail");
 
         let wet_params = BinauralFrameParams {
@@ -723,7 +752,7 @@ mod tests {
         };
         let mut wet = vec![0.0f32; n * 2];
         let mut r = BinauralRenderer::new(48_000);
-        r.render_frame(&input, 1, n, &wet_params, &pos, &[1.0], &mut wet);
+        r.render_frame(&input, 1, n, &wet_params, &pos, &[1.0], &[], &mut wet);
         assert!(tail(&wet) > 1e-7, "no reverb tail: {}", tail(&wet));
     }
 
@@ -742,7 +771,16 @@ mod tests {
             };
             let mut out = vec![0.0f32; n * 2];
             let mut r = BinauralRenderer::new(48_000);
-            r.render_frame(&input, 1, n, &params, &[[0.0, dist, 0.0]], &[1.0], &mut out);
+            r.render_frame(
+                &input,
+                1,
+                n,
+                &params,
+                &[[0.0, dist, 0.0]],
+                &[1.0],
+                &[],
+                &mut out,
+            );
             // Direct path no longer applies a 1/d gain, so the broadband level is
             // distance-independent; the only near/far difference is the
             // air-absorption HF roll-off under test.
@@ -787,6 +825,7 @@ mod tests {
             &dry_params(),
             &[[1.0, 0.0, 0.0]],
             &[0.0],
+            &[],
             &mut out,
         );
         assert!(out.iter().all(|&x| x == 0.0));

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -602,6 +602,7 @@ impl SpatialRenderer {
             binaural: crate::binaural::BinauralRenderer::new(sample_rate),
             binaural_pos_buf: Vec::new(),
             binaural_gain_buf: Vec::new(),
+            binaural_direct_buf: Vec::new(),
             render_bands,
             unified_table,
             render_bands_topology_identity: topology_identity,

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -184,6 +184,11 @@ pub struct SpatialRenderer {
     /// Scratch per-channel gains for the binaural path (reused).
     binaural_gain_buf: Vec<f32>,
 
+    /// Scratch per-channel "direct" flags for the binaural path (reused):
+    /// beds mapped to a `spatialize: false` speaker (the LFE) feed both ears
+    /// equally instead of being HRTF-spatialized.
+    binaural_direct_buf: Vec<bool>,
+
     /// Per-band VBAP engines.  Always has at least one entry (the "all speakers" band when
     /// no crossover is configured).  Each engine returns full-size `Gains` (`num_speakers`).
     render_bands: Vec<BandRenderer>,
@@ -584,6 +589,8 @@ impl SpatialRenderer {
                 .resize(input_channel_count, [0.0, 1.0, 0.0]);
             self.binaural_gain_buf.clear();
             self.binaural_gain_buf.resize(input_channel_count, 0.0);
+            self.binaural_direct_buf.clear();
+            self.binaural_direct_buf.resize(input_channel_count, false);
             let num_beds = bed_indices.len();
             {
                 let mut states = self.channel_states.lock();
@@ -608,9 +615,13 @@ impl SpatialRenderer {
                     let routed_as_bed = c < num_beds && bed_indices[c] != usize::MAX;
                     if routed_as_bed {
                         // Bed channel: place it at its mapped speaker's direction.
+                        // A bed mapped to a non-spatialized speaker (the LFE)
+                        // keeps the direct-routing intent in headphone mode
+                        // too: fed to both ears equally, no HRTF (issue #156).
                         if let Some(&spk) = active_bed_to_speaker_mapping.get(&bed_indices[c]) {
                             if let Some(s) = active_layout.speakers.get(spk) {
                                 self.binaural_pos_buf[c] = [s.x as f64, s.y as f64, s.z as f64];
+                                self.binaural_direct_buf[c] = !s.spatialize;
                             }
                         }
                     } else if let Some(st) = states.get_mut(&c) {
@@ -657,6 +668,7 @@ impl SpatialRenderer {
                 &binaural_params,
                 &self.binaural_pos_buf,
                 &self.binaural_gain_buf,
+                &self.binaural_direct_buf,
                 &mut output,
             );
             // Output gain parity with the speaker path: master gain × dialnorm

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -1252,5 +1252,90 @@ fn binaural_clipping_flags_ear_and_auto_gain_reduces_master() {
     );
 }
 
+/// In binaural mode a bed mapped to a `spatialize: false` speaker (the LFE)
+/// keeps its direct-routing intent (issue #156): both ears receive the
+/// identical dry feed at constant power — no HRIR tail, no ITD, no head-pose
+/// effect — instead of being HRTF-spatialized at the sub's direction.
+#[test]
+fn binaural_lfe_bed_feeds_both_ears_equally_and_dry() {
+    let layout = SpeakerLayout::preset("7.1.4").unwrap();
+    let mut r = SpatialRenderer::new(
+        layout,
+        48_000,
+        1,
+        1,
+        0.0,
+        2.0,
+        VbapTableMode::Cartesian {
+            x_size: 21,
+            y_size: 21,
+            z_size: 9,
+            z_neg_size: 9,
+        },
+        false,
+        true,
+        DistanceModel::Linear,
+        false,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        false,
+        [1.0, 2.0, 0.5],
+        2.0,
+        0.5,
+        0.0,
+        0.0,
+        false,
+        false,
+        false,
+        1.0,
+        1.0,
+        PreferredEvaluationMode::PrecomputedCartesian,
+        LiveEvaluationMode::PrecomputedCartesian,
+        21,
+        21,
+        9,
+        9,
+    )
+    .unwrap();
+    // Channel 0 = bed id 3 → the LFE speaker (index 3, spatialize:false).
+    r.configure_beds(&[3usize]);
+    {
+        let mut live = r.control.live.write();
+        live.binaural.output_mode = crate::live_params::OutputMode::Binaural;
+    }
+
+    let n = 40;
+    let mut pcm = vec![0.0f32; n];
+    pcm[0] = 0.8; // impulse: any post-render tail would expose a convolver
+    let event = vec![SpatialChannelEvent {
+        channel_idx: 0,
+        is_bed: true,
+        gain_db: Some(0),
+        ramp_length: Some(0),
+        size: None,
+        position: None,
+        sample_pos: Some(0),
+    }];
+    let out = r
+        .render_frame(&pcm, 1, &event, Vec::new(), false)
+        .unwrap()
+        .samples;
+
+    assert_eq!(out.len(), n * 2);
+    let expected = 0.8 * std::f32::consts::FRAC_1_SQRT_2;
+    assert!(
+        (out[0] - expected).abs() < 1e-6,
+        "constant-power direct feed expected {expected}, got {}",
+        out[0]
+    );
+    assert_eq!(out[0], out[1], "both ears must carry the identical feed");
+    assert!(
+        out[2..].iter().all(|&x| x == 0.0),
+        "direct feed must not ring (no HRIR/ITD tail)"
+    );
+}
+
 // TODO: Add integration test with real spatial metadata
 // For now, testing is done via real spatial audio content decoding


### PR DESCRIPTION
## Problem

Issue #156: in headphone mode every input channel took the identical HRIR/ITD path, so a bed mapped to a `spatialize: false` speaker (the LFE) was HRTF-spatialized at the sub's direction — the direct-routing intent was silently ignored, sub-bass picked up a meaningless ITD and pinna colouring, and the low end moved with head rotation.

## Policy (now documented in BINAURAL.md)

Beds mapped to a non-spatialized speaker keep their direct intent: fed to **both ears equally at constant power** (−3 dB each), dry and full-range — no HRIR, no ITD, no air absorption, no reflections, no reverb send — and head rotation has no effect, like real sub-bass. Level stays unity overall (no +10 dB LFE convention), matching the speaker path's untouched one-hot routing.

## Implementation

- The binaural branch fills a per-channel `direct` flag from the bed-to-speaker mapping (`spatialize == false`), passed to `BinauralRenderer::render_frame` alongside positions and gains (missing entries read as `false`, so existing callers are unaffected in behaviour).
- Direct channels skip `ChannelDsp` entirely (no convolver/delay state) and drop a stale reflection bank if the speaker was flipped live from spatialized — same policy as the reflections-disabled branch.

## Test

`binaural_lfe_bed_feeds_both_ears_equally_and_dry` — an impulse on an LFE bed reaches both ears bit-identically at 1/√2 with no tail after the impulse frame (any HRIR/ITD leakage would ring). Full suite: 189 passed.

**Stacked on #159** (both touch the binaural render path); merge that one first — GitHub will retarget this PR to `main` automatically.

Closes the binaural-audit follow-up pair (#153, #156).

🤖 Generated with [Claude Code](https://claude.com/claude-code)