### PR TITLE
Crossfade HRIR kernels across blocks

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/convolver.rs
+++ b/omniphony-renderer/renderer/src/binaural/convolver.rs
@@ -2,9 +2,16 @@
 //!
 //! Length is fixed at [`HRIR_LEN`]. The input-history ring buffer persists
 //! across coefficient swaps, so updating the HRIR between frames (as the object
-//! or head moves) keeps the output continuous. Direct-form FIR is the simplest
-//! steady-state cost for short kernels; a partitioned-FFT path can replace this
-//! in M2/M3 if profiling on the object count demands it.
+//! or head moves) keeps the *state* continuous — and a kernel change is
+//! additionally crossfaded over a caller-chosen ramp
+//! ([`set_coeffs_smooth`](EarConvolver::set_coeffs_smooth)): the old and new
+//! kernels run over the same history and blend linearly, which is exactly
+//! equivalent to interpolating the coefficients per sample, so the transfer
+//! function moves without a block-boundary discontinuity (issue #155). The
+//! doubled dot product is paid only during fade samples of blocks whose kernel
+//! actually changed. Direct-form FIR is the simplest steady-state cost for
+//! short kernels; a partitioned-FFT path can replace this in M2/M3 if
+//! profiling on the object count demands it.
 
 use super::hrir::HRIR_LEN;
 
@@ -13,6 +20,10 @@ pub struct EarConvolver {
     hist: [f32; HRIR_LEN],
     pos: usize,
     coeffs: [f32; HRIR_LEN],
+    /// Fade-out kernel of a running crossfade (valid while `fade_pos < fade_len`).
+    prev_coeffs: [f32; HRIR_LEN],
+    fade_pos: u32,
+    fade_len: u32,
 }
 
 impl Default for EarConvolver {
@@ -27,26 +38,77 @@ impl EarConvolver {
             hist: [0.0; HRIR_LEN],
             pos: 0,
             coeffs: [0.0; HRIR_LEN],
+            prev_coeffs: [0.0; HRIR_LEN],
+            fade_pos: 0,
+            fade_len: 0,
         }
     }
 
-    /// Replace the FIR kernel. The history is untouched, so the response remains
-    /// continuous through the swap.
+    /// Replace the FIR kernel immediately (no crossfade). The history is
+    /// untouched, so the *state* remains continuous through the swap, but the
+    /// transfer function jumps — prefer [`set_coeffs_smooth`](Self::set_coeffs_smooth)
+    /// on live update paths.
     #[inline]
     pub fn set_coeffs(&mut self, coeffs: &[f32; HRIR_LEN]) {
         self.coeffs.copy_from_slice(coeffs);
+        self.fade_pos = 0;
+        self.fade_len = 0;
+    }
+
+    /// Replace the FIR kernel, crossfading from the current one over the next
+    /// `fade_len` processed samples. A no-op when the kernel is unchanged (a
+    /// static object under a static head — the common case — costs one array
+    /// compare and keeps the single dot product). Restarting mid-fade departs
+    /// from the currently *effective* (blended) kernel, so back-to-back
+    /// changes stay click-free too.
+    pub fn set_coeffs_smooth(&mut self, coeffs: &[f32; HRIR_LEN], fade_len: usize) {
+        if *coeffs == self.coeffs {
+            return;
+        }
+        if fade_len == 0 {
+            self.set_coeffs(coeffs);
+            return;
+        }
+        if self.fade_pos < self.fade_len {
+            // Freeze the running blend as the new fade-out kernel.
+            let w = self.fade_pos as f32 / self.fade_len as f32;
+            for i in 0..HRIR_LEN {
+                self.prev_coeffs[i] += (self.coeffs[i] - self.prev_coeffs[i]) * w;
+            }
+        } else {
+            self.prev_coeffs.copy_from_slice(&self.coeffs);
+        }
+        self.coeffs.copy_from_slice(coeffs);
+        self.fade_pos = 0;
+        self.fade_len = fade_len as u32;
     }
 
     /// Push one input sample and return the filtered output.
     #[inline]
     pub fn process(&mut self, x: f32) -> f32 {
         self.hist[self.pos] = x;
-        let mut acc = 0.0f32;
         let mut idx = self.pos;
-        for &c in self.coeffs.iter() {
-            acc += c * self.hist[idx];
-            idx = if idx == 0 { HRIR_LEN - 1 } else { idx - 1 };
-        }
+        let acc = if self.fade_pos < self.fade_len {
+            // Crossfade: both kernels over the shared history, linear blend.
+            self.fade_pos += 1;
+            let w = self.fade_pos as f32 / self.fade_len as f32;
+            let mut acc_new = 0.0f32;
+            let mut acc_old = 0.0f32;
+            for i in 0..HRIR_LEN {
+                let h = self.hist[idx];
+                acc_new += self.coeffs[i] * h;
+                acc_old += self.prev_coeffs[i] * h;
+                idx = if idx == 0 { HRIR_LEN - 1 } else { idx - 1 };
+            }
+            acc_old + (acc_new - acc_old) * w
+        } else {
+            let mut acc = 0.0f32;
+            for &c in self.coeffs.iter() {
+                acc += c * self.hist[idx];
+                idx = if idx == 0 { HRIR_LEN - 1 } else { idx - 1 };
+            }
+            acc
+        };
         self.pos = if self.pos + 1 == HRIR_LEN {
             0
         } else {
@@ -94,5 +156,82 @@ mod tests {
             y = c.process(1.0);
         }
         assert!((y - 0.75).abs() < 1e-6);
+    }
+
+    /// A kernel change must ramp the output linearly over the fade instead of
+    /// jumping at the swap (issue #155): DC through gain 1.0 → gain 0.5 with a
+    /// 16-sample fade steps down by exactly 1/32 per sample.
+    #[test]
+    fn kernel_swap_crossfades_linearly() {
+        let mut c = EarConvolver::new();
+        let mut a = [0.0; HRIR_LEN];
+        a[0] = 1.0;
+        c.set_coeffs(&a);
+        for _ in 0..HRIR_LEN {
+            c.process(1.0); // settle at 1.0
+        }
+        let mut b = [0.0; HRIR_LEN];
+        b[0] = 0.5;
+        const FADE: usize = 16;
+        c.set_coeffs_smooth(&b, FADE);
+        let mut prev = 1.0f32;
+        for i in 0..FADE {
+            let y = c.process(1.0);
+            let expected = 1.0 - 0.5 * (i + 1) as f32 / FADE as f32;
+            assert!(
+                (y - expected).abs() < 1e-6,
+                "sample {i}: got {y}, expected {expected}"
+            );
+            assert!(y < prev, "fade must be monotonic");
+            prev = y;
+        }
+        // Steady state on the new kernel afterwards.
+        assert!((c.process(1.0) - 0.5).abs() < 1e-6);
+    }
+
+    /// Re-setting the same kernel must not restart a fade or change output.
+    #[test]
+    fn unchanged_kernel_is_a_no_op() {
+        let mut c = EarConvolver::new();
+        let mut k = [0.0; HRIR_LEN];
+        k[0] = 1.0;
+        c.set_coeffs(&k);
+        for _ in 0..4 {
+            c.process(1.0);
+        }
+        c.set_coeffs_smooth(&k, 16);
+        assert_eq!(c.process(1.0), 1.0, "same kernel must stay transparent");
+    }
+
+    /// A second change mid-fade must depart from the blended kernel — the
+    /// output stays inside the envelope of the kernels involved, no jump back.
+    #[test]
+    fn midfade_restart_stays_continuous() {
+        let mut c = EarConvolver::new();
+        let mut a = [0.0; HRIR_LEN];
+        a[0] = 1.0;
+        c.set_coeffs(&a);
+        for _ in 0..HRIR_LEN {
+            c.process(1.0);
+        }
+        let mut b = [0.0; HRIR_LEN];
+        b[0] = 0.0; // fade toward silence
+        c.set_coeffs_smooth(&b, 16);
+        let mut y = 1.0;
+        for _ in 0..8 {
+            y = c.process(1.0); // half-way: ~0.5
+        }
+        assert!((y - 0.5).abs() < 1e-6);
+        // Change again mid-fade, back to gain 1.0: must ramp 0.5 → 1.0.
+        c.set_coeffs_smooth(&a, 16);
+        let first = c.process(1.0);
+        assert!(
+            (first - 0.5).abs() < 0.1,
+            "restart must depart from the blended kernel, got {first}"
+        );
+        for _ in 0..16 {
+            y = c.process(1.0);
+        }
+        assert!((y - 1.0).abs() < 1e-6, "must settle on the new kernel");
     }
 }

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -492,8 +492,12 @@ impl BinauralRenderer {
             let (itd_l, itd_r) = itd::ear_delays_seconds(az_rad, el_rad, head_radius_m);
 
             let dsp = self.channels[c].get_or_insert_with(|| ChannelDsp::new(self.sample_rate));
-            dsp.conv_l.set_coeffs(&self.hrir_scratch.left);
-            dsp.conv_r.set_coeffs(&self.hrir_scratch.right);
+            // Kernel changes (moving object / head) crossfade over the block
+            // — capped at HRIR_LEN samples for large offline blocks — so the
+            // transfer function never jumps at a block boundary (issue #155).
+            let fade = sample_length.min(HRIR_LEN);
+            dsp.conv_l.set_coeffs_smooth(&self.hrir_scratch.left, fade);
+            dsp.conv_r.set_coeffs_smooth(&self.hrir_scratch.right, fade);
             dsp.delay_l.set_target_ms(itd_l * 1000.0, self.sample_rate);
             dsp.delay_r.set_target_ms(itd_r * 1000.0, self.sample_rate);
 


### PR DESCRIPTION
## Problem

Issue #155: HRIR coefficients are recomputed per block and were hard-swapped into the convolvers. The shared history keeps the *state* continuous, but the transfer function jumps at every block boundary — spectral zipper / click risk on fast motion, head rotation, or teleports. No test exercised temporal continuity.

## Fix

`EarConvolver::set_coeffs_smooth(kernel, fade_len)`: on a change, the old and new kernels run over the **shared** input history and blend linearly across the fade (block length, capped at `HRIR_LEN`). Output-blending is mathematically identical to per-sample coefficient interpolation. Cost model:

- static object + static head (common case): one `[f32; 128]` compare, single dot product — unchanged;
- kernel changed: one extra dot product for the fade samples of that block only;
- mid-fade restart departs from the currently *effective* blended kernel, so back-to-back changes stay click-free.

The binaural render path now uses it for both ears; `set_coeffs` (hard swap) remains for initialisation.

## Tests

- `kernel_swap_crossfades_linearly` — DC probe steps by exactly 1/32 per sample over a 16-sample fade, monotonic, settles on the new kernel.
- `unchanged_kernel_is_a_no_op` — identical kernel keeps output bit-transparent.
- `midfade_restart_stays_continuous` — second change mid-fade continues from the blend.
- Full suite: 192 passed.

Backlog of the binaural audit (#154, #155, #157, #158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)