### PR TITLE
Harden the liborender C ABI and make Studio the engine distribution channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,18 @@ jobs:
         working-directory: omniphony-renderer
         run: cargo test --workspace
 
+      # ── C ABI smoke test (liborender) ──────────────────────────────────────
+      # Compile and run the header/link smoke test against the debug cdylib
+      # (debug builds skip the soname so the bare .so links directly). Guards
+      # the generated header, the exported symbols, and the version handshake —
+      # this is what mpv consumes, so it must never drift silently.
+      - name: C ABI smoke test (liborender)
+        working-directory: omniphony-renderer
+        run: |
+          cc -Wall -Werror -I orender_ffi/include orender_ffi/examples/smoke.c \
+             -L target/debug -lorender -o target/debug/orender_smoke
+          LD_LIBRARY_PATH=target/debug target/debug/orender_smoke
+
       # ── Studio frontend build (no Tauri bundling / no sidecar) ─────────────
       - name: Install Studio npm dependencies
         working-directory: omniphony-studio

--- a/.github/workflows/liborender-release.yml
+++ b/.github/workflows/liborender-release.yml
@@ -32,6 +32,19 @@ jobs:
             echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not on the 'release' branch. Cut release tags from 'release' (merge main->release, then tag)."
             exit 1
           fi
+      # liborender-v* tags name the crate version (see ABI.md's version table);
+      # a mismatched tag would publish artifacts whose orender_build_id()
+      # contradicts the release name.
+      - name: Tag must match the orender_ffi crate version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          crate_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' omniphony-renderer/orender_ffi/Cargo.toml | head -1)
+          tag_version="${GITHUB_REF_NAME#liborender-v}"
+          if [ "$crate_version" != "$tag_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match orender_ffi version $crate_version. Bump orender_ffi/Cargo.toml (and regenerate the header) before tagging."
+            exit 1
+          fi
+          echo "OK: tag matches orender_ffi $crate_version"
 
   build-linux:
     needs: guard

--- a/omniphony-renderer/ABI.md
+++ b/omniphony-renderer/ABI.md
@@ -1,0 +1,65 @@
+# liborender C ABI contract
+
+`orender_ffi` builds the engine's only stable C surface: `liborender.so.<major>`
+(Linux) / `orender.dll` (Windows) / `liborender.dylib` (macOS), described by the
+generated header `orender_ffi/include/orender.h`. Known consumers: mpv's
+`ad_orender.c` decoder + `orender_overlay.c` overlay client, and the smoke test
+`orender_ffi/examples/smoke.c`. The `orender` CLI does NOT use this ABI — it
+links the engine as a Rust crate.
+
+## Version numbers (who is who)
+
+| Number | Where | Meaning |
+|---|---|---|
+| ABI major (`ORENDER_ABI_MAJOR`) | `orender_ffi/src/lib.rs`, `#define` in header, `orender_version_major()` | Breaking-change counter. Linux soname `liborender.so.<major>` derives from it (build.rs). |
+| ABI minor (`ORENDER_ABI_MINOR`) | same | Additive-change counter. Logging/diagnostics only. |
+| Crate version (`orender_ffi/Cargo.toml`) | crate, `orender_build_id()`, `liborender-v*` release tags, Arch `pkgver` | Package/release identity. Moves faster than the ABI pair. |
+| Build fingerprint | `orender_build_id()`, `/omniphony/state/render/version` | git-describe + build time; identifies the exact build. |
+
+The ABI pair and the crate version have different lifecycles on purpose: a
+release with no header change bumps the crate version only.
+
+## Change policy
+
+- **Additive** (new exported function, new `orender_set_option` key, enum value
+  **appended**): bump `ORENDER_ABI_MINOR`. Existing consumers keep working
+  unchanged.
+- **Breaking** (changing/removing a symbol or its semantics, touching a struct
+  layout, reordering/removing enum values): bump `ORENDER_ABI_MAJOR`, reset
+  minor to 0. The Linux soname follows automatically; Windows/macOS file names
+  do not change — consumers there are protected only by the runtime check.
+
+**`OrenderConfig` is frozen at ABI major 0.** It crosses the boundary by layout
+with no size handshake. New knobs go through `orender_set_option` (post-create)
+or the config YAML (create-time), never through new struct fields.
+
+**`OrenderChannelLabel` is append-only** and must mirror
+`bridge_api::RChannelLabel` exactly — a unit test in `orender_ffi` asserts
+discriminant parity and breaks the build when `bridge_api` adds a variant.
+
+## Consumer contract
+
+At load time a consumer must:
+
+1. Resolve `orender_version_major`/`orender_version_minor` first; reject the
+   library if they are missing (pre-handshake build).
+2. Reject the library if `orender_version_major() != ORENDER_ABI_MAJOR` it was
+   compiled against.
+3. Gate optional features on **symbol presence** (`dlsym`), not on the minor.
+   The minor is for logs. This makes both skew directions degrade gracefully:
+   an older library just lacks the newer optional symbols; a newer library
+   keeps every old symbol working.
+4. Log `orender_build_id()` (when present) and the path the library was loaded
+   from.
+
+Probing an `orender_set_option` key: a return of `-1` means "this build does
+not know that key" — treat it as feature-unavailable, not as an error.
+
+## Bump checklist
+
+1. Edit `ORENDER_ABI_MINOR` (or `MAJOR`) in `orender_ffi/src/lib.rs` and extend
+   the changelog comment above it.
+2. `cargo build -p orender_ffi` — regenerates `include/orender.h`; commit it.
+3. If breaking: expect the soname to change; update packaging (`PKGBUILD`
+   symlinks) and warn mpv-omniphony (bundled lib name changes).
+4. `cargo test -p orender_ffi` + run `examples/smoke.c` (CI does both).

--- a/omniphony-renderer/orender_engine/src/degraded.rs
+++ b/omniphony-renderer/orender_engine/src/degraded.rs
@@ -47,13 +47,16 @@ pub struct DegradedReporter {
 
 /// Build and start the degraded reporter. `config_yaml_path` seeds the layout /
 /// room / OSC settings exactly as the real engine would, so Studio sees a
-/// coherent (if non-decoding) state alongside `bridge_error`. The returned value
-/// must be kept alive to keep the OSC server up.
+/// coherent (if non-decoding) state alongside `bridge_error`. `host_abi` is the
+/// FFI shim's C-ABI pair when the host is liborender (`None` for Rust-linked
+/// hosts), mirrored so About stays complete in the degraded state. The returned
+/// value must be kept alive to keep the OSC server up.
 pub fn start_degraded_reporter(
     config_yaml_path: Option<&Path>,
     sample_rate: u32,
     osc: OscOptions,
     bridge_error: String,
+    host_abi: Option<(u32, u32)>,
 ) -> Result<DegradedReporter> {
     let render_cfg = config_yaml_path
         .map(Config::load_or_default)
@@ -76,6 +79,9 @@ pub fn start_degraded_reporter(
 
     let control = renderer.renderer_control();
     control.set_bridge_error(Some(bridge_error));
+    if let Some((major, minor)) = host_abi {
+        control.set_host_abi(major, minor);
+    }
     // Mirror the real engine so About's config diagnostics stay meaningful.
     if let Some(path) = config_yaml_path {
         control.set_config_path(path.to_path_buf());

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -253,6 +253,14 @@ impl Engine {
             .set_object_generators_schema(self.object_gen.registry().listings_json());
     }
 
+    /// Record the hosting FFI shim's C-ABI version so the live-state snapshot
+    /// broadcasts it (`/omniphony/state/render/abi`, shown in Studio's About).
+    /// Called by liborender right after creation; hosts linking the engine as a
+    /// Rust crate never call it.
+    pub fn set_host_abi(&self, major: u32, minor: u32) {
+        self.renderer.renderer_control().set_host_abi(major, minor);
+    }
+
     /// Start the OSC live-control server, attaching the renderer control so
     /// incoming `/omniphony/control/*` messages adjust live params (gains, room,
     /// spread, …) — picked up by the next `render_frame` — and registered

--- a/omniphony-renderer/orender_ffi/Cargo.toml
+++ b/omniphony-renderer/orender_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orender_ffi"
-version = "0.2.3"
+version = "0.3.0"
 # Edition 2021 (not 2024) so cbindgen sees plain #[no_mangle] and unsafe fn
 # bodies stay implicitly unsafe — simpler for a thin C ABI shim.
 edition = "2021"
@@ -15,9 +15,16 @@ crate-type = ["cdylib"]
 
 [dependencies]
 orender_engine = { version = "0.2.2", path = "../orender_engine" }
+# For build_fingerprint() (orender_build_id): the git-describe stamp lives in
+# runtime_control, which both hosts already link — one source of truth.
+runtime_control = { version = "0.2.4", path = "../runtime_control" }
 anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"
+
+[dev-dependencies]
+# The OrenderChannelLabel ↔ RChannelLabel discriminant-parity unit test.
+bridge_api = { version = "0.2.0", path = "../bridge_api" }
 
 [features]
 # SOFA (personalised HRTF) support, on by default: liborender is the desktop

--- a/omniphony-renderer/orender_ffi/build.rs
+++ b/omniphony-renderer/orender_ffi/build.rs
@@ -1,6 +1,28 @@
-//! Generate the C header (include/orender.h) from the FFI surface via cbindgen.
+//! Generate the C header (include/orender.h) from the FFI surface via cbindgen,
+//! and stamp the shared library's platform version metadata (Linux soname).
 
 use std::path::PathBuf;
+
+/// Parse `pub const ORENDER_ABI_MAJOR: u32 = N;` out of src/lib.rs so the
+/// soname has a single source of truth: bumping the const IS the whole bump
+/// (`cargo:rerun-if-changed=src/lib.rs` keeps this in sync).
+fn abi_major(crate_dir: &str) -> u32 {
+    let lib = std::fs::read_to_string(PathBuf::from(crate_dir).join("src/lib.rs"))
+        .expect("src/lib.rs must be readable");
+    for line in lib.lines() {
+        if let Some(value) = line
+            .trim()
+            .strip_prefix("pub const ORENDER_ABI_MAJOR: u32 =")
+        {
+            return value
+                .trim()
+                .trim_end_matches(';')
+                .parse()
+                .expect("ORENDER_ABI_MAJOR must be a plain integer literal");
+        }
+    }
+    panic!("ORENDER_ABI_MAJOR not found in src/lib.rs");
+}
 
 fn main() {
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -9,16 +31,20 @@ fn main() {
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
 
-    // On Linux, stamp the release cdylib with a SemVer soname (`liborender.so.0`)
-    // so the packaged library participates in normal shared-object versioning:
-    // consumers (mpv) record `liborender.so.0` as DT_NEEDED, resolved at runtime
-    // via the symlinks the PKGBUILD installs. Debug builds skip this so the C
-    // smoke test can link and run against the bare `target/debug/liborender.so`
-    // without needing the versioned symlinks.
+    // On Linux, stamp the release cdylib with a SemVer soname
+    // (`liborender.so.<ABI major>`) so the packaged library participates in
+    // normal shared-object versioning: consumers (mpv) record it as DT_NEEDED
+    // or dlopen it by that name, resolved at runtime via the symlinks the
+    // PKGBUILD installs. Debug builds skip this so the C smoke test can link
+    // and run against the bare `target/debug/liborender.so` without needing
+    // the versioned symlinks.
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let profile = std::env::var("PROFILE").unwrap_or_default();
     if target_os == "linux" && profile == "release" {
-        println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,liborender.so.0");
+        println!(
+            "cargo:rustc-cdylib-link-arg=-Wl,-soname,liborender.so.{}",
+            abi_major(&crate_dir)
+        );
     }
     // On macOS, stamp the release dylib with an `@rpath` install name so a
     // bundled consumer (mpv, Studio) resolves `liborender.dylib` via its own
@@ -30,11 +56,15 @@ fn main() {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,@rpath/liborender.dylib");
     }
 
+    // Load cbindgen.toml explicitly: the library Builder (unlike the cbindgen
+    // CLI) does not pick it up on its own, and the export/enum settings there
+    // (forced OrenderChannelLabel emission, name-prefixed variants) are part of
+    // the ABI surface.
+    let cfg = cbindgen::Config::from_file(PathBuf::from(&crate_dir).join("cbindgen.toml"))
+        .expect("cbindgen.toml must parse");
     match cbindgen::Builder::new()
         .with_crate(&crate_dir)
-        .with_language(cbindgen::Language::C)
-        .with_include_guard("ORENDER_H")
-        .with_pragma_once(true)
+        .with_config(cfg)
         .generate()
     {
         Ok(bindings) => {

--- a/omniphony-renderer/orender_ffi/cbindgen.toml
+++ b/omniphony-renderer/orender_ffi/cbindgen.toml
@@ -10,3 +10,10 @@ parse_deps = false
 
 [export]
 prefix = ""
+# The label enum is not referenced by any signature (labels cross as raw bytes),
+# so cbindgen only emits it when listed explicitly.
+include = ["OrenderChannelLabel"]
+
+[enum]
+# C has one flat namespace: emit OrenderChannelLabel_L, not a bare `L`/`C`.
+prefix_with_name = true

--- a/omniphony-renderer/orender_ffi/examples/smoke.c
+++ b/omniphony-renderer/orender_ffi/examples/smoke.c
@@ -16,10 +16,52 @@
 int main(void) {
     printf("orender ABI %u.%u\n", orender_version_major(), orender_version_minor());
 
-    /* bridge_path is required, so creation must fail gracefully (NULL),
-     * exercising the catch_unwind boundary rather than crashing. */
+    /* Runtime handshake vs the header we compiled against. This test builds
+     * library and header from the same tree, so both must match exactly (a
+     * real consumer only requires major equality and probes symbols). */
+    if (orender_version_major() != ORENDER_ABI_MAJOR) {
+        printf("FAIL: runtime major %u != header %u\n",
+               orender_version_major(), (unsigned)ORENDER_ABI_MAJOR);
+        return 6;
+    }
+    if (orender_version_minor() != ORENDER_ABI_MINOR) {
+        printf("FAIL: runtime minor %u != header %u\n",
+               orender_version_minor(), (unsigned)ORENDER_ABI_MINOR);
+        return 7;
+    }
+
+    /* Build id is static and never NULL. */
+    const char *build_id = orender_build_id();
+    if (build_id == NULL) { printf("FAIL: orender_build_id() == NULL\n"); return 8; }
+    printf("build id: %s\n", build_id);
+
+    /* set_option error contract: NULL handle/args -> -3 (never a crash). */
+    if (orender_set_option(NULL, "nope", "x") != -3) {
+        printf("FAIL: set_option(NULL handle) != -3\n");
+        return 9;
+    }
+
+    /* The label enum is the byte contract of orender_channel_layout /
+     * orender_bed_layout; spot-check the anchored values. */
+    if (OrenderChannelLabel_L != 0 || OrenderChannelLabel_Lfe2 != 23 ||
+        OrenderChannelLabel_Unknown != 255) {
+        printf("FAIL: OrenderChannelLabel discriminants drifted\n");
+        return 10;
+    }
+
+    /* An unresolvable bridge means creation must fail gracefully (NULL),
+     * exercising the catch_unwind boundary rather than crashing.
+     *
+     * Pin BOTH paths to files that cannot exist so the run is hermetic on any
+     * machine: a NULL config resolves to the user's shared config (whose OSC
+     * settings would make this test race the machine's live renderer for the
+     * OSC port), and even with no config the engine's last-resort search can
+     * find a system-installed bridge — creation would then SUCCEED on a dev
+     * box while failing in CI. Explicit dead paths defeat both fallbacks. */
     OrenderConfig cfg = {0};
     cfg.sample_rate = 48000;
+    cfg.config_yaml_path = "/nonexistent/orender-smoke-config.yaml";
+    cfg.bridge_path = "/nonexistent/orender-smoke-bridge.so";
     OrenderRenderer *r = orender_create(&cfg);
     if (r != NULL) {
         printf("FAIL: got a renderer without a bridge_path\n");

--- a/omniphony-renderer/orender_ffi/include/orender.h
+++ b/omniphony-renderer/orender_ffi/include/orender.h
@@ -8,177 +8,183 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/**
- * Opaque handle to a decode→render session. Created by [`orender_create`],
- * freed by [`orender_destroy`]. Internally a boxed [`Engine`].
- */
+// C-ABI major version of this library. A bump means a breaking change: the
+// Linux soname `liborender.so.<major>` follows automatically (see build.rs);
+// Windows/macOS consumers must gate on [`orender_version_major`] at load time
+// (their library file name does not change).
+//
+// Exported into the generated header (as a `#define`) so a consumer can
+// compare the constants it was compiled against with the runtime values
+// reported by [`orender_version_major`]/[`orender_version_minor`]. Policy:
+// additive change (new symbol, new [`orender_set_option`] key, enum value
+// appended) bumps the minor; anything else (signature/struct/semantic change,
+// symbol removal, enum reorder) bumps the major. See ABI.md.
+#define ORENDER_ABI_MAJOR 0
+
+// C-ABI minor version: backwards-compatible additions only. Consumers should
+// gate optional features on symbol presence (dlsym), not on this value; it
+// exists for logging and diagnostics.
+#define ORENDER_ABI_MINOR 5
+
+// Speaker-position labels written by [`orender_channel_layout`] and
+// [`orender_bed_layout`] (one byte per channel). Mirrors the engine's
+// ABI-stable `bridge_api::RChannelLabel` exactly (a unit test asserts
+// discriminant parity); values are append-only per the ABI policy.
+enum OrenderChannelLabel {
+    OrenderChannelLabel_L = 0,
+    OrenderChannelLabel_R = 1,
+    OrenderChannelLabel_C = 2,
+    OrenderChannelLabel_Lfe = 3,
+    OrenderChannelLabel_Ls = 4,
+    OrenderChannelLabel_Rs = 5,
+    OrenderChannelLabel_Tfl = 6,
+    OrenderChannelLabel_Tfr = 7,
+    OrenderChannelLabel_Tsl = 8,
+    OrenderChannelLabel_Tsr = 9,
+    OrenderChannelLabel_Tbl = 10,
+    OrenderChannelLabel_Tbr = 11,
+    OrenderChannelLabel_Lsc = 12,
+    OrenderChannelLabel_Rsc = 13,
+    OrenderChannelLabel_Lb = 14,
+    OrenderChannelLabel_Rb = 15,
+    OrenderChannelLabel_Cb = 16,
+    OrenderChannelLabel_Tc = 17,
+    OrenderChannelLabel_Lsd = 18,
+    OrenderChannelLabel_Rsd = 19,
+    OrenderChannelLabel_Lw = 20,
+    OrenderChannelLabel_Rw = 21,
+    OrenderChannelLabel_Tfc = 22,
+    OrenderChannelLabel_Lfe2 = 23,
+    OrenderChannelLabel_Unknown = 255,
+};
+typedef uint8_t OrenderChannelLabel;
+
+// Opaque handle to a decode→render session. Created by [`orender_create`],
+// freed by [`orender_destroy`]. Internally a boxed [`Engine`].
 typedef struct OrenderRenderer {
-  uint8_t _private[0];
+    uint8_t _private[0];
 } OrenderRenderer;
 
-/**
- * Session configuration passed to [`orender_create`]. All `*const c_char`
- * fields are UTF-8, nul-terminated, and may be NULL (treated as "unset").
- */
+// Session configuration passed to [`orender_create`]. All `*const c_char`
+// fields are UTF-8, nul-terminated, and may be NULL (treated as "unset").
+//
+// **FROZEN at ABI major 0** — never add, remove, reorder, or retype fields:
+// consumers compiled against an older header pass this struct by layout with
+// no size handshake, so any change here is silently breaking. New knobs go
+// through [`orender_set_option`] (post-create) or the config YAML
+// (create-time). See ABI.md.
 typedef struct OrenderConfig {
-  /**
-   * Output/host sample rate in Hz. 0 → 48000.
-   */
-  uint32_t sample_rate;
-  /**
-   * Path to the omniphony YAML config (drives bridge path, speaker layout +
-   * all render params). NULL → the shared default config used by the orender
-   * CLI + studio (`~/.config/omniphony/config.yaml`).
-   */
-  const char *config_yaml_path;
-  /**
-   * Optional speaker-layout YAML path overriding the config. NULL → use the
-   * config's embedded layout, else the 7.1.4 preset.
-   */
-  const char *speaker_layout_path;
-  /**
-   * Optional decoder bridge plugin path (the `*_bridge.so` produced by
-   * the input format's bridge crate) overriding the config. NULL → taken
-   * from the config YAML's `render.bridge_path` (the source of truth;
-   * library hosts have no exe-relative search).
-   */
-  const char *bridge_path;
-  /**
-   * Codec identifier of the raw access units the host will feed (matches
-   * the bridge's supported codec IDs, e.g. as used in FFmpeg/IEC958).
-   * Disambiguates the bridge's raw transport (which carries no data-type
-   * byte). NULL → the bridge sniffs the sync word.
-   */
-  const char *codec;
-  /**
-   * Enable the OSC live-control server. (Not yet wired in this build.)
-   */
-  int osc_enabled;
-  /**
-   * Incoming OSC port (0 = auto).
-   */
-  uint16_t osc_port_in;
-  /**
-   * Outgoing/monitoring OSC port.
-   */
-  uint16_t osc_port_out;
-  /**
-   * OSC bind address (default "127.0.0.1").
-   */
-  const char *osc_bind;
-  /**
-   * OSC monitoring target host.
-   */
-  const char *osc_host;
+    // Output/host sample rate in Hz. 0 → 48000.
+    uint32_t sample_rate;
+    // Path to the omniphony YAML config (drives bridge path, speaker layout +
+    // all render params). NULL → the shared default config used by the orender
+    // CLI + studio (`~/.config/omniphony/config.yaml`).
+    const char *config_yaml_path;
+    // Optional speaker-layout YAML path overriding the config. NULL → use the
+    // config's embedded layout, else the 7.1.4 preset.
+    const char *speaker_layout_path;
+    // Optional decoder bridge plugin path (the `*_bridge.so` produced by
+    // the input format's bridge crate) overriding the config. NULL → taken
+    // from the config YAML's `render.bridge_path` (the source of truth;
+    // library hosts have no exe-relative search).
+    const char *bridge_path;
+    // Codec identifier of the raw access units the host will feed (matches
+    // the bridge's supported codec IDs, e.g. as used in FFmpeg/IEC958).
+    // Disambiguates the bridge's raw transport (which carries no data-type
+    // byte). NULL → the bridge sniffs the sync word.
+    const char *codec;
+    // Enable the OSC live-control server. (Not yet wired in this build.)
+    int osc_enabled;
+    // Incoming OSC port (0 = auto).
+    uint16_t osc_port_in;
+    // Outgoing/monitoring OSC port.
+    uint16_t osc_port_out;
+    // OSC bind address (default "127.0.0.1").
+    const char *osc_bind;
+    // OSC monitoring target host.
+    const char *osc_host;
 } OrenderConfig;
 
-/**
- * Create a session. Returns NULL on failure (bad config, missing bridge, etc.).
- */
+// Create a session. Returns NULL on failure (bad config, missing bridge, etc.).
 struct OrenderRenderer *orender_create(const struct OrenderConfig *cfg);
 
-/**
- * Free a session created by [`orender_create`]. NULL is ignored.
- */
+// Free a session created by [`orender_create`]. NULL is ignored.
 void orender_destroy(struct OrenderRenderer *r);
 
-/**
- * 1 if the current presentation carries spatial objects, 0 if it is a plain
- * multichannel stream (the host should fall back to its standard decoder),
- * <0 on error. Meaningful after at least one [`orender_process`] call.
- */
+// 1 if the current presentation carries spatial objects, 0 if it is a plain
+// multichannel stream (the host should fall back to its standard decoder),
+// <0 on error. Meaningful after at least one [`orender_process`] call.
 int orender_is_spatial(const struct OrenderRenderer *r);
 
-/**
- * Dynamic object count of the last rendered frame (decoded channels minus the
- * bed channels) for object-based content, `0` for plain multichannel, `-1` on
- * a NULL handle / error. For the host's track info display. Meaningful after at
- * least one [`orender_process`] call.
- */
+// Dynamic object count of the last rendered frame (decoded channels minus the
+// bed channels) for object-based content, `0` for plain multichannel, `-1` on
+// a NULL handle / error. For the host's track info display. Meaningful after at
+// least one [`orender_process`] call.
 int orender_object_count(const struct OrenderRenderer *r);
 
-/**
- * Dialogue normalisation level in dBFS (always ≤ 0) once the stream has
- * declared it, or [`i32::MIN`] when unknown / not yet seen (also on a NULL
- * handle / error). For the host's track info display.
- */
+// Dialogue normalisation level in dBFS (always ≤ 0) once the stream has
+// declared it, or [`i32::MIN`] when unknown / not yet seen (also on a NULL
+// handle / error). For the host's track info display.
 int orender_dialnorm_db(const struct OrenderRenderer *r);
 
-/**
- * Write the bed channel labels of the last object-based frame (one
- * [`RChannelLabel`] byte per bed channel) so the host can show the bed
- * composition (e.g. "LFE+11 objects").
- *
- * Same query/fill convention as [`orender_channel_layout`]: returns the bed
- * channel count `N`; if `out_labels` is non-NULL and `cap >= N`, the first `N`
- * bytes are filled (else nothing is written — call with `out_labels = NULL` to
- * query `N`). `0` for plain multichannel / no bed / NULL handle / error.
- */
+// Write the bed channel labels of the last object-based frame (one
+// [`OrenderChannelLabel`] byte per bed channel) so the host can show the bed
+// composition (e.g. "LFE+11 objects").
+//
+// Same query/fill convention as [`orender_channel_layout`]: returns the bed
+// channel count `N`; if `out_labels` is non-NULL and `cap >= N`, the first `N`
+// bytes are filled (else nothing is written — call with `out_labels = NULL` to
+// query `N`). `0` for plain multichannel / no bed / NULL handle / error.
 uint32_t orender_bed_layout(const struct OrenderRenderer *r, uint8_t *out_labels, uint32_t cap);
 
-/**
- * Configured render mode for channel-based (non-object) content:
- * 0 = host, 1 = spatial; <0 on error. When this is `host` (0) and
- * [`orender_is_spatial`] reports 0, the host should decline this track and fall
- * back to its native decoder. Meaningful once the renderer is created (the mode
- * comes from config / live params, not from the stream).
- */
+// Configured render mode for channel-based (non-object) content:
+// 0 = host, 1 = spatial; <0 on error. When this is `host` (0) and
+// [`orender_is_spatial`] reports 0, the host should decline this track and fall
+// back to its native decoder. Meaningful once the renderer is created (the mode
+// comes from config / live params, not from the stream).
 int orender_channel_mode(const struct OrenderRenderer *r);
 
-/**
- * Override the channel render mode for non-object content at runtime (a
- * per-host override of the config value): 0 = host, 1 = spatial. No-op on a
- * NULL handle.
- */
+// Override the channel render mode for non-object content at runtime (a
+// per-host override of the config value): 0 = host, 1 = spatial. No-op on a
+// NULL handle.
 void orender_set_channel_mode(struct OrenderRenderer *r, int mode);
 
-/**
- * Output channel mapping: 0 = by_index (positionless — output port N carries
- * layout speaker N), 1 = by_name (positional — each channel tagged with its
- * speaker position). <0 on error. The host uses this to choose between a
- * positionless and a positional channel map.
- */
+// Output channel mapping: 0 = by_index (positionless — output port N carries
+// layout speaker N), 1 = by_name (positional — each channel tagged with its
+// speaker position). <0 on error. The host uses this to choose between a
+// positionless and a positional channel map.
 int orender_channel_mapping(const struct OrenderRenderer *r);
 
-/**
- * Override the output channel mapping at runtime: 0 = by_index, 1 = by_name.
- * No-op on a NULL handle or an unknown code.
- */
+// Override the output channel mapping at runtime: 0 = by_index, 1 = by_name.
+// No-op on a NULL handle or an unknown code.
 void orender_set_channel_mapping(struct OrenderRenderer *r, int mode);
 
-/**
- * Number of output channels (speakers) the renderer produces, 0 on error.
- */
+// Number of output channels (speakers) the renderer produces, 0 on error.
 uint32_t orender_channel_count(const struct OrenderRenderer *r);
 
-/**
- * Write the active output layout's per-channel labels (one [`RChannelLabel`]
- * byte per speaker, in render order) so the host can build a channel map.
- *
- * Returns the channel count `N`. If `out_labels` is non-NULL and `cap >= N`,
- * the first `N` bytes are filled with label discriminants; otherwise nothing is
- * written — call with `out_labels = NULL` to query `N`, size a buffer, then
- * call again. Each byte is an `RChannelLabel` value (255 = Unknown). Returns 0
- * on error/NULL handle.
- */
+// Write the active output layout's per-channel labels (one
+// [`OrenderChannelLabel`] byte per speaker, in render order) so the host can
+// build a channel map.
+//
+// Returns the channel count `N`. If `out_labels` is non-NULL and `cap >= N`,
+// the first `N` bytes are filled with label discriminants; otherwise nothing is
+// written — call with `out_labels = NULL` to query `N`, size a buffer, then
+// call again. Each byte is an [`OrenderChannelLabel`] value (255 = Unknown).
+// Returns 0 on error/NULL handle.
 uint32_t orender_channel_layout(const struct OrenderRenderer *r, uint8_t *out_labels, uint32_t cap);
 
-/**
- * Reset after a seek/discontinuity (flushes decoder + renderer state, keeps
- * live params).
- */
+// Reset after a seek/discontinuity (flushes decoder + renderer state, keeps
+// live params).
 void orender_reset(struct OrenderRenderer *r);
 
-/**
- * Push one raw encoded packet and render whatever frames it yields.
- *
- * The caller owns `out` (capacity `out_cap_samples` floats). On success the
- * rendered interleaved samples are written there and `*out_frames` /
- * `*out_channels` / `*out_pts_us` are set.
- *
- * Returns: 0 = OK (may be 0 frames — need more data), >0 = output buffer too
- * small (nothing written; retry with a larger buffer), <0 = error.
- */
+// Push one raw encoded packet and render whatever frames it yields.
+//
+// The caller owns `out` (capacity `out_cap_samples` floats). On success the
+// rendered interleaved samples are written there and `*out_frames` /
+// `*out_channels` / `*out_pts_us` are set.
+//
+// Returns: 0 = OK (may be 0 frames — need more data), >0 = output buffer too
+// small (nothing written; retry with a larger buffer), <0 = error.
 int orender_process(struct OrenderRenderer *r,
                     const uint8_t *pkt,
                     uintptr_t pkt_len,
@@ -189,120 +195,114 @@ int orender_process(struct OrenderRenderer *r,
                     uint32_t *out_channels,
                     int64_t *out_pts_us);
 
-/**
- * Render the spatial overlay for the given OSD resolution and copy the ASS
- * `osd-overlay` payload into `out` (UTF-8, not nul-terminated).
- *
- * This *is* the overlay redraw: each call rebuilds the scene and advances the
- * motion trails, so the host (the mpv Lua shim) must call it exactly once per
- * redraw — typically on a periodic timer and on OSD resize. It also marks the
- * overlay "active" so the engine starts feeding it (the engine does no overlay
- * work until the first pull).
- *
- * Returns the number of bytes the payload needs. If `out` is non-NULL and
- * `cap >= len`, the first `len` bytes are written; otherwise nothing is written
- * (the host should grow its buffer and skip this redraw — the next one fits).
- * A handful of KiB is always enough; the output is bounded. Returns 0 when the
- * overlay is disabled, the resolution is zero, or there is nothing to draw.
- *
- * Handle-less by design: the overlay is a process-global singleton, and the Lua
- * shim has no session handle (it `ffi.load`s this already-loaded library).
- */
+// Render the spatial overlay for the given OSD resolution and copy the ASS
+// `osd-overlay` payload into `out` (UTF-8, not nul-terminated).
+//
+// This *is* the overlay redraw: each call rebuilds the scene and advances the
+// motion trails, so the host (the mpv Lua shim) must call it exactly once per
+// redraw — typically on a periodic timer and on OSD resize. It also marks the
+// overlay "active" so the engine starts feeding it (the engine does no overlay
+// work until the first pull).
+//
+// Returns the number of bytes the payload needs. If `out` is non-NULL and
+// `cap >= len`, the first `len` bytes are written; otherwise nothing is written
+// (the host should grow its buffer and skip this redraw — the next one fits).
+// A handful of KiB is always enough; the output is bounded. Returns 0 when the
+// overlay is disabled, the resolution is zero, or there is nothing to draw.
+//
+// Handle-less by design: the overlay is a process-global singleton, and the Lua
+// shim has no session handle (it `ffi.load`s this already-loaded library).
 uintptr_t orender_overlay_ass(uint32_t res_x, uint32_t res_y, uint8_t *out, uintptr_t cap);
 
-/**
- * Enable or disable the overlay (host keybind / script message). Disabling also
- * makes the engine stop feeding it. `0` = off, non-zero = on.
- */
+// Enable or disable the overlay (host keybind / script message). Disabling also
+// makes the engine stop feeding it. `0` = off, non-zero = on.
 void orender_overlay_set_enabled(int enabled);
 
-/**
- * Drop all overlay scene state (object positions, levels, trails, labels)
- * without touching the master enable. Used by a host that stops feeding the
- * overlay — e.g. mpv routing channel audio to its native decoder in host mode —
- * so the spatial overlay clears immediately instead of lingering on the last
- * frame until the trails decay. The next pull after feeding resumes shows the
- * live scene again; the user's overlay on/off preference is preserved.
- */
+// Drop all overlay scene state (object positions, levels, trails, labels)
+// without touching the master enable. Used by a host that stops feeding the
+// overlay — e.g. mpv routing channel audio to its native decoder in host mode —
+// so the spatial overlay clears immediately instead of lingering on the last
+// frame until the trails decay. The next pull after feeding resumes shows the
+// live scene again; the user's overlay on/off preference is preserved.
 void orender_overlay_clear(void);
 
-/**
- * Suppress or resume *all* overlay drawing — the wireframe cube included — for a
- * live session, independent of the master enable. A host that keeps the engine
- * alive but is not spatial-rendering (mpv in host mode, decoding channel audio
- * natively) sets `0` so the whole overlay disappears, and `1` when it resumes
- * spatial rendering. `0` = not rendering (blank), non-zero = rendering.
- */
+// Suppress or resume *all* overlay drawing — the wireframe cube included — for a
+// live session, independent of the master enable. A host that keeps the engine
+// alive but is not spatial-rendering (mpv in host mode, decoding channel audio
+// natively) sets `0` so the whole overlay disappears, and `1` when it resumes
+// spatial rendering. `0` = not rendering (blank), non-zero = rendering.
 void orender_overlay_set_rendering(int rendering);
 
-/**
- * Flip the master enable and return the new state (1 = on, 0 = off).
- */
+// Flip the master enable and return the new state (1 = on, 0 = off).
 int orender_overlay_toggle(void);
 
-/**
- * Flip object-label visibility and return the new state (1 = on, 0 = off).
- */
+// Flip object-label visibility and return the new state (1 = on, 0 = off).
 int orender_overlay_toggle_labels(void);
 
-/**
- * Flip object visibility (markers + labels + trails + depth lines) and return
- * the new state (1 = on, 0 = off).
- */
+// Flip object visibility (markers + labels + trails + depth lines) and return
+// the new state (1 = on, 0 = off).
 int orender_overlay_toggle_objects(void);
 
-/**
- * Flip whether motion trails are drawn and return the new state (1 = on,
- * 0 = off). Clears the trail buffers when disabling.
- */
+// Flip whether motion trails are drawn and return the new state (1 = on,
+// 0 = off). Clears the trail buffers when disabling.
 int orender_overlay_toggle_trails(void);
 
-/**
- * Flip the object energy heatmap and return the new state (1 = on, 0 = off).
- */
+// Flip the object energy heatmap and return the new state (1 = on, 0 = off).
 int orender_overlay_toggle_heatmap(void);
 
-/**
- * Advance the heatmap colour gradient to the next index (wraps 0..=4) and return
- * the new index.
- */
+// Advance the heatmap colour gradient to the next index (wraps 0..=4) and return
+// the new index.
 uint32_t orender_overlay_cycle_heatmap_colormap(void);
 
-/**
- * Step the heatmap depth-plane count by `delta` (clamped to 1..=12) and return
- * the new count.
- */
+// Step the heatmap depth-plane count by `delta` (clamped to 1..=12) and return
+// the new count.
 uint32_t orender_overlay_adjust_heatmap_bands(int32_t delta);
 
-/**
- * Render the object energy heatmap as a single flattened BGRA bitmap
- * (premultiplied alpha) for mpv's `overlay-add`, drawn *under* the ASS overlay.
- *
- * On success copies `w*h*4` BGRA bytes into `out` and writes the geometry into
- * `geom` (6 × i32: `[x, y, w, h, dw, dh]` — top-left position, source size, and
- * the on-screen display size mpv scales the source to), then returns the number
- * of bytes written. Returns 0 — and writes nothing — when the overlay is
- * disabled, the resolution is zero, the buffers are too small, or there is no
- * audible object. The bitmap is bounded (`FIELD_BITMAP_MAX²·4` ≈ 256 KiB).
- *
- * Read-only with respect to the scene: unlike `orender_overlay_ass`, this does
- * not advance trails or the pull clock (the ASS pull already does), so the host
- * may call it alongside the ASS redraw.
- */
+// Render the object energy heatmap as a single flattened BGRA bitmap
+// (premultiplied alpha) for mpv's `overlay-add`, drawn *under* the ASS overlay.
+//
+// On success copies `w*h*4` BGRA bytes into `out` and writes the geometry into
+// `geom` (6 × i32: `[x, y, w, h, dw, dh]` — top-left position, source size, and
+// the on-screen display size mpv scales the source to), then returns the number
+// of bytes written. Returns 0 — and writes nothing — when the overlay is
+// disabled, the resolution is zero, the buffers are too small, or there is no
+// audible object. The bitmap is bounded (`FIELD_BITMAP_MAX²·4` ≈ 256 KiB).
+//
+// Read-only with respect to the scene: unlike `orender_overlay_ass`, this does
+// not advance trails or the pull clock (the ASS pull already does), so the host
+// may call it alongside the ASS redraw.
 uintptr_t orender_overlay_heatmap_bgra(uint32_t res_x,
                                        uint32_t res_y,
                                        uint8_t *out,
                                        uintptr_t cap,
                                        int32_t *geom);
 
-/**
- * ABI major version. A bump means a breaking change (new soname).
- */
+// ABI major version of the loaded library (see [`ORENDER_ABI_MAJOR`]). A
+// consumer must refuse a library whose major differs from the one it was
+// compiled against.
 uint32_t orender_version_major(void);
 
-/**
- * ABI minor version (backwards-compatible additions).
- */
+// ABI minor version of the loaded library (backwards-compatible additions;
+// see [`ORENDER_ABI_MINOR`]). For logging — gate features on symbol presence.
 uint32_t orender_version_minor(void);
+
+// Human-readable build identifier of the loaded library:
+// `"<crate-version> <git-describe> (built <timestamp>)"`. Static storage,
+// never NULL — for host logs, so "which engine did I actually load" is one
+// log line instead of a debugging session.
+const char *orender_build_id(void);
+
+// Set a named runtime option on a session — the additive evolution path for
+// the frozen [`OrenderConfig`]: new knobs get a string key here instead of a
+// struct field, so consumers compiled against older headers keep working and
+// newer consumers can probe.
+//
+// Returns 0 on success, -1 for an unknown key (also how a consumer probes
+// whether this build supports a key), -2 for an invalid value, -3 on a NULL
+// handle/argument or internal error.
+//
+// No keys are defined at ABI 0.5 — every call returns -1. The mechanism ships
+// ahead of the first key so consumers can adopt the probe pattern now.
+int orender_set_option(struct OrenderRenderer *r, const char *key, const char *value);
 
 #endif  /* ORENDER_H */

--- a/omniphony-renderer/orender_ffi/src/lib.rs
+++ b/omniphony-renderer/orender_ffi/src/lib.rs
@@ -45,7 +45,13 @@ fn start_degraded_reporter_global(
         return;
     }
     std::thread::spawn(move || {
-        match start_degraded_reporter(config_path.as_deref(), sample_rate, opts, message) {
+        match start_degraded_reporter(
+            config_path.as_deref(),
+            sample_rate,
+            opts,
+            message,
+            Some((ORENDER_ABI_MAJOR, ORENDER_ABI_MINOR)),
+        ) {
             Ok(reporter) => {
                 // A real engine may have started while we were building; only
                 // keep ours if the slot is still claimed (else drop → free port).
@@ -109,6 +115,12 @@ pub struct OrenderRenderer {
 
 /// Session configuration passed to [`orender_create`]. All `*const c_char`
 /// fields are UTF-8, nul-terminated, and may be NULL (treated as "unset").
+///
+/// **FROZEN at ABI major 0** — never add, remove, reorder, or retype fields:
+/// consumers compiled against an older header pass this struct by layout with
+/// no size handshake, so any change here is silently breaking. New knobs go
+/// through [`orender_set_option`] (post-create) or the config YAML
+/// (create-time). See ABI.md.
 #[repr(C)]
 pub struct OrenderConfig {
     /// Output/host sample rate in Hz. 0 → 48000.
@@ -142,11 +154,61 @@ pub struct OrenderConfig {
     pub osc_host: *const c_char,
 }
 
-const VERSION_MAJOR: u32 = 0;
+/// C-ABI major version of this library. A bump means a breaking change: the
+/// Linux soname `liborender.so.<major>` follows automatically (see build.rs);
+/// Windows/macOS consumers must gate on [`orender_version_major`] at load time
+/// (their library file name does not change).
+///
+/// Exported into the generated header (as a `#define`) so a consumer can
+/// compare the constants it was compiled against with the runtime values
+/// reported by [`orender_version_major`]/[`orender_version_minor`]. Policy:
+/// additive change (new symbol, new [`orender_set_option`] key, enum value
+/// appended) bumps the minor; anything else (signature/struct/semantic change,
+/// symbol removal, enum reorder) bumps the major. See ABI.md.
+pub const ORENDER_ABI_MAJOR: u32 = 0;
+/// C-ABI minor version: backwards-compatible additions only. Consumers should
+/// gate optional features on symbol presence (dlsym), not on this value; it
+/// exists for logging and diagnostics.
 // 2: added orender_overlay_ass / orender_overlay_set_enabled (in-process overlay).
 // 3: added orender_overlay_heatmap_bgra (BGRA energy-field bitmap for overlay-add).
 // 4: added overlay toggles (labels/objects/trails/heatmap) + heatmap band/colormap cycling.
-const VERSION_MINOR: u32 = 4;
+// 5: added orender_set_option, orender_build_id, exported ORENDER_ABI_* consts,
+//    OrenderChannelLabel, and the /omniphony/state/render/abi OSC broadcast.
+pub const ORENDER_ABI_MINOR: u32 = 5;
+
+/// Speaker-position labels written by [`orender_channel_layout`] and
+/// [`orender_bed_layout`] (one byte per channel). Mirrors the engine's
+/// ABI-stable `bridge_api::RChannelLabel` exactly (a unit test asserts
+/// discriminant parity); values are append-only per the ABI policy.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OrenderChannelLabel {
+    L = 0,
+    R = 1,
+    C = 2,
+    Lfe = 3,
+    Ls = 4,
+    Rs = 5,
+    Tfl = 6,
+    Tfr = 7,
+    Tsl = 8,
+    Tsr = 9,
+    Tbl = 10,
+    Tbr = 11,
+    Lsc = 12,
+    Rsc = 13,
+    Lb = 14,
+    Rb = 15,
+    Cb = 16,
+    Tc = 17,
+    Lsd = 18,
+    Rsd = 19,
+    Lw = 20,
+    Rw = 21,
+    Tfc = 22,
+    Lfe2 = 23,
+    Unknown = 255,
+}
 
 unsafe fn opt_str<'a>(p: *const c_char) -> Option<&'a str> {
     if p.is_null() {
@@ -305,6 +367,9 @@ pub unsafe extern "C" fn orender_create(cfg: *const OrenderConfig) -> *mut Orend
         }
         match build_engine(&*cfg) {
             Ok(engine) => {
+                // Stamp the shim's C-ABI version so the live-state snapshot
+                // broadcasts it (Studio About shows it next to the fingerprint).
+                engine.set_host_abi(ORENDER_ABI_MAJOR, ORENDER_ABI_MINOR);
                 // Arm the spatial overlay: it stays blank until a session exists,
                 // so a host that loads the overlay shim without selecting
                 // `--ad=orender` (no session created) draws nothing.
@@ -386,7 +451,7 @@ pub unsafe extern "C" fn orender_dialnorm_db(r: *const OrenderRenderer) -> c_int
 }
 
 /// Write the bed channel labels of the last object-based frame (one
-/// [`RChannelLabel`] byte per bed channel) so the host can show the bed
+/// [`OrenderChannelLabel`] byte per bed channel) so the host can show the bed
 /// composition (e.g. "LFE+11 objects").
 ///
 /// Same query/fill convention as [`orender_channel_layout`]: returns the bed
@@ -484,14 +549,15 @@ pub unsafe extern "C" fn orender_channel_count(r: *const OrenderRenderer) -> u32
     .unwrap_or(0)
 }
 
-/// Write the active output layout's per-channel labels (one [`RChannelLabel`]
-/// byte per speaker, in render order) so the host can build a channel map.
+/// Write the active output layout's per-channel labels (one
+/// [`OrenderChannelLabel`] byte per speaker, in render order) so the host can
+/// build a channel map.
 ///
 /// Returns the channel count `N`. If `out_labels` is non-NULL and `cap >= N`,
 /// the first `N` bytes are filled with label discriminants; otherwise nothing is
 /// written — call with `out_labels = NULL` to query `N`, size a buffer, then
-/// call again. Each byte is an `RChannelLabel` value (255 = Unknown). Returns 0
-/// on error/NULL handle.
+/// call again. Each byte is an [`OrenderChannelLabel`] value (255 = Unknown).
+/// Returns 0 on error/NULL handle.
 #[no_mangle]
 pub unsafe extern "C" fn orender_channel_layout(
     r: *const OrenderRenderer,
@@ -798,14 +864,151 @@ pub unsafe extern "C" fn orender_overlay_heatmap_bgra(
     .unwrap_or(0)
 }
 
-/// ABI major version. A bump means a breaking change (new soname).
+/// ABI major version of the loaded library (see [`ORENDER_ABI_MAJOR`]). A
+/// consumer must refuse a library whose major differs from the one it was
+/// compiled against.
 #[no_mangle]
 pub extern "C" fn orender_version_major() -> u32 {
-    VERSION_MAJOR
+    ORENDER_ABI_MAJOR
 }
 
-/// ABI minor version (backwards-compatible additions).
+/// ABI minor version of the loaded library (backwards-compatible additions;
+/// see [`ORENDER_ABI_MINOR`]). For logging — gate features on symbol presence.
 #[no_mangle]
 pub extern "C" fn orender_version_minor() -> u32 {
-    VERSION_MINOR
+    ORENDER_ABI_MINOR
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OrenderChannelLabel;
+    use bridge_api::RChannelLabel;
+
+    /// Exhaustive by construction: a new `RChannelLabel` variant breaks this
+    /// match at compile time, forcing the FFI mirror (and thus the generated C
+    /// header) to be updated in the same change.
+    fn mirror(label: RChannelLabel) -> OrenderChannelLabel {
+        match label {
+            RChannelLabel::L => OrenderChannelLabel::L,
+            RChannelLabel::R => OrenderChannelLabel::R,
+            RChannelLabel::C => OrenderChannelLabel::C,
+            RChannelLabel::LFE => OrenderChannelLabel::Lfe,
+            RChannelLabel::Ls => OrenderChannelLabel::Ls,
+            RChannelLabel::Rs => OrenderChannelLabel::Rs,
+            RChannelLabel::Tfl => OrenderChannelLabel::Tfl,
+            RChannelLabel::Tfr => OrenderChannelLabel::Tfr,
+            RChannelLabel::Tsl => OrenderChannelLabel::Tsl,
+            RChannelLabel::Tsr => OrenderChannelLabel::Tsr,
+            RChannelLabel::Tbl => OrenderChannelLabel::Tbl,
+            RChannelLabel::Tbr => OrenderChannelLabel::Tbr,
+            RChannelLabel::Lsc => OrenderChannelLabel::Lsc,
+            RChannelLabel::Rsc => OrenderChannelLabel::Rsc,
+            RChannelLabel::Lb => OrenderChannelLabel::Lb,
+            RChannelLabel::Rb => OrenderChannelLabel::Rb,
+            RChannelLabel::Cb => OrenderChannelLabel::Cb,
+            RChannelLabel::Tc => OrenderChannelLabel::Tc,
+            RChannelLabel::Lsd => OrenderChannelLabel::Lsd,
+            RChannelLabel::Rsd => OrenderChannelLabel::Rsd,
+            RChannelLabel::Lw => OrenderChannelLabel::Lw,
+            RChannelLabel::Rw => OrenderChannelLabel::Rw,
+            RChannelLabel::Tfc => OrenderChannelLabel::Tfc,
+            RChannelLabel::LFE2 => OrenderChannelLabel::Lfe2,
+            RChannelLabel::Unknown => OrenderChannelLabel::Unknown,
+        }
+    }
+
+    #[test]
+    fn channel_label_discriminants_match_bridge_api() {
+        let all = [
+            RChannelLabel::L,
+            RChannelLabel::R,
+            RChannelLabel::C,
+            RChannelLabel::LFE,
+            RChannelLabel::Ls,
+            RChannelLabel::Rs,
+            RChannelLabel::Tfl,
+            RChannelLabel::Tfr,
+            RChannelLabel::Tsl,
+            RChannelLabel::Tsr,
+            RChannelLabel::Tbl,
+            RChannelLabel::Tbr,
+            RChannelLabel::Lsc,
+            RChannelLabel::Rsc,
+            RChannelLabel::Lb,
+            RChannelLabel::Rb,
+            RChannelLabel::Cb,
+            RChannelLabel::Tc,
+            RChannelLabel::Lsd,
+            RChannelLabel::Rsd,
+            RChannelLabel::Lw,
+            RChannelLabel::Rw,
+            RChannelLabel::Tfc,
+            RChannelLabel::LFE2,
+            RChannelLabel::Unknown,
+        ];
+        for label in all {
+            assert_eq!(
+                label as u8,
+                mirror(label) as u8,
+                "discriminant mismatch for {label:?}"
+            );
+        }
+    }
+}
+
+/// Human-readable build identifier of the loaded library:
+/// `"<crate-version> <git-describe> (built <timestamp>)"`. Static storage,
+/// never NULL — for host logs, so "which engine did I actually load" is one
+/// log line instead of a debugging session.
+#[no_mangle]
+pub extern "C" fn orender_build_id() -> *const c_char {
+    use std::ffi::CString;
+    use std::sync::OnceLock;
+    static BUILD_ID: OnceLock<CString> = OnceLock::new();
+    catch_unwind(AssertUnwindSafe(|| {
+        BUILD_ID
+            .get_or_init(|| {
+                let id = format!(
+                    "{} {}",
+                    env!("CARGO_PKG_VERSION"),
+                    runtime_control::build_fingerprint()
+                );
+                CString::new(id).unwrap_or_default()
+            })
+            .as_ptr()
+    }))
+    .unwrap_or(ptr::null())
+}
+
+/// Set a named runtime option on a session — the additive evolution path for
+/// the frozen [`OrenderConfig`]: new knobs get a string key here instead of a
+/// struct field, so consumers compiled against older headers keep working and
+/// newer consumers can probe.
+///
+/// Returns 0 on success, -1 for an unknown key (also how a consumer probes
+/// whether this build supports a key), -2 for an invalid value, -3 on a NULL
+/// handle/argument or internal error.
+///
+/// No keys are defined at ABI 0.5 — every call returns -1. The mechanism ships
+/// ahead of the first key so consumers can adopt the probe pattern now.
+#[no_mangle]
+pub unsafe extern "C" fn orender_set_option(
+    r: *mut OrenderRenderer,
+    key: *const c_char,
+    value: *const c_char,
+) -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        if r.is_null() {
+            return -3;
+        }
+        let (Some(key), Some(_value)) = (opt_str(key), opt_str(value)) else {
+            return -3;
+        };
+        let _engine = &mut *(r as *mut Engine);
+        // No keys defined yet (ABI 0.5): report "unknown key" so consumers can
+        // probe support. First real key: match on `key` and route to the engine.
+        let _ = key;
+        -1
+    }))
+    .unwrap_or(-3)
 }

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -923,6 +923,12 @@ pub struct RendererControl {
     /// Studio can surface a red banner. `None`/empty in normal operation.
     pub bridge_error: Mutex<Option<String>>,
 
+    /// C-ABI version pair of the FFI shim hosting this engine (liborender),
+    /// set by the shim at session start. `None` for hosts that link the engine
+    /// as a Rust crate (the orender CLI). Broadcast to Studio's About panel
+    /// next to the build fingerprint.
+    pub host_abi: Mutex<Option<(u32, u32)>>,
+
     /// Actual renderer input path used for this process.
     pub input_path: Mutex<Option<String>>,
     /// Requested format bridge path to be persisted into render.bridge_path.
@@ -993,6 +999,7 @@ impl RendererControl {
             config_path: Mutex::new(None),
             config_status: Mutex::new(None),
             bridge_error: Mutex::new(None),
+            host_abi: Mutex::new(None),
             input_path: Mutex::new(None),
             bridge_path: Mutex::new(None),
             bridge_supported_drc_modes: Mutex::new(Vec::new()),
@@ -1171,6 +1178,16 @@ impl RendererControl {
 
     pub fn bridge_error(&self) -> Option<String> {
         self.bridge_error.lock().clone()
+    }
+
+    /// Record the hosting FFI shim's C-ABI version (liborender only; Rust-linked
+    /// hosts never call this).
+    pub fn set_host_abi(&self, major: u32, minor: u32) {
+        *self.host_abi.lock() = Some((major, minor));
+    }
+
+    pub fn host_abi(&self) -> Option<(u32, u32)> {
+        *self.host_abi.lock()
     }
 
     pub fn active_topology(&self) -> Arc<RenderTopology> {

--- a/omniphony-renderer/runtime_control/src/lib.rs
+++ b/omniphony-renderer/runtime_control/src/lib.rs
@@ -11,3 +11,15 @@ pub mod persist;
 pub mod snapshot;
 
 pub use host_control::HostControlHandler;
+
+/// Build fingerprint of this workspace build (`<git-describe> (built <ts>)`),
+/// stamped by this crate's build.rs. Both renderer hosts (the `orender` CLI
+/// and the `liborender` cdylib) link this crate, so the string identifies the
+/// engine build regardless of packaging.
+pub fn build_fingerprint() -> String {
+    format!(
+        "{} (built {})",
+        env!("VERGEN_GIT_DESCRIBE"),
+        env!("BUILD_TIMESTAMP"),
+    )
+}

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -231,6 +231,7 @@ pub const STATE_OSC_METERING: &str = "/omniphony/state/osc/metering";
 pub const STATE_REALTIME_MASTER_GAIN: &str = "/omniphony/state/realtime/master_gain";
 pub const STATE_REALTIME_OBJECT_GAIN: &str = "/omniphony/state/realtime/object_gain";
 pub const STATE_REALTIME_SPEAKER_GAIN: &str = "/omniphony/state/realtime/speaker_gain";
+pub const STATE_RENDER_ABI: &str = "/omniphony/state/render/abi";
 pub const STATE_RENDER_BRIDGE_ERROR: &str = "/omniphony/state/render/bridge_error";
 pub const STATE_RENDER_BRIDGE_PATH: &str = "/omniphony/state/render/bridge_path";
 pub const STATE_RENDER_CONFIG_PATH: &str = "/omniphony/state/render/config_path";
@@ -416,6 +417,7 @@ pub const ALL_STATE: &[&str] = &[
     STATE_REALTIME_MASTER_GAIN,
     STATE_REALTIME_OBJECT_GAIN,
     STATE_REALTIME_SPEAKER_GAIN,
+    STATE_RENDER_ABI,
     STATE_RENDER_BRIDGE_ERROR,
     STATE_RENDER_BRIDGE_PATH,
     STATE_RENDER_CONFIG_PATH,

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -549,11 +549,20 @@ pub fn build_live_state_bundle(
             // mpv-embedded liborender link). Studio shows it in About so a
             // liborender-vs-orender version skew is visible at a glance.
             addr: "/omniphony/state/render/version".to_string(),
-            args: vec![OscType::String(format!(
-                "{} (built {})",
-                env!("VERGEN_GIT_DESCRIBE"),
-                env!("BUILD_TIMESTAMP"),
-            ))],
+            args: vec![OscType::String(crate::build_fingerprint())],
+        }),
+        OscPacket::Message(OscMessage {
+            // C-ABI version ("major.minor") of the liborender shim hosting this
+            // engine, or "" when the engine is linked directly as a Rust crate
+            // (the CLI — no C ABI involved). Studio shows it in About next to
+            // the build fingerprint.
+            addr: "/omniphony/state/render/abi".to_string(),
+            args: vec![OscType::String(
+                control
+                    .host_abi()
+                    .map(|(major, minor)| format!("{major}.{minor}"))
+                    .unwrap_or_default(),
+            )],
         }),
         OscPacket::Message(OscMessage {
             // Non-empty when this renderer came up in the degraded "no decoder"

--- a/omniphony-studio/package-lock.json
+++ b/omniphony-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniphony-studio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniphony-studio",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@codemirror/language": "^6",
         "@codemirror/legacy-modes": "^6",

--- a/omniphony-studio/scripts/prepare-sidecar.mjs
+++ b/omniphony-studio/scripts/prepare-sidecar.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, chmodSync, existsSync, mkdirSync } from 'fs';
+import { copyFileSync, chmodSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
@@ -41,3 +41,45 @@ if (process.platform !== 'win32') {
 }
 
 console.log(`Prepared sidecar: ${sidecarPath}`);
+
+// ── engine library (liborender) ────────────────────────────────────────────
+// Bundled as a resource and deployed at startup (src-tauri/src/engine_deploy.rs)
+// to the per-user path the forked mpv's runtime loader searches — so shipping
+// Studio ships the engine every consumer uses, built from this same commit as
+// the CLI sidecar above. The Linux artifact is named after its soname
+// (liborender.so.<ABI major>, read from the generated header) to match what
+// the loader probes.
+execFileSync('cargo', ['build', '--release', '-p', 'orender_ffi'], {
+  cwd: rendererDir,
+  stdio: 'inherit'
+});
+
+const engineDir = join(binariesDir, 'engine');
+mkdirSync(engineDir, { recursive: true });
+
+let libSrc, libName;
+if (process.platform === 'win32') {
+  libSrc = join(rendererDir, 'target', 'release', 'orender.dll');
+  libName = 'orender.dll';
+} else if (process.platform === 'darwin') {
+  libSrc = join(rendererDir, 'target', 'release', 'liborender.dylib');
+  libName = 'liborender.dylib';
+} else {
+  const header = readFileSync(
+    join(rendererDir, 'orender_ffi', 'include', 'orender.h'), 'utf8');
+  const major = /^#define ORENDER_ABI_MAJOR (\d+)$/m.exec(header)?.[1];
+  if (!major) {
+    throw new Error('ORENDER_ABI_MAJOR not found in orender.h');
+  }
+  libSrc = join(rendererDir, 'target', 'release', 'liborender.so');
+  libName = `liborender.so.${major}`;
+}
+if (!existsSync(libSrc)) {
+  throw new Error(`Engine library not found after build: ${libSrc}`);
+}
+copyFileSync(libSrc, join(engineDir, libName));
+if (process.platform !== 'win32') {
+  chmodSync(join(engineDir, libName), 0o755);
+}
+
+console.log(`Prepared engine library: ${join(engineDir, libName)}`);

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -468,6 +468,8 @@ pub struct AppState {
     pub render_config_status: Option<String>,
     #[serde(rename = "renderVersion")]
     pub render_version: Option<String>,
+    #[serde(rename = "renderAbi")]
+    pub render_abi: Option<String>,
     #[serde(rename = "renderBridgeError")]
     pub render_bridge_error: Option<String>,
     #[serde(rename = "liveInput")]
@@ -737,6 +739,7 @@ impl Default for AppState {
             render_config_path: None,
             render_config_status: None,
             render_version: None,
+            render_abi: None,
             render_bridge_error: None,
             live_input: LiveInputState::default(),
             orender_input_pipe: None,

--- a/omniphony-studio/src-tauri/src/engine_deploy.rs
+++ b/omniphony-studio/src-tauri/src/engine_deploy.rs
@@ -1,0 +1,97 @@
+//! Deploy the bundled engine library (liborender) to the per-user location
+//! external consumers search at runtime.
+//!
+//! The Studio bundle carries the engine library built from the same commit as
+//! the `orender` sidecar (see `scripts/prepare-sidecar.mjs`). On startup we
+//! copy it to `<local data dir>/omniphony/lib/` — the exact path the forked
+//! mpv's runtime loader probes after `--ad-orender-library`/`$ORENDER_LIBRARY`
+//! and before its own bundled fallback — so updating Studio updates the engine
+//! every consumer uses, with no mpv rebuild.
+//!
+//! Tauri's `local_data_dir()` resolves to `~/.local/share` (Linux),
+//! `~/Library/Application Support` (macOS) and `%LOCALAPPDATA%` (Windows),
+//! matching the loader's search list on all three.
+//!
+//! Deployment is best-effort and must never block startup: the copy only
+//! happens when the bytes differ (upgrade), goes through a temp file + rename
+//! so a consumer never sees a half-written library, and failures (e.g. the
+//! DLL locked by a running mpv on Windows) are logged and retried on the next
+//! launch.
+
+use std::fs;
+use std::path::Path;
+
+use tauri::Manager;
+
+pub(crate) fn deploy(app: &tauri::App) {
+    let Ok(resource_dir) = app.path().resource_dir() else {
+        log::warn!("engine deploy: no resource dir; skipping");
+        return;
+    };
+    let Ok(local_data) = app.path().local_data_dir() else {
+        log::warn!("engine deploy: no local data dir; skipping");
+        return;
+    };
+
+    let src_dir = resource_dir.join("engine");
+    if !src_dir.is_dir() {
+        // Dev runs (`tauri dev`) have no bundled resources — normal.
+        log::info!("engine deploy: no bundled engine at {src_dir:?}; skipping");
+        return;
+    }
+    let dest_dir = local_data.join("omniphony").join("lib");
+
+    let entries = match fs::read_dir(&src_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("engine deploy: cannot read {src_dir:?}: {e}");
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let src = entry.path();
+        if !src.is_file() {
+            continue;
+        }
+        let Some(name) = src.file_name() else { continue };
+        if let Err(e) = deploy_one(&src, &dest_dir.join(name)) {
+            log::warn!("engine deploy: {src:?} -> {dest_dir:?}: {e}");
+        }
+    }
+}
+
+fn deploy_one(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let src_bytes = fs::read(src)?;
+    // Copy only when the content actually changed, so an unchanged engine
+    // never touches the file a consumer may have open.
+    if let Ok(dest_bytes) = fs::read(dest) {
+        if dest_bytes == src_bytes {
+            log::info!("engine deploy: {dest:?} up to date");
+            return Ok(());
+        }
+    }
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    // Temp file + rename: atomic on the same filesystem, so a consumer either
+    // sees the old library or the new one, never a torn write.
+    let tmp = dest.with_extension("tmp-deploy");
+    fs::write(&tmp, &src_bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755));
+    }
+    match fs::rename(&tmp, dest) {
+        Ok(()) => {
+            log::info!("engine deploy: installed {dest:?}");
+            Ok(())
+        }
+        Err(e) => {
+            // Windows: rename-over fails while the DLL is loaded by a running
+            // mpv. Leave things as they were; the next launch retries.
+            let _ = fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -4,6 +4,7 @@
 mod app_state;
 mod commands;
 mod config;
+mod engine_deploy;
 mod layouts;
 mod osc_listener;
 mod osc_parser;
@@ -131,6 +132,10 @@ fn main() {
                 let window_icon = tauri::image::Image::new_owned(decoded.into_raw(), width, height);
                 let _ = window.set_icon(window_icon);
             }
+
+            // Publish the bundled engine library (liborender) to the per-user
+            // path external consumers (the forked mpv) load it from.
+            engine_deploy::deploy(app);
 
             let config_dir = app
                 .path()

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -2504,6 +2504,17 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                     removed_ids,
                 )
             }
+            OscEvent::StateRenderAbi { value } => {
+                s.render_abi = if value.trim().is_empty() {
+                    None
+                } else {
+                    Some(value.clone())
+                };
+                (
+                    Some(("render:abi", serde_json::json!({ "value": value }))),
+                    removed_ids,
+                )
+            }
             OscEvent::StateRenderBridgeError { value } => {
                 s.render_bridge_error = if value.trim().is_empty() {
                     None

--- a/omniphony-studio/src-tauri/src/osc_parser.rs
+++ b/omniphony-studio/src-tauri/src/osc_parser.rs
@@ -293,6 +293,8 @@ pub enum OscEvent {
     StateRenderConfigStatus { value: String },
     #[serde(rename = "state:render:version")]
     StateRenderVersion { value: String },
+    #[serde(rename = "state:render:abi")]
+    StateRenderAbi { value: String },
     #[serde(rename = "state:render:bridge_error")]
     StateRenderBridgeError { value: String },
     #[serde(rename = "state:input_pipe")]
@@ -851,6 +853,11 @@ fn parse_omniphony_state(parts: &[&str], args: &[f64], raw_args: &[OscType]) -> 
             value: raw_args.first().and_then(unwrap_string)?,
         }),
         (4, "render") if parts[3] == "version" => Some(OscEvent::StateRenderVersion {
+            value: raw_args.first().and_then(unwrap_string)?,
+        }),
+        // C-ABI version of the liborender shim hosting the engine
+        // ("major.minor"); empty when the engine is linked as a Rust crate.
+        (4, "render") if parts[3] == "abi" => Some(OscEvent::StateRenderAbi {
             value: raw_args.first().and_then(unwrap_string)?,
         }),
         (4, "render") if parts[3] == "bridge_error" => Some(OscEvent::StateRenderBridgeError {

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
     "externalBin": ["binaries/orender"],
     "resources": {
       "../../layouts/*.yaml": "layouts/",
-      "../../layouts/legacy/*.yaml": "layouts/legacy/"
+      "../../layouts/legacy/*.yaml": "layouts/legacy/",
+      "binaries/engine/*": "engine/"
     },
     "windows": {
       "nsis": {

--- a/omniphony-studio/src/controls/config.js
+++ b/omniphony-studio/src/controls/config.js
@@ -87,9 +87,12 @@ export function updateAboutRendererVersion() {
   const el = document.getElementById('aboutRendererVersion');
   if (!el) return;
   const version = typeof app.renderVersion === 'string' ? app.renderVersion.trim() : '';
-  if (version) {
-    el.textContent = version;
-    el.title = version;
+  // The liborender host also reports its C-ABI pair; the CLI reports none.
+  const abi = typeof app.renderAbi === 'string' ? app.renderAbi.trim() : '';
+  const text = version && abi ? `${version} · ABI ${abi}` : version;
+  if (text) {
+    el.textContent = text;
+    el.title = text;
   } else {
     el.textContent = '—';
     el.removeAttribute('title');

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -585,6 +585,9 @@ export function applyInitState(payload) {
   if (typeof payload.renderVersion === 'string') {
     app.renderVersion = payload.renderVersion.trim() || null;
   }
+  if (typeof payload.renderAbi === 'string') {
+    app.renderAbi = payload.renderAbi.trim() || null;
+  }
   if (typeof payload.renderBridgeError === 'string') {
     app.renderBridgeError = payload.renderBridgeError.trim() || null;
   }

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -307,6 +307,9 @@ export const app = {
   // Build fingerprint of the connected renderer (git-describe + build time).
   // Lets About expose a liborender-vs-orender version skew.
   renderVersion: null,
+  // C-ABI version ("major.minor") of the liborender shim hosting the engine.
+  // Null when the engine is linked as a Rust crate (the CLI — no C ABI).
+  renderAbi: null,
   // Non-empty when the renderer came up degraded (decoder bridge missing) —
   // drives a red banner under the OSC status. Cleared when a healthy renderer
   // reports an empty value.

--- a/omniphony-studio/src/tauri-bridge.js
+++ b/omniphony-studio/src/tauri-bridge.js
@@ -413,6 +413,11 @@ export function setupTauriBridge() {
     updateAboutRendererVersion();
   });
 
+  listen('render:abi', ({ payload }) => {
+    app.renderAbi = String(payload?.value ?? '').trim() || null;
+    updateAboutRendererVersion();
+  });
+
   listen('render:bridge_error', ({ payload }) => {
     app.renderBridgeError = String(payload?.value ?? '').trim() || null;
     renderOscStatus();


### PR DESCRIPTION
## What

Two building blocks of the "one shared engine" plan (mpv side: mgth/mpv + mgth/mpv-omniphony PRs):

**ABI hardening (`orender_ffi`, ABI 0.4 → 0.5 — everything additive):**
- Export `ORENDER_ABI_MAJOR`/`ORENDER_ABI_MINOR` into the generated header as `#define`s so a consumer can compare its compiled-against constants with the runtime `orender_version_major()/minor()` values.
- **Freeze `OrenderConfig`** (documented): it crosses the boundary by layout with no size handshake. New knobs go through the new probe-able `orender_set_option(key, value)` entry point (no keys defined yet; -1 = unknown key = feature probe) or the config YAML.
- Add `orender_build_id()` (crate version + git-describe + build time) so hosts can log exactly which engine they loaded.
- Export `OrenderChannelLabel` into the header, mirroring `bridge_api::RChannelLabel`; a unit test asserts discriminant parity and an exhaustive match breaks the build when `bridge_api` gains a variant. Kills the implicit raw-u8 label contract consumers had to hardcode.
- Derive the Linux soname (`liborender.so.<major>`) from `ORENDER_ABI_MAJOR` in build.rs instead of hardcoding `.so.0`.
- Fix: build.rs never loaded `cbindgen.toml` (the library Builder ignores it, unlike the CLI) — the export/enum settings there silently never applied.
- Broadcast `/omniphony/state/render/abi` (set by liborender at session/degraded-reporter start; empty for the CLI) and factor the build fingerprint into `runtime_control::build_fingerprint()`.
- `ABI.md`: the contract, version-number map, bump checklist. CI now compiles + runs the C smoke test against the debug cdylib; `liborender-release.yml` asserts `liborender-v*` tags match the crate version. Crate bumped to 0.3.0.

**Studio distributes the engine:**
- `prepare-sidecar.mjs` also builds `orender_ffi` and stages the library under `binaries/engine/` (Linux name derived from the ABI major = the library's own soname), bundled as a Tauri resource next to the `orender` CLI sidecar — both built from the same commit, so they can never skew.
- New `engine_deploy` module: on startup, copy the bundled library to `<local data dir>/omniphony/lib` (the per-user path the forked mpv's runtime loader probes), only when bytes differ, via temp file + atomic rename. Best-effort: a locked DLL on Windows retries next launch.
- About shows the engine's C-ABI next to the build fingerprint (`version · ABI 0.5`).

## Why

mpv currently rebuilds and bundles its own liborender at a pinned ref, so two engine copies ship independently and every engine evolution needs an mpv rebuild. With this PR + the mpv-side dlopen loader, updating Studio updates the engine every consumer uses; the runtime handshake rejects incompatible libraries cleanly.

## Verification

- `cargo test` on the touched crates (incl. the new enum-parity test) + full workspace build; `cargo fmt` clean.
- Extended `smoke.c` runs against the debug cdylib (handshake, build id, set_option error contract, enum anchors); made hermetic — it used to pick up the dev machine's real config/bridge and could race a live renderer for the OSC port.
- E2E on Linux: the dlopen mpv build loaded this branch's liborender via the runtime loader and rendered a real object-audio stream to 12ch float; Studio `cargo check` + frontend build + `prepare-sidecar.mjs` staging verified.
- Not yet exercised: Windows/macOS runtime deploy, full Studio bundle first-launch deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)