### PR TITLE
feat(studio): keep the memory diagnostic sampler in-tree, opt-in

### DIFF
--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2195,6 +2195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2572,7 @@ dependencies = [
  "flate2",
  "image",
  "log",
+ "memory-stats",
  "rfd 0.15.4",
  "rosc",
  "serde",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -28,6 +28,15 @@ tokio = { version = "1", features = ["sync", "rt", "macros"] }
 log = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }
 rfd = "0.15"
+# Cross-platform process RSS/virtual memory readout for the opt-in memory
+# sampler (debug_memory_stats command). Tiny, no transitive bloat.
+memory-stats = "1"
+
+[features]
+# Ship WebView DevTools (F12, Inspect, heap snapshots) in RELEASE builds too,
+# for memory hunts on Windows where DevTools is otherwise debug-only:
+#   cargo build --release --features devtools
+devtools = ["tauri/devtools"]
 
 [target.'cfg(windows)'.dependencies]
 # Overlapped pipe I/O for the mpv IPC bridge so writes can't park the
@@ -39,6 +48,8 @@ windows-sys = { version = "0.59", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
     "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp", # process-tree enumeration (debug_memory_stats)
+    "Win32_System_ProcessStatus",        # K32GetProcessMemoryInfo (WebView2 child RSS)
 ] }
 
 [build-dependencies]

--- a/omniphony-studio/src-tauri/src/commands/diag.rs
+++ b/omniphony-studio/src-tauri/src/commands/diag.rs
@@ -76,3 +76,146 @@ pub fn unsubscribe_speaker_gaintable(state: State<SharedState>) {
         },
     );
 }
+
+// ── memory diagnostics ─────────────────────────────────────────────────────
+// Backend for the opt-in memory sampler (src/debug-memory.js). Inert unless
+// invoked; kept in-tree so future memory hunts don't have to rebuild the
+// tooling that localised the 2026-06 WebView2 growth.
+
+/// Diagnostic: current resident/virtual memory of the Studio host process plus,
+/// on Windows, the summed working set of the whole process tree (host + every
+/// WebView2 child). Cross-platform anchor for memory hunts.
+///
+/// `rssBytes`/`virtualBytes` are the HOST process only — on Windows the actual
+/// web content runs in separate `msedgewebview2.exe` children, so a WebView2
+/// leak is invisible there; `treeRssBytes` captures it. (On Linux the WebKit
+/// web process is also separate; `treeRssBytes` is None there because the
+/// enumeration is Windows-only, but `performance.memory` is absent under
+/// WebKitGTK anyway, so Linux runs rely on the WebGL/state counters.)
+#[tauri::command]
+pub fn debug_memory_stats() -> serde_json::Value {
+    let (rss, virt) = match memory_stats::memory_stats() {
+        Some(stats) => (
+            Some(stats.physical_mem as u64),
+            Some(stats.virtual_mem as u64),
+        ),
+        None => (None, None),
+    };
+    serde_json::json!({
+        "rssBytes": rss,
+        "virtualBytes": virt,
+        "treeRssBytes": process_tree_rss_bytes(),
+    })
+}
+
+/// Diagnostic: live sizes of every per-id map in `AppState`. If any of these
+/// climbs without bound during playback, the leak is Rust-side (ids never
+/// recycled); if they stay flat while host RSS climbs, the leak is in the
+/// WebView/emit layer instead.
+#[tauri::command]
+pub fn debug_state_sizes(state: State<SharedState>) -> serde_json::Value {
+    let s = state.inner.lock().unwrap();
+    serde_json::json!({
+        "sources": s.sources.len(),
+        "sourceLevels": s.source_levels.len(),
+        "speakerLevels": s.speaker_levels.len(),
+        "objectSpeakerGains": s.object_speaker_gains.len(),
+        "objectGains": s.object_gains.len(),
+        "objectBandGains": s.object_band_gains.len(),
+        "speakerGains": s.speaker_gains.len(),
+        "objectMutes": s.object_mutes.len(),
+        "speakerMutes": s.speaker_mutes.len(),
+        "layouts": s.layouts.len(),
+    })
+}
+
+/// Diagnostic: persist the memory-sampler CSV to a file so a clean capture can
+/// be taken with DevTools CLOSED (DevTools itself runs inside WebView2 and
+/// inflates the very process tree we are measuring). Overwrites a fixed file in
+/// the user's Downloads dir each call; returns the path.
+#[tauri::command]
+pub fn debug_write_memory_csv(app: tauri::AppHandle, csv: String) -> Result<String, String> {
+    use tauri::Manager;
+    let dir = app
+        .path()
+        .download_dir()
+        .or_else(|_| app.path().app_log_dir())
+        .map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join("omniphony-memory.csv");
+    std::fs::write(&path, csv).map_err(|e| e.to_string())?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+#[cfg(not(windows))]
+fn process_tree_rss_bytes() -> Option<u64> {
+    None
+}
+
+/// Sum the working-set size of this process and all of its descendants. On
+/// Windows the WebView2 renderer/GPU/utility processes are children of the
+/// Studio host, so this is where a WebView2-side leak actually shows up.
+#[cfg(windows)]
+fn process_tree_rss_bytes() -> Option<u64> {
+    use std::collections::HashSet;
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows_sys::Win32::System::ProcessStatus::{
+        K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcessId, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return None;
+        }
+
+        // (pid, parent_pid) for every process, so we can walk our subtree.
+        let mut pairs: Vec<(u32, u32)> = Vec::new();
+        let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                pairs.push((entry.th32ProcessID, entry.th32ParentProcessID));
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+
+        // Transitive closure of descendants of the current process.
+        let mut tree: HashSet<u32> = HashSet::new();
+        tree.insert(GetCurrentProcessId());
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for &(pid, parent) in &pairs {
+                if pid != 0 && tree.contains(&parent) && tree.insert(pid) {
+                    changed = true;
+                }
+            }
+        }
+
+        let mut total: u64 = 0;
+        for &pid in &tree {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+            if handle.is_null() {
+                continue;
+            }
+            let mut counters: PROCESS_MEMORY_COUNTERS = std::mem::zeroed();
+            counters.cb = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+            if K32GetProcessMemoryInfo(handle, &mut counters, counters.cb) != 0 {
+                total += counters.WorkingSetSize as u64;
+            }
+            CloseHandle(handle);
+        }
+        Some(total)
+    }
+}

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -189,6 +189,9 @@ fn main() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            debug_memory_stats,
+            debug_state_sizes,
+            debug_write_memory_csv,
             get_state,
             get_osc_config,
             renderer_is_local,

--- a/omniphony-studio/src/app.js
+++ b/omniphony-studio/src/app.js
@@ -103,6 +103,11 @@ import {
 } from './speakers.js';
 import { rebuildTrailGeometry, captureTrailPointColor } from './trails.js';
 import { muteSoloCallbacks } from './mute-solo.js';
+import { installMemoryDiagnostics } from './debug-memory.js';
+
+// Memory diagnostics: registers window.omniphonyDebug.memory and samples only
+// when opted in via localStorage 'spatialviz.memory_sampler' (see debug-memory.js).
+installMemoryDiagnostics();
 
 flushCallbacks.renderRoomRatioDisplay = renderRoomRatioDisplay;
 flushCallbacks.renderEvaluationMode = renderEvaluationMode;

--- a/omniphony-studio/src/debug-memory.js
+++ b/omniphony-studio/src/debug-memory.js
@@ -1,0 +1,207 @@
+/**
+ * Memory diagnostic sampler (opt-in).
+ *
+ * Kept in-tree for memory hunts: Windows Studio once climbed from ~200 MB past
+ * 1 GB (native WebView2 growth, fixed by the `state:batch` emit coalescing and
+ * the energy-volume upload throttle). To localise such growth the sampler
+ * separates the three memory pools and traces each over time:
+ *   1. host-process RSS / virtual  (Rust side, via the `debug_memory_stats`
+ *                                   command; on Windows it also sums the whole
+ *                                   process tree — host + WebView2 children —
+ *                                   which is where a WebView2 leak shows up)
+ *   2. WebView JS heap             (`performance.memory`, Chromium/WebView2 only —
+ *                                   absent under WebKitGTK, hence the RSS anchor)
+ *   3. WebGL / Three.js resources  (`renderer.info.memory` geometries/textures +
+ *                                   `renderer.info.programs` — live cumulative
+ *                                   counts, NOT reset by rendering, so a steady
+ *                                   climb is a dispose leak)
+ * Plus the live sizes of every per-id AppState map (`debug_state_sizes`) so a
+ * Rust-side map growth is caught at a glance.
+ *
+ * Whichever curve has an unbounded positive slope is the culprit. The sampler is
+ * itself bounded (ring buffer) so it never contributes to the growth it measures.
+ *
+ * Off by default; nothing runs unless explicitly enabled. Usage (DevTools console):
+ *   localStorage.setItem('spatialviz.memory_sampler', '1')  // auto-start on next launch
+ *   window.omniphonyDebug.memory.start()                    // or start right now
+ *   window.omniphonyDebug.memory.stop()                     // pause sampling
+ *   window.omniphonyDebug.memory.dump()                     // CSV of all samples so far
+ * The CSV also auto-saves to Downloads/omniphony-memory.csv while sampling, so a
+ * clean capture can be taken with DevTools CLOSED (DevTools itself runs inside
+ * WebView2 and inflates the very process tree being measured). Release builds
+ * have no DevTools unless compiled with `cargo build --features devtools`.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { renderer } from './scene/setup.js';
+
+const AUTO_START_KEY = 'spatialviz.memory_sampler';
+
+const SAMPLE_INTERVAL_MS = 2000;
+// 1 h of history at 2 s cadence. The buffer is capped so the diagnostic tool
+// cannot itself leak while hunting a leak.
+const MAX_SAMPLES = 1800;
+
+// Persist the CSV to disk every N samples (see the header note on DevTools).
+const AUTOSAVE_EVERY = 8; // ~16 s at the 2 s sample cadence
+
+const samples = [];
+let intervalId = null;
+let startedAt = 0;
+let tickCount = 0;
+let savedPathLogged = false;
+
+const MB = 1024 * 1024;
+const toMB = (bytes) => (typeof bytes === 'number' ? +(bytes / MB).toFixed(1) : null);
+
+async function takeSample() {
+  const now = Date.now();
+  const elapsedS = startedAt ? +((now - startedAt) / 1000).toFixed(1) : 0;
+
+  // WebGL / Three.js — synchronous, always available.
+  const info = renderer?.info;
+  const geometries = info?.memory?.geometries ?? null;
+  const textures = info?.memory?.textures ?? null;
+  const programs = info?.programs?.length ?? null;
+
+  // JS heap — Chromium/WebView2 only (undefined under WebKitGTK).
+  const jsHeapMB = toMB(performance?.memory?.usedJSHeapSize);
+
+  // Rust host process + AppState map sizes — may throw if Tauri is unavailable
+  // (e.g. a plain browser dev build); fail soft so the WebGL/JS pools still log.
+  let rssMB = null;
+  let virtualMB = null;
+  let treeRssMB = null;
+  let stateSizes = null;
+  try {
+    const mem = await invoke('debug_memory_stats');
+    rssMB = toMB(mem?.rssBytes);
+    virtualMB = toMB(mem?.virtualBytes);
+    treeRssMB = toMB(mem?.treeRssBytes);
+  } catch (_) { /* not in a Tauri host */ }
+  try {
+    stateSizes = await invoke('debug_state_sizes');
+  } catch (_) { /* not in a Tauri host */ }
+
+  const sample = {
+    t: now,
+    elapsedS,
+    rssMB,
+    treeRssMB,
+    virtualMB,
+    jsHeapMB,
+    geometries,
+    textures,
+    programs,
+    state: stateSizes,
+  };
+
+  samples.push(sample);
+  if (samples.length > MAX_SAMPLES) {
+    samples.splice(0, samples.length - MAX_SAMPLES);
+  }
+
+  // One compact line per tick so the trend is visible live in the console.
+  const stateStr = stateSizes
+    ? ` src=${stateSizes.sources} bandGains=${stateSizes.objectBandGains} spkLvl=${stateSizes.speakerLevels}`
+    : '';
+  // eslint-disable-next-line no-console
+  console.log(
+    `[mem] +${elapsedS}s rss=${rssMB}MB tree=${treeRssMB}MB jsHeap=${jsHeapMB}MB`
+      + ` geom=${geometries} tex=${textures} prog=${programs}${stateStr}`
+  );
+
+  tickCount += 1;
+  if (tickCount % AUTOSAVE_EVERY === 0) {
+    saveToFile();
+  }
+}
+
+// Write the current CSV to disk via the Rust host. Returns the path (or null).
+async function saveToFile() {
+  const csv = buildCsv();
+  try {
+    const path = await invoke('debug_write_memory_csv', { csv });
+    if (!savedPathLogged) {
+      savedPathLogged = true;
+      // eslint-disable-next-line no-console
+      console.log(`[mem] CSV auto-saved to: ${path} (overwritten every `
+        + `${(AUTOSAVE_EVERY * SAMPLE_INTERVAL_MS) / 1000}s)`);
+    }
+    return path;
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildCsv() {
+  const header = 't_ms,elapsed_s,rss_mb,tree_rss_mb,virtual_mb,js_heap_mb,geometries,textures,programs,'
+    + 'sources,source_levels,speaker_levels,object_speaker_gains,object_gains,'
+    + 'object_band_gains,speaker_gains,object_mutes,speaker_mutes,layouts';
+  const rows = samples.map((s) => {
+    const st = s.state || {};
+    return [
+      s.t, s.elapsedS, s.rssMB, s.treeRssMB, s.virtualMB, s.jsHeapMB,
+      s.geometries, s.textures, s.programs,
+      st.sources, st.sourceLevels, st.speakerLevels, st.objectSpeakerGains,
+      st.objectGains, st.objectBandGains, st.speakerGains, st.objectMutes,
+      st.speakerMutes, st.layouts,
+    ].map((v) => (v === null || v === undefined ? '' : v)).join(',');
+  });
+  return [header, ...rows].join('\n');
+}
+
+export function startMemorySampler() {
+  if (intervalId) return;
+  startedAt = Date.now();
+  // Immediate first sample so a baseline is recorded at t≈0.
+  takeSample();
+  intervalId = setInterval(takeSample, SAMPLE_INTERVAL_MS);
+  // eslint-disable-next-line no-console
+  console.log(`[mem] sampler started (every ${SAMPLE_INTERVAL_MS / 1000}s) — `
+    + 'use window.omniphonyDebug.memory.dump() for CSV');
+}
+
+export function stopMemorySampler() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * Register the console handle and, if the localStorage opt-in flag is set,
+ * start sampling. Called once at boot; costs a single localStorage read when
+ * the sampler is disabled.
+ */
+export function installMemoryDiagnostics() {
+  if (typeof window === 'undefined') return;
+
+  // Merge into the shared debug handle (visual-recovery.js also writes to it).
+  const existing = window.omniphonyDebug && typeof window.omniphonyDebug === 'object'
+    ? window.omniphonyDebug
+    : {};
+  window.omniphonyDebug = {
+    ...existing,
+    memory: {
+      samples,
+      start: startMemorySampler,
+      stop: stopMemorySampler,
+      dump() {
+        const csv = buildCsv();
+        // eslint-disable-next-line no-console
+        console.log(csv);
+        return csv;
+      },
+      save: saveToFile,
+    },
+  };
+
+  let autoStart = false;
+  try {
+    autoStart = window.localStorage?.getItem(AUTO_START_KEY) === '1';
+  } catch (_) { /* storage unavailable */ }
+  if (autoStart) {
+    startMemorySampler();
+  }
+}


### PR DESCRIPTION
## Summary

Finishes the `diag/studio-memory-leak` branch. The two fixes it produced (the `state:batch` emit coalescing and the energy-volume upload throttle) already landed via #88 — what remained on that branch was the diagnostic instrumentation that localised the Windows WebView2 memory growth, kept around for future hunts. This ports it onto main in a form that is safe to ship, so the branch can be deleted.

- **`src/debug-memory.js`** — 3-pool sampler: host RSS/virtual (Rust command), WebView JS heap (`performance.memory`, WebView2 only), WebGL resource counters (`renderer.info`), plus the live sizes of every per-id `AppState` map. Ring-buffered (1 h) and CSV auto-saved to `Downloads/omniphony-memory.csv` so captures can be taken with DevTools closed (DevTools itself inflates the measured process tree).
- **Opt-in, zero steady-state cost** — nothing samples unless `localStorage 'spatialviz.memory_sampler' = '1'` is set (or `window.omniphonyDebug.memory.start()` from the console). Boot cost when disabled is one localStorage read.
- **Rust commands** `debug_memory_stats`, `debug_state_sizes`, `debug_write_memory_csv` — inert unless invoked. On Windows, `debug_memory_stats` sums the working set of the whole process tree (host + `msedgewebview2.exe` children), which is where WebView2-side growth actually shows up; the host process alone doesn't see it.
- **New cargo feature `devtools`** (`cargo build --release --features devtools`) enables WebView DevTools in release builds for such hunts, instead of the diag branch's approach of hard-enabling it in every build.

## Test plan

- `cargo check` (default) and `cargo check --features devtools` pass; `cargo test` green (7/7).
- `npm run build` (vite) passes.
- Windows-specific process-tree code is unchanged from the diag branch, which was built and used on Windows during the June hunt.

Supersedes `diag/studio-memory-leak`, which will be deleted after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)