### PR TITLE
fix(engine): stop and join OSC threads before engine teardown

### DIFF
--- a/omniphony-renderer/Cargo.toml
+++ b/omniphony-renderer/Cargo.toml
@@ -69,6 +69,18 @@ inherits = "release"
 lto = "thin"
 strip = "symbols"
 
+# Diagnostic-only: a release build that keeps full debug info so the cdylib
+# (orender.dll / liborender.so) symbolizes in a crash dump. Used to investigate
+# the intermittent Windows heap/loader access violations (ucrtbase/ntdll
+# c0000005) under PageHeap. Never ship this — the shipped artifact stays
+# `release-deploy` (stripped). Build with:
+#   cargo build --profile release-debug -p orender_ffi
+# On windows-msvc this emits orender.pdb next to orender.dll.
+[profile.release-debug]
+inherits = "release"
+debug = "full"
+strip = false
+
 [features]
 # Pure-Rust native VBAP backend is the default — no external library required.
 default = []

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -199,6 +199,13 @@ impl PerfLog {
 
 impl Drop for Engine {
     fn drop(&mut self) {
+        // Tear down the OSC server (stop + join its listener/standby threads)
+        // *before* the implicit field drops below free the renderer and bridge
+        // those threads read from. `osc` is declared after `bridge`/`renderer`,
+        // so plain field-order drop would stop the threads last, leaving a
+        // teardown window where a worker could read state mid-free. Explicit so
+        // it can't regress if the field order changes.
+        drop(self.osc.take());
         if let Some(perf) = self.perf.as_mut() {
             perf.flush();
         }

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -821,6 +821,14 @@ impl Drop for OscSender {
         if let Some(handle) = self.listener_thread.lock().unwrap().take() {
             let _ = handle.join();
         }
+        // Also stop + join the standby resume-watch thread if this engine is
+        // dropped while in standby (RX port yielded to an mpv-embedded renderer).
+        // Without this it outlives the OscSender, probing `rx_port` after its
+        // owner is gone — a live thread leaked per destroy/create cycle.
+        self.standby_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.standby_thread.lock().unwrap().take() {
+            let _ = handle.join();
+        }
         // Deregister from the same-process release registry only if we are still
         // the entry there (a successor may have already overwritten it — see
         // `still_port_owner` above, computed atomically at the start of drop).


### PR DESCRIPTION
## Summary

Finishes the `diag/mpv-heap-crash` branch: the two teardown hardenings it produced, plus the diagnostic build profile, ported onto main. (The track-change crash itself — the `ad_orender` `codec_profile` use-after-free — was fixed on the mpv side and shipped in `v0.4.1-1` / `v0.4.1-fel-beta.3`; the startup-crash diagnosis still awaits a symbolized dump and is unaffected by this PR.)

- **`Engine::drop`** now tears down the OSC server (stop + join listener/standby threads) explicitly *before* the implicit field drops free the renderer and bridge those threads read from. `osc` is declared after `bridge`/`renderer`, so plain field-order drop stopped the threads last, leaving a teardown window where a worker could read state mid-free. Making it explicit also prevents regression if the field order changes.
- **`OscSender::drop`** also stops + joins the standby resume-watch thread. Previously an engine dropped while in standby (RX port yielded to an mpv-embedded renderer) leaked one live thread per destroy/create cycle, probing `rx_port` after its owner was gone.
- **New opt-in `[profile.release-debug]`** (inherits release, full debug info, unstripped) so the cdylib symbolizes in crash dumps: `cargo build --profile release-debug -p orender_ffi` (emits `orender.pdb` on windows-msvc). Inert unless selected; shipped artifacts stay `release-deploy` (stripped).

## Test plan

- `cargo fmt --check` clean; `cargo test -p orender_engine`: 95/96 pass locally — the one failure (`maps_a_7_1_4_bed_including_height_channels`) is the known pre-existing hermeticity issue (the test reads `/usr/share/orender/layouts`, populated here by the AUR install) and fails identically on untouched `main`; CI's clean environment is unaffected.
- The OSC drop/standby behaviour is covered by the existing yield/standby drop tests, which pass.

Supersedes `diag/mpv-heap-crash`, which will be deleted after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)