### PR TITLE
fix(tests): don't probe system layout dirs in unit tests

### DIFF
--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -121,22 +121,30 @@ fn load_virtual_bed_layout(file_name: &str) -> Option<SpeakerLayout> {
     // The 5.1 / 7.1 virtual-bed layouts are height-less, so they now live in
     // the layouts/legacy/ subfolder. Try that first, then the historical
     // top-level path (older installs / packaging that still ships them flat).
-    // `mut` is used only on Windows (the %ProgramData% push below).
-    #[cfg_attr(not(windows), allow(unused_mut))]
+    // `mut` is unused when the install-dir pushes below are compiled out.
+    #[cfg_attr(test, allow(unused_mut))]
     let mut bases: Vec<PathBuf> = vec![
         // cwd-relative first — matches the CLI run from the workspace root.
         PathBuf::from("layouts"),
         PathBuf::from("omniphony").join("layouts"),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("layouts"),
-        // Fixed install dirs for the embedded host (mpv has no workspace cwd);
-        // reached only when the cwd-relative lookups miss, so CLI parity holds.
-        PathBuf::from("/usr/lib/orender/layouts"),
-        PathBuf::from("/usr/share/orender/layouts"),
     ];
+    // Fixed install dirs for the embedded host (mpv has no workspace cwd);
+    // reached only when the cwd-relative lookups miss, so CLI parity holds.
+    // Compiled out of unit tests: a system package (e.g. the AUR install)
+    // shipping layouts here made test outcomes depend on machine state — the
+    // installed 7.1.yaml's non-spatialized LFE placeholder pose (z=-0.5)
+    // tripped the virtual-bed pose asserts on hosts with orender installed
+    // while CI's clean environment passed.
+    #[cfg(not(test))]
+    {
+        bases.push(PathBuf::from("/usr/lib/orender/layouts"));
+        bases.push(PathBuf::from("/usr/share/orender/layouts"));
+    }
     // Windows: the embedded host (mpv) has no workspace cwd, and the shared
     // install lives under %ProgramData%\omniphony (machine-wide, same as the
     // config + service). Search its layouts dir so layouts ship/resolve there.
-    #[cfg(windows)]
+    #[cfg(all(windows, not(test)))]
     if let Ok(program_data) = std::env::var("ProgramData") {
         let mut p = PathBuf::from(program_data);
         p.push("omniphony");


### PR DESCRIPTION
## Summary

`orender_engine`'s `maps_a_7_1_4_bed_including_height_channels` failed on any host with the AUR `orender` package installed while passing on CI — a test-hermeticity bug, not a code regression.

`load_virtual_bed_layout` probes cwd-relative candidates, then fixed install dirs (`/usr/lib|share/orender/layouts`, `%ProgramData%\omniphony\layouts` on Windows). Under `cargo test` the cwd-relative candidates never exist (the repo's layouts live at the repo root, not under the crate), so on a machine with the package installed the unit test silently loaded the **shipped** `legacy/7.1.yaml` — whose non-spatialized LFE carries a placeholder pose `(1, 1, -0.5)` — and the "floor channels near ear level" assert panicked on exactly that value. CI has no package installed, falls back to the procedural mapping, and passes.

Fix: compile the install-dir candidates out under `cfg(test)`, so unit tests always exercise the deterministic procedural fallback regardless of machine state. Runtime behaviour (CLI, mpv-embedded host, Windows shared install) is unchanged.

## Test plan

- Before, on a host with the AUR package installed: 102/103 (`maps_a_7_1_4_bed…` panics with `floor channel should be ~level, got [1.0, 1.0, -0.5]`).
- After, same host: **103/103** + doctests green; `cargo fmt --check` clean.
- CI (clean env) exercised the fallback path both before and after — no behaviour change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)