### PR TITLE
feat(binaural): persist head-tracking recenter reference across rebuilds

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -870,6 +870,33 @@ fn persist_output_channel_mapping(
     renderer::config::clear_live_overlay_cache();
 }
 
+/// Persist the head-tracking recenter reference to the on-disk config so the
+/// chosen "forward" survives an engine rebuild (mpv track change) and a restart.
+/// Same targeted, sidecar-clearing write as [`persist_surround_placement`].
+fn persist_head_center(control: &Arc<RendererControl>, reference_quat: [f32; 4]) {
+    let Some(path) = control.config_path() else {
+        return;
+    };
+    persist_head_center_to_path(&path, reference_quat);
+}
+
+fn persist_head_center_to_path(path: &Path, reference_quat: [f32; 4]) {
+    let mut config = renderer::config::Config::load_or_default(path);
+    let render = config.render.get_or_insert_with(Default::default);
+    let bin = render.binaural.get_or_insert_with(Default::default);
+    let ht = bin.head_tracking.get_or_insert_with(Default::default);
+    // Drop the key when back at identity so an "uncentered" tracker leaves a clean
+    // config rather than persisting a no-op quaternion.
+    let identity = renderer::binaural::HeadPose::identity().to_quat_array();
+    ht.reference_quat = (reference_quat != identity).then_some(reference_quat);
+    if let Err(e) = config.save(path) {
+        log::warn!("failed to persist head recenter to {}: {e}", path.display());
+        return;
+    }
+    let _ = std::fs::remove_file(renderer::config::live_sidecar_path(path));
+    renderer::config::clear_live_overlay_cache();
+}
+
 fn apply_control_effects(
     effects: ControlEffects,
     control: &Arc<RendererControl>,
@@ -882,6 +909,9 @@ fn apply_control_effects(
         set_dirty(control, socket, clients);
         let state_bytes = build_live_state_bundle(control, host);
         super::transport::send_raw(socket, clients, &state_bytes);
+    }
+    if let Some(reference_quat) = effects.persist_head_center {
+        persist_head_center(control, reference_quat);
     }
     for update in effects.broadcasts {
         match update.value {
@@ -1278,6 +1308,54 @@ mod tests {
             "unknown key lost: {written}"
         );
         assert!(!sidecar.exists(), "live sidecar not removed");
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn persist_head_center_writes_reference_and_clears_sidecar() {
+        let path = temp_config_path("head-center");
+        std::fs::write(
+            &path,
+            "render:\n  bridge_path: /tmp/libbridge.so\n  binaural:\n    head_tracking:\n      osc_address: /android/rotationvector\n",
+        )
+        .unwrap();
+        let sidecar = renderer::config::live_sidecar_path(&path);
+        std::fs::write(&sidecar, "render:\n  surround_placement: back\n").unwrap();
+
+        let reference = [0.5, 0.5, 0.5, 0.5];
+        persist_head_center_to_path(&path, reference);
+
+        // Written under binaural.head_tracking, the existing osc_address kept,
+        // bridge_path preserved, and the stale sidecar removed.
+        let cfg = renderer::config::Config::load_or_default(&path);
+        let ht = cfg
+            .render
+            .as_ref()
+            .and_then(|r| r.binaural.as_ref())
+            .and_then(|b| b.head_tracking.as_ref())
+            .expect("head_tracking present");
+        assert_eq!(ht.reference_quat, Some(reference));
+        assert_eq!(ht.osc_address.as_deref(), Some("/android/rotationvector"));
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .contains("bridge_path: /tmp/libbridge.so"),
+            "known key lost"
+        );
+        assert!(!sidecar.exists(), "live sidecar not removed");
+
+        // Recentering back to identity drops the key entirely.
+        let identity = renderer::binaural::HeadPose::identity().to_quat_array();
+        persist_head_center_to_path(&path, identity);
+        let cfg = renderer::config::Config::load_or_default(&path);
+        let ht = cfg
+            .render
+            .as_ref()
+            .and_then(|r| r.binaural.as_ref())
+            .and_then(|b| b.head_tracking.as_ref())
+            .expect("head_tracking present");
+        assert_eq!(ht.reference_quat, None, "identity should omit the key");
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -657,6 +657,14 @@ pub fn build_spatial_renderer(
                     {
                         live.binaural.tracking.format = fmt;
                     }
+                    // Restore the persisted recenter reference so the centering
+                    // survives an engine rebuild (mpv track change) and a restart.
+                    // `head_pose`/`last_raw` stay at their defaults: the first
+                    // incoming OSC packet re-derives the centered pose.
+                    if let Some(q) = ht.reference_quat {
+                        live.binaural.tracking.reference =
+                            renderer::binaural::HeadPose::from_quat_array(q);
+                    }
                 }
                 // HRIR source: a "sofa" selector resolves its path from
                 // `hrtf_sofa_path` (or an inline "sofa:<path>").

--- a/omniphony-renderer/renderer/src/binaural/head_pose.rs
+++ b/omniphony-renderer/renderer/src/binaural/head_pose.rs
@@ -52,6 +52,16 @@ impl HeadPose {
         }
     }
 
+    /// Quaternion components as `[w, x, y, z]`, for compact config storage.
+    pub fn to_quat_array(self) -> [f32; 4] {
+        [self.w, self.x, self.y, self.z]
+    }
+
+    /// Rebuild from a `[w, x, y, z]` array (normalising, see [`Self::from_quat`]).
+    pub fn from_quat_array(a: [f32; 4]) -> Self {
+        Self::from_quat(a[0], a[1], a[2], a[3])
+    }
+
     /// Build from intrinsic yaw→pitch→roll Euler angles in degrees.
     ///
     /// Axis convention (ADM): yaw about +Z (turn left/right), pitch about +X

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -425,6 +425,11 @@ pub struct HeadTrackingConfig {
     /// Orientation value format: `"auto"` (default), `"quat"`, `"rotvec"`, `"euler"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
+    /// Recenter "forward" reference quaternion `[w, x, y, z]`, persisted so the
+    /// chosen centering survives an engine rebuild (mpv track change) or restart.
+    /// Absent until the tracker has been recentered (identity = uncentered).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_quat: Option<[f32; 4]>,
     /// See `Config::extra` — preserve unknown keys through round-trips.
     #[serde(flatten, default, skip_serializing_if = "Mapping::is_empty")]
     pub extra: Mapping,
@@ -802,6 +807,28 @@ mod tests {
         assert_eq!(rc.room_ratio.as_deref(), Some("1.0,2.000000,1.000000"));
         assert_eq!(rc.room_ratio_rear, Some(1.0));
         assert_eq!(rc.room_ratio_lower, Some(0.5));
+    }
+
+    #[test]
+    fn head_tracking_reference_quat_round_trips_and_omits_when_absent() {
+        // Present: serializes and parses back equal.
+        let ht = HeadTrackingConfig {
+            osc_address: Some("/android/rotationvector".to_string()),
+            reference_quat: Some([0.5, 0.5, 0.5, 0.5]),
+            ..Default::default()
+        };
+        let yaml = serde_yaml_ng::to_string(&ht).unwrap();
+        assert!(yaml.contains("reference_quat"), "field not written: {yaml}");
+        let back: HeadTrackingConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back.reference_quat, Some([0.5, 0.5, 0.5, 0.5]));
+
+        // Absent: the key is skipped entirely.
+        let bare = HeadTrackingConfig::default();
+        let yaml = serde_yaml_ng::to_string(&bare).unwrap();
+        assert!(
+            !yaml.contains("reference_quat"),
+            "None should omit the key: {yaml}"
+        );
     }
 
     #[test]

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -54,6 +54,10 @@ pub struct ControlEffects {
     pub evaluation_only: bool,
     pub broadcasts: Vec<BroadcastUpdate>,
     pub log_message: Option<String>,
+    /// Head-tracking recenter reference `[w, x, y, z]` to write straight to
+    /// `config.yaml` (systematic save, like `surround_placement`). The engine
+    /// layer performs the I/O in `apply_control_effects`.
+    pub persist_head_center: Option<[f32; 4]>,
 }
 
 // AdaptiveResamplingPatch / AudioConfigPatch / LiveInputPatch / InputConfigPatch
@@ -1051,6 +1055,9 @@ pub fn apply_simple_osc_control(
         let mut live = ctx.renderer.live.write();
         live.binaural.tracking.recenter();
         live.binaural.head_pose = renderer::binaural::HeadPose::identity();
+        // Persist the new reference to config right away so the centering survives
+        // an engine rebuild (mpv track change) and a restart.
+        effects.persist_head_center = Some(live.binaural.tracking.reference.to_quat_array());
         effects.mark_dirty = true;
         effects.log_message = Some("OSC: head/recenter".to_string());
         return Some(effects);

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -254,6 +254,13 @@ pub fn save_live_config_to_path(
         head_tracking: Some(renderer::config::HeadTrackingConfig {
             osc_address: live.binaural.tracking.address.clone(),
             format: Some(live.binaural.tracking.format.as_str().to_string()),
+            reference_quat: {
+                // Carry the recenter reference through an explicit Save too (the
+                // targeted write-back already persists it on recenter); omit when
+                // back at identity to keep the YAML clean.
+                let r = live.binaural.tracking.reference;
+                (r != renderer::binaural::HeadPose::identity()).then(|| r.to_quat_array())
+            },
             extra: Default::default(),
         }),
         reflections: Some(renderer::config::ReflectionsConfig {


### PR DESCRIPTION
## Summary

Lands the parked `fix/head-tracking-recenter-persist` branch (2026-06-26), rebased cleanly onto current main (no conflicts with the binaural-audit changes).

The head-tracking recenter reference (the "this is straight ahead" quaternion captured when the user recenters) was held only in the live head-pose state, so any renderer rebuild — topology change, config reload, engine restart — silently forgot the calibration and the user had to recenter again. This persists the reference quaternion through the config layer and restores it on rebuild:

- `head_pose.rs`: `to_quat_array`/`from_quat_array` round-trip helpers.
- `config.rs`: optional `reference_quat` field (omitted from YAML when absent).
- OSC dispatch: `persist_head_center` control persists the reference and clears the sidecar; covered by new unit tests (round-trip + omit-when-absent + sidecar clear).

## Test plan

- `cargo test -p orender_engine -p renderer -p runtime_control`: 104 + 198 + 10 green, including the branch's new tests; `cargo fmt --check` clean.
- E2E with a live tracker (nxosc) still to be done ear/eyes-on — same status as the rest of the head-tracking stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)