### PR TITLE
refactor: remove the abandoned per-object output gain control

### DIFF
--- a/omniphony-renderer/OSC_PROTOCOL.md
+++ b/omniphony-renderer/OSC_PROTOCOL.md
@@ -166,7 +166,6 @@ Sequenced realtime controls use `latest-wins` semantics:
 
 - `/omniphony/control/realtime/master_gain [f32 value, i32 seq]`
 - `/omniphony/control/realtime/speaker_gain [i32 id, f32 value, i32 seq]`
-- `/omniphony/control/realtime/object_gain [s id, f32 value, i32 seq]`
 
 Serialized config-domain controls use JSON patches:
 
@@ -182,7 +181,6 @@ Canonical acknowledgements:
 
 - `/omniphony/state/realtime/master_gain [f32 value, i32 seq]`
 - `/omniphony/state/realtime/speaker_gain [i32 id, f32 value, i32 seq]`
-- `/omniphony/state/realtime/object_gain [s id, f32 value, i32 seq]`
 
 Common control addresses include:
 

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -30,7 +30,6 @@ use super::transport::{
 pub(crate) struct RealtimeSeqState {
     pub master_gain: Option<i32>,
     pub speaker_gain: HashMap<usize, i32>,
-    pub object_gain: HashMap<String, i32>,
 }
 
 pub(crate) fn handle_control_message(
@@ -535,71 +534,6 @@ pub(crate) fn handle_control_message(
         })) {
             super::transport::send_raw(socket, clients, &bytes);
         }
-        return;
-    }
-
-    if addr == osc_contract::CONTROL_REALTIME_OBJECT_GAIN {
-        let Some(id) = msg.args.first().and_then(|arg| match arg {
-            OscType::String(v) => {
-                let trimmed = v.trim();
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(trimmed.to_string())
-                }
-            }
-            OscType::Int(v) if *v >= 0 => Some(v.to_string()),
-            OscType::Float(v) if *v >= 0.0 => Some((*v as i32).to_string()),
-            _ => None,
-        }) else {
-            return;
-        };
-        let Some(value) = msg.args.get(1).and_then(|arg| match arg {
-            OscType::Float(v) => Some(*v),
-            OscType::Int(v) => Some(*v as f32),
-            _ => None,
-        }) else {
-            return;
-        };
-        let Some(seq) = msg.args.get(2).and_then(|arg| match arg {
-            OscType::Int(v) => Some(*v),
-            _ => None,
-        }) else {
-            return;
-        };
-        if realtime_seq
-            .object_gain
-            .get(&id)
-            .copied()
-            .is_some_and(|last| seq < last)
-        {
-            return;
-        }
-        let Ok(idx) = id.parse::<usize>() else {
-            return;
-        };
-        let clamped = value.clamp(0.0, 2.0);
-        realtime_seq.object_gain.insert(id.clone(), seq);
-        control.live.write().objects.entry(idx).or_default().gain = clamped;
-        control.mark_object_params_dirty();
-        control.mark_dirty();
-        broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
-        if let Ok(bytes) = rosc::encoder::encode(&rosc::OscPacket::Message(rosc::OscMessage {
-            addr: osc_contract::STATE_REALTIME_OBJECT_GAIN.to_string(),
-            args: vec![
-                OscType::String(id.clone()),
-                OscType::Float(clamped),
-                OscType::Int(seq),
-            ],
-        })) {
-            super::transport::send_raw(socket, clients, &bytes);
-        }
-        broadcast_float(
-            socket,
-            clients,
-            &format!("/omniphony/state/object/{idx}/gain"),
-            clamped,
-        );
         return;
     }
 

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -375,18 +375,13 @@ impl Default for BinauralLiveParams {
 /// Live-tunable parameters for a single input object (bed or audio object).
 #[derive(Clone)]
 pub struct ObjectLiveParams {
-    /// Linear gain override (default 1.0 = unity).
-    pub gain: f32,
     /// Mute flag; when true the object is silenced.
     pub muted: bool,
 }
 
 impl Default for ObjectLiveParams {
     fn default() -> Self {
-        Self {
-            gain: 1.0,
-            muted: false,
-        }
+        Self { muted: false }
     }
 }
 
@@ -512,8 +507,8 @@ pub struct LiveParams {
     /// Master output gain, linear scale (1.0 = unity, 0.5 ≈ −6 dB).
     pub master_gain: f32,
 
-    /// Per-object live parameters (gain, mute).
-    /// Absent entries use `ObjectLiveParams::default()` (gain=1.0, muted=false).
+    /// Per-object live parameters (mute).
+    /// Absent entries use `ObjectLiveParams::default()` (muted=false).
     pub objects: HashMap<usize, ObjectLiveParams>,
 
     /// Minimum spread applied when the object spread value is 0.0.

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -648,10 +648,11 @@ impl SpatialRenderer {
             {
                 let mut states = self.channel_states.lock();
                 for c in 0..input_channel_count {
+                    // Object-level mute as a 0/1 factor (per-object output gain was
+                    // removed; only mute remains live-tunable).
                     let obj_gain = match self.object_params_buf.get(c) {
                         Some(o) if o.muted => 0.0,
-                        Some(o) => o.gain,
-                        None => 1.0,
+                        _ => 1.0,
                     };
                     // Stream metadata gain, same semantics as the VBAP path:
                     // silent (-128 = -inf dB) until the first metadata arrives.
@@ -855,11 +856,10 @@ impl SpatialRenderer {
 
         // Process each channel
         for input_channel_idx in 0..input_channel_count {
-            // Per-channel mute (applies to beds and objects).
+            // Per-channel mute (applies to beds and objects), as a 0/1 factor.
             let obj_gain = match live.object_params.get(input_channel_idx) {
                 Some(o) if o.muted => 0.0,
-                Some(o) => o.gain,
-                None => 1.0,
+                _ => 1.0,
             };
 
             // Get gain from cached metadata (common for ALL channels - beds and objects)

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -1668,29 +1668,6 @@ pub fn apply_simple_osc_control(
     }
 
     if let Some(rest) = addr.strip_prefix("/omniphony/control/object/") {
-        if let Some(idx_str) = rest.strip_suffix("/gain") {
-            if let Ok(idx) = idx_str.parse::<usize>() {
-                if let Some(gain) =
-                    parse_f32_arg(msg.args.first()).map(|value| value.clamp(0.0, 2.0))
-                {
-                    ctx.renderer
-                        .live
-                        .write()
-                        .objects
-                        .entry(idx)
-                        .or_default()
-                        .gain = gain;
-                    ctx.renderer.mark_object_params_dirty();
-                    effects.mark_dirty = true;
-                    effects.broadcasts.push(BroadcastUpdate {
-                        addr: format!("/omniphony/state/object/{}/gain", idx),
-                        value: BroadcastValue::Float(gain),
-                    });
-                    effects.log_message = Some(format!("OSC: object[{}] gain → {}", idx, gain));
-                }
-            }
-            return Some(effects);
-        }
         if let Some(idx_str) = rest.strip_suffix("/mute") {
             if let Ok(idx) = idx_str.parse::<usize>() {
                 if let Some(muted) = parse_bool_arg(msg.args.first()) {

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -155,7 +155,6 @@ pub const CONTROL_OVERLAY_TRAILS: &str = "/omniphony/control/overlay/trails";
 pub const CONTROL_QUIT: &str = "/omniphony/control/quit";
 pub const CONTROL_RAMP_MODE: &str = "/omniphony/control/ramp_mode";
 pub const CONTROL_REALTIME_MASTER_GAIN: &str = "/omniphony/control/realtime/master_gain";
-pub const CONTROL_REALTIME_OBJECT_GAIN: &str = "/omniphony/control/realtime/object_gain";
 pub const CONTROL_REALTIME_SPEAKER_GAIN: &str = "/omniphony/control/realtime/speaker_gain";
 pub const CONTROL_RELOAD_CONFIG: &str = "/omniphony/control/reload_config";
 pub const CONTROL_RENDER_BACKEND: &str = "/omniphony/control/render_backend";
@@ -229,7 +228,6 @@ pub const STATE_MONITORING: &str = "/omniphony/state/monitoring";
 pub const STATE_OSC_DIAG: &str = "/omniphony/state/osc/diag";
 pub const STATE_OSC_METERING: &str = "/omniphony/state/osc/metering";
 pub const STATE_REALTIME_MASTER_GAIN: &str = "/omniphony/state/realtime/master_gain";
-pub const STATE_REALTIME_OBJECT_GAIN: &str = "/omniphony/state/realtime/object_gain";
 pub const STATE_REALTIME_SPEAKER_GAIN: &str = "/omniphony/state/realtime/speaker_gain";
 pub const STATE_RENDER_ABI: &str = "/omniphony/state/render/abi";
 pub const STATE_RENDER_BRIDGE_ERROR: &str = "/omniphony/state/render/bridge_error";
@@ -353,7 +351,6 @@ pub const ALL_CONTROL: &[&str] = &[
     CONTROL_QUIT,
     CONTROL_RAMP_MODE,
     CONTROL_REALTIME_MASTER_GAIN,
-    CONTROL_REALTIME_OBJECT_GAIN,
     CONTROL_REALTIME_SPEAKER_GAIN,
     CONTROL_RELOAD_CONFIG,
     CONTROL_RENDER_BACKEND,
@@ -415,7 +412,6 @@ pub const ALL_STATE: &[&str] = &[
     STATE_OSC_DIAG,
     STATE_OSC_METERING,
     STATE_REALTIME_MASTER_GAIN,
-    STATE_REALTIME_OBJECT_GAIN,
     STATE_REALTIME_SPEAKER_GAIN,
     STATE_RENDER_ABI,
     STATE_RENDER_BRIDGE_ERROR,

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -282,7 +282,7 @@ fn build_renderer_capabilities_json(has_audio: bool, has_input: bool) -> String 
         "variant": if has_audio { "standalone" } else { "embedded" },
         "host": if has_audio { "cli" } else { "mpv" },
         "domains": domains,
-        "realtime": ["master_gain", "speaker_gain", "object_gain"],
+        "realtime": ["master_gain", "speaker_gain"],
         "spatial": true,
         "metering": true,
         "controlConfig": control_config
@@ -597,12 +597,6 @@ pub fn build_live_state_bundle(
     let mut all_messages = messages;
 
     for (&idx, obj) in &live.objects {
-        if obj.gain != 1.0 {
-            all_messages.push(OscPacket::Message(OscMessage {
-                addr: format!("/omniphony/state/object/{}/gain", idx),
-                args: vec![OscType::Float(obj.gain)],
-            }));
-        }
         if obj.muted {
             all_messages.push(OscPacket::Message(OscMessage {
                 addr: format!("/omniphony/state/object/{}/mute", idx),

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -316,8 +316,6 @@ pub struct AppState {
     pub master_level: Option<Meter>,
     #[serde(rename = "objectSpeakerGains")]
     pub object_speaker_gains: HashMap<String, Vec<f64>>,
-    #[serde(rename = "objectGains")]
-    pub object_gains: HashMap<String, f64>,
     #[serde(rename = "speakerGains")]
     pub speaker_gains: HashMap<String, f64>,
     #[serde(rename = "objectMutes")]
@@ -659,7 +657,6 @@ impl Default for AppState {
             speaker_levels: HashMap::new(),
             master_level: None,
             object_speaker_gains: HashMap::new(),
-            object_gains: HashMap::new(),
             speaker_gains: HashMap::new(),
             object_mutes: HashMap::new(),
             speaker_mutes: HashMap::new(),

--- a/omniphony-studio/src-tauri/src/commands/diag.rs
+++ b/omniphony-studio/src-tauri/src/commands/diag.rs
@@ -120,7 +120,6 @@ pub fn debug_state_sizes(state: State<SharedState>) -> serde_json::Value {
         "sourceLevels": s.source_levels.len(),
         "speakerLevels": s.speaker_levels.len(),
         "objectSpeakerGains": s.object_speaker_gains.len(),
-        "objectGains": s.object_gains.len(),
         "objectBandGains": s.object_band_gains.len(),
         "speakerGains": s.speaker_gains.len(),
         "objectMutes": s.object_mutes.len(),

--- a/omniphony-studio/src-tauri/src/commands/gain.rs
+++ b/omniphony-studio/src-tauri/src/commands/gain.rs
@@ -38,23 +38,6 @@ pub fn control_object_mute(state: State<SharedState>, id: i32, muted: i32) {
 }
 
 #[tauri::command]
-pub fn control_object_gain(state: State<SharedState>, id: String, gain: f32) {
-    let clamped = gain.clamp(0.0, 2.0);
-    let seq = state.realtime_seq.fetch_add(1, Ordering::Relaxed) + 1;
-    send_control(
-        &state.osc_tx,
-        OscControlMsg::SendArgs {
-            address: "/omniphony/control/realtime/object_gain".to_string(),
-            args: vec![
-                rosc::OscType::String(id),
-                rosc::OscType::Float(clamped),
-                rosc::OscType::Int(seq),
-            ],
-        },
-    );
-}
-
-#[tauri::command]
 pub fn control_speaker_mute(state: State<SharedState>, id: i32, muted: i32) {
     send_json_control(
         &state.osc_tx,

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -220,7 +220,6 @@ fn main() {
             export_layout_to_path,
             control_speaker_gain,
             control_object_mute,
-            control_object_gain,
             control_speaker_mute,
             control_master_gain,
             control_loudness,

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -1797,7 +1797,6 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                     s.source_levels.remove(id);
                     s.object_speaker_gains.remove(id);
                     s.object_band_gains.remove(id);
-                    s.object_gains.remove(id);
                     if !is_reset {
                         s.object_mutes.remove(id);
                     }
@@ -1875,7 +1874,6 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                 s.source_levels.remove(&id);
                 s.object_speaker_gains.remove(&id);
                 s.object_band_gains.remove(&id);
-                s.object_gains.remove(&id);
                 s.object_mutes.remove(&id);
                 (
                     Some(("source:remove", serde_json::json!({ "id": id }))),
@@ -1988,13 +1986,6 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                         "speaker:gain",
                         serde_json::json!({ "id": id, "gain": gain }),
                     )),
-                    removed_ids,
-                )
-            }
-            OscEvent::StateObjectGain { id, gain } => {
-                s.object_gains.insert(id.clone(), gain);
-                (
-                    Some(("object:gain", serde_json::json!({ "id": id, "gain": gain }))),
                     removed_ids,
                 )
             }
@@ -2304,17 +2295,6 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                     removed_ids,
                 )
             }
-            OscEvent::StateRealtimeObjectGain { id, value, .. } => {
-                s.object_gains.insert(id.clone(), value);
-                (
-                    Some((
-                        "object:gain",
-                        serde_json::json!({ "id": id, "gain": value }),
-                    )),
-                    removed_ids,
-                )
-            }
-
             OscEvent::StateLatency { value } => {
                 let rounded = s.set_latency_value(value);
                 (

--- a/omniphony-studio/src-tauri/src/osc_parser.rs
+++ b/omniphony-studio/src-tauri/src/osc_parser.rs
@@ -188,8 +188,6 @@ pub enum OscEvent {
 
     #[serde(rename = "state:speaker:gain")]
     StateSpeakerGain { id: String, gain: f64 },
-    #[serde(rename = "state:object:gain")]
-    StateObjectGain { id: String, gain: f64 },
     #[serde(rename = "state:speaker:delay")]
     StateSpeakerDelay { id: String, delay_ms: f64 },
     #[serde(rename = "state:object:mute")]
@@ -243,8 +241,6 @@ pub enum OscEvent {
     StateRealtimeMasterGain { value: f64, seq: i32 },
     #[serde(rename = "state:realtime:speaker_gain")]
     StateRealtimeSpeakerGain { id: String, value: f64, seq: i32 },
-    #[serde(rename = "state:realtime:object_gain")]
-    StateRealtimeObjectGain { id: String, value: f64, seq: i32 },
     #[serde(rename = "state:latency")]
     StateLatency { value: f64 },
     #[serde(rename = "state:latency:instant")]
@@ -689,11 +685,6 @@ fn parse_omniphony_state(parts: &[&str], args: &[f64], raw_args: &[OscType]) -> 
                 value: to_number(args.get(1).copied()?)?,
                 seq: to_number(args.get(2).copied()?)? as i32,
             }),
-            "object_gain" => Some(OscEvent::StateRealtimeObjectGain {
-                id: raw_args.first().and_then(unwrap_string)?,
-                value: to_number(args.get(1).copied()?)?,
-                seq: to_number(args.get(2).copied()?)? as i32,
-            }),
             _ => None,
         },
         (5, "debug") if parts[3] == "speaker_gaintable" => match parts[4] {
@@ -871,11 +862,6 @@ fn parse_omniphony_state(parts: &[&str], args: &[f64], raw_args: &[OscType]) -> 
             enabled: to_number(args[0])? != 0.0,
         }),
         (5, kind) if kind == "object" || kind == "speaker" => match parts[4] {
-            "gain" if kind == "object" => {
-                let id = parts[3].to_string();
-                let gain = clamp(to_number(args[0])?, 0.0, 2.0);
-                Some(OscEvent::StateObjectGain { id, gain })
-            }
             "gain" if kind == "speaker" => {
                 let id = parts[3].parse::<u32>().ok()?.to_string();
                 let gain = clamp(to_number(args[0])?, 0.0, 2.0);

--- a/omniphony-studio/src/debug-memory.js
+++ b/omniphony-studio/src/debug-memory.js
@@ -136,7 +136,7 @@ async function saveToFile() {
 
 function buildCsv() {
   const header = 't_ms,elapsed_s,rss_mb,tree_rss_mb,virtual_mb,js_heap_mb,geometries,textures,programs,'
-    + 'sources,source_levels,speaker_levels,object_speaker_gains,object_gains,'
+    + 'sources,source_levels,speaker_levels,object_speaker_gains,'
     + 'object_band_gains,speaker_gains,object_mutes,speaker_mutes,layouts';
   const rows = samples.map((s) => {
     const st = s.state || {};
@@ -144,7 +144,7 @@ function buildCsv() {
       s.t, s.elapsedS, s.rssMB, s.treeRssMB, s.virtualMB, s.jsHeapMB,
       s.geometries, s.textures, s.programs,
       st.sources, st.sourceLevels, st.speakerLevels, st.objectSpeakerGains,
-      st.objectGains, st.objectBandGains, st.speakerGains, st.objectMutes,
+      st.objectBandGains, st.speakerGains, st.objectMutes,
       st.speakerMutes, st.layouts,
     ].map((v) => (v === null || v === undefined ? '' : v)).join(',');
   });


### PR DESCRIPTION
## Summary

Lands the parked `refactor/drop-per-object-output-gain` branch (2026-06-26), rebased onto current main. Removes the abandoned per-object output gain control end to end: OSC dispatch + contract, live params, snapshot, Studio commands/parser/state and the OSC protocol doc — 14 files, −173 lines, no functional replacement (the control was never adopted; per-band gains and object mutes are the surviving mechanisms).

Two rebase adaptations beyond the original commit:
- Purged the `object_gains` references that the memory-diagnostics PR #171 had added meanwhile (`debug_state_sizes` field + sampler CSV column) — the branch wouldn't have compiled otherwise.
- Preserved #176's `is_reset` guard around the `object_mutes` removal in the stale-source loop while dropping the adjacent `object_gains` removal (the only textual conflict).

## Test plan

- Renderer workspace: `cargo test -p orender_engine -p renderer -p runtime_control` — 104 + 2 + 198 + 10 green, `cargo fmt --check` clean.
- Studio: src-tauri crate 7/7 (not compiled by ci.yml — local check is the gate), `npm run build` (vite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)