### PR TITLE
Live-options registry core (RFC phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,16 @@ jobs:
         working-directory: omniphony-studio
         run: npm run lint:dead
 
+      # Options-schema contract: the renderer dumps its declared live options
+      # (registry rows); every option must resolve its Studio i18n keys. Hard
+      # gate — an option declared engine-side but invisible to the UI is the
+      # silent-omission class the registry exists to kill.
+      - name: Check options-schema ↔ Studio contract
+        run: |
+          cargo run -q -p renderer --example dump_options_schema \
+            --manifest-path omniphony-renderer/Cargo.toml > /tmp/options-schema.json
+          node omniphony-studio/scripts/check-options-schema.mjs /tmp/options-schema.json
+
   build-macos:
     # macOS arm64 compile gate. The renderer workspace pulls the CoreAudio
     # output backend (cpal) and the `sys` signal/IO layer, both of which carry

--- a/docs/live-options-registry.md
+++ b/docs/live-options-registry.md
@@ -14,9 +14,12 @@ Progress:
   bootstrap and `Engine::from_paths`; one shared store used by the full save
   and the targeted persists; the snapshot `options` block + the
   `/state/options_schema` publication; the Tauri/JS `options` passthrough; and
-  the options-schema ↔ Studio i18n contract check in CI. The
-  `options_epoch` counter exists on `RendererControl`; the `PlanSig`s migrate
-  onto it in a follow-up (they are owned by files an open engine PR touches).
+  the options-schema ↔ Studio i18n contract check in CI. The plan
+  signatures compare `RendererControl::options_epoch` — bumped by
+  `options::apply_to_control` only when a `REPLAN`-flagged option **actually
+  changes value** (a redundant re-send must not re-prime the stages) — instead
+  of enumerating options field by field, so a new re-planning option cannot be
+  forgotten in a signature.
 - **Next (phase 2)**: the Studio `data-option` binder reading `app.options` +
   the published schema, replacing the typed `LiveOptionsState` mirror and the
   hand-written listeners for simple controls.

--- a/docs/live-options-registry.md
+++ b/docs/live-options-registry.md
@@ -1,12 +1,35 @@
 # RFC: a declared registry for live options
 
 Status: accepted — written after the Side/Back state-sync bug (see "The
-incident" below); related fix: `fix/studio-live-options-state-sync`. Phase 0
-(safety nets) has landed: the live-options conformance net
-(`omniphony-renderer/runtime_control/tests/live_options_conformance.rs`) and
-the knip dead-code gate in the Studio CI. The registry itself (phases 1+) is
-next; the options-schema contract check lands with it (it needs the registry
-to dump the schema).
+incident" below); related fix: `fix/studio-live-options-state-sync`.
+
+Progress:
+
+- **Phase 0 landed**: the live-options conformance net
+  (`omniphony-renderer/runtime_control/tests/live_options_conformance.rs`) and
+  the knip dead-code gate in the Studio CI.
+- **Phase 1 landed**: the registry itself (`renderer/src/options.rs`) with the
+  2D-sources family migrated; the generic `/omniphony/control/option` setter
+  (legacy addresses are aliases); one shared config seed used by BOTH the CLI
+  bootstrap and `Engine::from_paths`; one shared store used by the full save
+  and the targeted persists; the snapshot `options` block + the
+  `/state/options_schema` publication; the Tauri/JS `options` passthrough; and
+  the options-schema ↔ Studio i18n contract check in CI. The
+  `options_epoch` counter exists on `RendererControl`; the `PlanSig`s migrate
+  onto it in a follow-up (they are owned by files an open engine PR touches).
+- **Next (phase 2)**: the Studio `data-option` binder reading `app.options` +
+  the published schema, replacing the typed `LiveOptionsState` mirror and the
+  hand-written listeners for simple controls.
+
+## Adding a live option today (post-phase-1)
+
+1. Add the typed field to `LiveParams` (+ its `RenderConfig`/`config_fields`
+   descriptor).
+2. Add ONE `OptionSpec` row in `renderer/src/options.rs` (+ Studio i18n keys).
+3. Done: OSC (generic + schema), persistence, CLI/FFI seeding, the snapshot
+   block and the CI contract checks all derive from the row. The conformance
+   net fails if a layer is missing; UI wiring is still hand-written until the
+   phase-2 binder.
 
 ## The problem
 
@@ -95,7 +118,7 @@ lookups or allocation in the audio thread, matching the realtime rules.
 
 ### 2. Everything else derived, once
 
-- **OSC**: one generic `/omniphony/control/opt <key> <value>` handler
+- **OSC**: one generic `/omniphony/control/option <key> <value>` handler
   validating against the spec. Existing addresses stay as aliases until
   migration completes.
 - **Persist + seed**: one generic save (options flagged `PERSIST`) and one

--- a/docs/osc-control-contract.md
+++ b/docs/osc-control-contract.md
@@ -163,7 +163,8 @@ and heatmap configuration.
 | `/control/debug/speaker_gaintable/nack` | … | Request missing chunks / version. |
 | `/control/log_level` | s | `off`\|`error`\|`warn`\|`info`\|`debug`\|`trace`. |
 | `/control/ramp_mode` | s | `off` \| `frame` \| `sample`. |
-| `/control/channel_render_mode` | s | `host` \| `direct` \| `virtual`. Render mode for non-object content. |
+| `/control/channel_render_mode` | s | `spatial` \| `host` (legacy `direct`/`virtual` load as `spatial`). Render mode for non-object content. Legacy alias of `/control/option`. |
+| `/control/option` | s key, value | Generic setter for any declared live option (`renderer::options` registry; schema on `/state/options_schema`). The dedicated addresses (`channel_render_mode`, `surround_placement`, `output_channel_mapping`, `object_generator`, `phantom_extract`) are aliases of this. |
 | `/control/save_config` | — | Persist the current config. |
 | `/control/reload_config` | — | Reload config from disk. |
 | `/control/quit` | — | Shut the engine down. |
@@ -172,6 +173,11 @@ and heatmap configuration.
 ---
 
 ## State — engine → clients
+
+`/state/options_schema` carries the declared live-options schema (JSON:
+`[{key, kind, values?, default, flags, i18nKey, helpI18nKey?}]`), mirroring the
+generator/phantom param-schema pattern; option values ride in the `options`
+block of the renderer snapshot.
 
 The full state snapshot is published as `/omniphony/state/renderer` (JSON);
 individual deltas use the addresses below. `osc_contract::ALL_STATE` is the

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -456,63 +456,14 @@ impl Engine {
         control.set_requested_ramp_mode(ramp_mode);
         control.live.write().ramp_mode = ramp_mode;
 
-        // Channel render mode for non-object content (host / spatial). Mirror
-        // `ramp_mode`: the live snapshot is seeded from config here so the
-        // embedded host matches the CLI bootstrap. Default = Spatial.
-        let channel_render_mode = render_cfg
-            .as_ref()
-            .and_then(renderer::config_fields::channel_render_mode::get)
-            .unwrap_or(renderer::config_fields::channel_render_mode::DEFAULT);
-        control.live.write().channel_render_mode = channel_render_mode;
-
-        // Surround placement (side/back) for 4.x/5.x content; seeded from config
-        // like `channel_render_mode`. Default = Side.
-        let surround_placement = render_cfg
-            .as_ref()
-            .and_then(renderer::config_fields::surround_placement::get)
-            .unwrap_or(renderer::config_fields::surround_placement::DEFAULT);
-        control.live.write().surround_placement = surround_placement;
-
-        // Output channel mapping (by_index/by_name); seeded from config like
-        // `surround_placement`. Default = ByIndex.
-        let output_channel_mapping = render_cfg
-            .as_ref()
-            .and_then(renderer::config_fields::output_channel_mapping::get)
-            .unwrap_or(renderer::config_fields::output_channel_mapping::DEFAULT);
-        control.live.write().output_channel_mapping = output_channel_mapping;
-
-        // Bed→height object generator selection + its live param overrides; seeded
-        // from config so the choice survives a restart (FFI/CLI parity). Empty id
-        // = off; absent params = the generator's declared defaults.
-        let object_generator_id = render_cfg
-            .as_ref()
-            .and_then(renderer::config_fields::object_generator_id::get)
-            .unwrap_or_default();
-        control.live.write().object_generator_id = object_generator_id;
-        if let Some(params) = render_cfg
-            .as_ref()
-            .and_then(|c| c.object_generator_params.clone())
-        {
-            control.live.write().object_generator_params = params;
+        // Declared live options (channel_render_mode, surround_placement,
+        // output_channel_mapping, object_generator_id, phantom_enabled) plus
+        // their param bags and the virtual bed: seeded from config through the
+        // shared registry seed — the same call as the CLI bootstrap, so the
+        // embedded host cannot drift from it (FFI/CLI parity by construction).
+        if let Some(render) = render_cfg.as_ref() {
+            renderer::options::seed_live_from_config(&mut control.live.write(), render);
         }
-
-        // Phantom-source extraction pre-stage: enable flag + its param overrides,
-        // seeded from config (FFI/CLI parity). Absent = off / declared defaults.
-        if let Some(enabled) = render_cfg
-            .as_ref()
-            .and_then(renderer::config_fields::phantom_enabled::get)
-        {
-            control.live.write().phantom_enabled = enabled;
-        }
-        if let Some(params) = render_cfg.as_ref().and_then(|c| c.phantom_params.clone()) {
-            control.live.write().phantom_params = params;
-        }
-
-        // Parametrable virtual bed (per-channel direct/virtual placement). Seed
-        // from config so the embedded host matches the CLI bootstrap; `None`
-        // leaves the built-in canonical poses in effect (LFE direct).
-        let virtual_bed = render_cfg.as_ref().and_then(|c| c.virtual_bed.clone());
-        control.live.write().virtual_bed = virtual_bed;
 
         // DRC: seed the live params from config and publish the bridge's
         // supported modes (so studio shows the DRC control). The decode-side

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -863,6 +863,7 @@ impl Engine {
                 room_ratio_center_blend,
                 object_generator_id,
                 phantom_enabled,
+                options_epoch,
             ) = {
                 let control = self.renderer.renderer_control();
                 let live = control.live.read();
@@ -876,6 +877,7 @@ impl Engine {
                     live.room_ratio_center_blend,
                     live.object_generator_id.clone(),
                     live.phantom_enabled,
+                    control.options_epoch(),
                 )
             };
             let output_layout = self.renderer.speaker_layout();
@@ -942,8 +944,10 @@ impl Engine {
             // Phantom-extraction pre-stage runs first: its planar objects occupy the
             // channel slots right after the bed; the height-lift objects follow. The
             // audio (and the bed reduction) is applied after the bed PCM is built.
-            phantom_count = self.phantom.sync(phantom_enabled, &ctx);
-            synth_count = self.object_gen.sync(&object_generator_id, &ctx);
+            phantom_count = self.phantom.sync(phantom_enabled, &ctx, options_epoch);
+            synth_count = self
+                .object_gen
+                .sync(&object_generator_id, &ctx, options_epoch);
             if phantom_count > 0 || synth_count > 0 {
                 // Push each stage's live param overrides (declared schema; sparse —
                 // absent keys keep the stage's default). Cheap + idempotent, so a

--- a/omniphony-renderer/orender_engine/src/object_gen.rs
+++ b/omniphony-renderer/orender_engine/src/object_gen.rs
@@ -1359,10 +1359,13 @@ struct PlanSig {
     out_height: bool,
     labels: Vec<RChannelLabel>,
     rate: u32,
-    /// Planned positions depend on the Side/Back surround placement
-    /// ([`channel_top_position`]); a live toggle must re-plan or the already
-    /// synthesized objects keep their stale row.
-    placement: SurroundPlacement,
+    /// `RendererControl::options_epoch` at plan time. Bumped whenever a
+    /// `REPLAN`-flagged registry option actually changes value (e.g. the
+    /// Side/Back surround placement, which moves the planned positions), so a
+    /// live toggle re-plans without this signature enumerating options field
+    /// by field — a new re-planning option cannot be forgotten here (see
+    /// `renderer::options`).
+    options_epoch: u64,
 }
 
 /// Host-side state for the object-generator stage: the registry, the active
@@ -1405,7 +1408,10 @@ impl ObjectGenStage {
 
     /// (Re)build + plan if the selection or environment changed; returns the
     /// number of synthesized objects (`0` = inactive / no-op).
-    pub fn sync(&mut self, desired_id: &str, ctx: &PrepareCtx) -> usize {
+    ///
+    /// `options_epoch` is `RendererControl::options_epoch()`: any change to a
+    /// `REPLAN`-flagged registry option re-plans through it.
+    pub fn sync(&mut self, desired_id: &str, ctx: &PrepareCtx, options_epoch: u64) -> usize {
         let did = desired_id.trim();
         let out_n = ctx.output_layout.speakers.len();
         let out_height = layout_has_height(ctx.output_layout);
@@ -1413,7 +1419,7 @@ impl ObjectGenStage {
             && self.sig.out_n == out_n
             && self.sig.out_height == out_height
             && self.sig.rate == ctx.sample_rate
-            && self.sig.placement == ctx.surround_placement
+            && self.sig.options_epoch == options_epoch
             && self.sig.labels.as_slice() == ctx.input_labels;
         if !unchanged {
             self.sig.id.clear();
@@ -1421,7 +1427,7 @@ impl ObjectGenStage {
             self.sig.out_n = out_n;
             self.sig.out_height = out_height;
             self.sig.rate = ctx.sample_rate;
-            self.sig.placement = ctx.surround_placement;
+            self.sig.options_epoch = options_epoch;
             self.sig.labels.clear();
             self.sig.labels.extend_from_slice(ctx.input_labels);
 
@@ -1587,7 +1593,7 @@ mod tests {
     }
 
     #[test]
-    fn stage_replans_on_surround_placement_change() {
+    fn stage_replans_on_options_epoch_bump() {
         use renderer::live_params::SurroundPlacement;
         let mut stage = ObjectGenStage::new();
         let out = layout_7_1_4();
@@ -1597,24 +1603,32 @@ mod tests {
             sample_rate: 48_000,
             surround_placement: SurroundPlacement::Side,
         };
-        assert_eq!(stage.sync("copy_up", &ctx_side), 5);
-        let ls_y_side = stage
-            .specs()
-            .iter()
-            .find(|s| s.name.contains("Ls"))
-            .expect("Ls object planned")
-            .position[1];
+        assert_eq!(stage.sync("copy_up", &ctx_side, 0), 5);
+        let ls_y = |stage: &ObjectGenStage| {
+            stage
+                .specs()
+                .iter()
+                .find(|s| s.name.contains("Ls"))
+                .expect("Ls object planned")
+                .position[1]
+        };
+        let ls_y_side = ls_y(&stage);
         let ctx_back = PrepareCtx {
             surround_placement: SurroundPlacement::Back,
             ..ctx_side
         };
-        assert_eq!(stage.sync("copy_up", &ctx_back), 5);
-        let ls_y_back = stage
-            .specs()
-            .iter()
-            .find(|s| s.name.contains("Ls"))
-            .expect("Ls object planned")
-            .position[1];
+        // The ctx value alone must NOT re-plan: the options epoch is the
+        // invalidator (a redundant state echo must not re-prime the stages).
+        assert_eq!(stage.sync("copy_up", &ctx_back, 0), 5);
+        assert_eq!(
+            ls_y(&stage),
+            ls_y_side,
+            "no epoch bump: the previous plan must be kept"
+        );
+        // The real flow: a live placement change is a REPLAN-flagged registry
+        // option, so it arrives together with an epoch bump → re-plan.
+        assert_eq!(stage.sync("copy_up", &ctx_back, 1), 5);
+        let ls_y_back = ls_y(&stage);
         assert!(
             ls_y_side > ls_y_back + 0.5,
             "Ls object must move to the back row on a live placement change \

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -659,9 +659,9 @@ fn raw_option_value(arg: Option<&OscType>) -> Option<renderer::options::RawOptio
 }
 
 /// Registry-driven application of a declared live option: validate + apply via
-/// the spec, mark the config dirty, bump the replan epoch (`REPLAN`), commit to
-/// config.yaml (`PERSIST`), and notify clients. Invalid values are dropped with
-/// a warning, per the OSC contract.
+/// `options::apply_to_control` (which marks dirty and bumps the replan epoch
+/// on a real change), then commit to config.yaml (`PERSIST`) and notify
+/// clients. Invalid values are dropped with a warning, per the OSC contract.
 fn apply_live_option(
     control: &Arc<RendererControl>,
     spec: &'static renderer::options::OptionSpec,
@@ -669,18 +669,10 @@ fn apply_live_option(
     socket: &Arc<UdpSocket>,
     clients: &Arc<OscClientRegistry>,
 ) {
-    let applied = {
-        let mut live = control.live.write();
-        (spec.set)(&mut live, raw)
-    };
-    let Some(canonical) = applied else {
+    let Some(canonical) = renderer::options::apply_to_control(control, spec, raw) else {
         log::warn!("OSC option {}: rejected value", spec.key);
         return;
     };
-    control.mark_dirty();
-    if spec.flags.contains(renderer::options::OptionFlags::REPLAN) {
-        control.bump_options_epoch();
-    }
     if spec.flags.contains(renderer::options::OptionFlags::PERSIST) {
         if let Some(path) = control.config_path() {
             persist_render_field_to_path(&path, spec.key, |render| {

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -66,47 +66,30 @@ pub(crate) fn handle_control_message(
         return;
     }
 
-    // Channel render mode for non-object content (host / direct / virtual).
-    // Live-tunable from Studio; persists to config so it survives a restart.
-    if addr == osc_contract::CONTROL_CHANNEL_RENDER_MODE {
-        if let Some(OscType::String(s)) = msg.args.first() {
-            if let Some(mode) = renderer::live_params::ChannelRenderMode::from_str(s) {
-                control.live.write().channel_render_mode = mode;
-                control.mark_dirty();
-                // Persist to config.yaml right away (not only mark_dirty). `host`
-                // makes the embedded mpv decoder decline and tear the engine down,
-                // so the OSC re-enable after a fallback is received by a *different*
-                // orender instance (the standby renderer that resumes on the port).
-                // Committing it to config.yaml here — by whichever instance gets the
-                // toggle — is what lets the next mpv launch read the right mode.
-                persist_channel_render_mode(control, mode);
-                broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
-                log::info!("OSC channel render mode set to {}", mode.as_str());
-            } else {
-                log::warn!("OSC channel render mode: unknown value '{}'", s);
-            }
+    // Declared live options (renderer::options registry): the generic setter
+    // `/control/option [key, value]` and the legacy per-option addresses both
+    // land on the same registry-driven path — validate, apply, mark dirty,
+    // bump the replan epoch, and commit PERSIST-flagged options to config.yaml
+    // right away (not only mark_dirty): a host fallback can route the next
+    // toggle to a *different* orender instance (the standby renderer that
+    // resumes on the port), so the file — written by whichever instance got
+    // the toggle — is what the next boot reads.
+    if addr == osc_contract::CONTROL_OPTION {
+        let Some(OscType::String(key)) = msg.args.first() else {
+            return;
+        };
+        let Some(spec) = renderer::options::find(key) else {
+            log::warn!("OSC option: unknown key '{}'", key);
+            return;
+        };
+        if let Some(raw) = raw_option_value(msg.args.get(1)) {
+            apply_live_option(control, spec, &raw, socket, clients);
         }
         return;
     }
-
-    // Bed→height object generator (2D upmix) selection for channel content.
-    // Live-tunable from Studio; an empty / "none" id disables it. (Persistence
-    // to config is added with the Studio UI; for now it is a live-only toggle
-    // committed on the next dirty flush.)
-    if addr == osc_contract::CONTROL_OBJECT_GENERATOR {
-        if let Some(OscType::String(s)) = msg.args.first() {
-            {
-                let mut live = control.live.write();
-                if live.object_generator_id != *s {
-                    // New generator: drop the previous one's param overrides so the
-                    // new generator starts at its declared defaults.
-                    live.object_generator_params.clear();
-                }
-                live.object_generator_id = s.clone();
-            }
-            control.mark_dirty();
-            broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
-            log::info!("OSC object generator set to '{}'", s);
+    if let Some(spec) = renderer::options::find_by_legacy_addr(addr) {
+        if let Some(raw) = raw_option_value(msg.args.first()) {
+            apply_live_option(control, spec, &raw, socket, clients);
         }
         return;
     }
@@ -137,23 +120,6 @@ pub(crate) fn handle_control_message(
         return;
     }
 
-    // Phantom-source extraction pre-stage enable toggle (int 0/1).
-    if addr == osc_contract::CONTROL_PHANTOM_EXTRACT {
-        if let Some(arg) = msg.args.first() {
-            let on = match arg {
-                OscType::Int(i) => *i != 0,
-                OscType::Float(f) => *f != 0.0,
-                OscType::Bool(b) => *b,
-                _ => return,
-            };
-            control.live.write().phantom_enabled = on;
-            control.mark_dirty();
-            broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
-            log::info!("OSC phantom extraction {}", if on { "on" } else { "off" });
-        }
-        return;
-    }
-
     // Live phantom-extraction parameter (strength / passes / lift).
     if addr == osc_contract::CONTROL_PHANTOM_EXTRACT_PARAM {
         let key = match msg.args.first() {
@@ -171,42 +137,6 @@ pub(crate) fn handle_control_message(
         }
         control.live.write().phantom_params.insert(key, value);
         control.mark_dirty();
-        return;
-    }
-
-    // Surround placement (side/back) for 4.x/5.x channel content. Live-tunable
-    // from Studio; persists to config right away (same rationale as
-    // channel_render_mode: a host fallback can route the next toggle to a
-    // different orender instance, so commit it to config.yaml here).
-    if addr == osc_contract::CONTROL_SURROUND_PLACEMENT {
-        if let Some(OscType::String(s)) = msg.args.first() {
-            if let Some(placement) = renderer::live_params::SurroundPlacement::from_str(s) {
-                control.live.write().surround_placement = placement;
-                control.mark_dirty();
-                persist_surround_placement(control, placement);
-                broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
-                log::info!("OSC surround placement set to {}", placement.as_str());
-            } else {
-                log::warn!("OSC surround placement: unknown value '{}'", s);
-            }
-        }
-        return;
-    }
-
-    // Output channel mapping (by_index/by_name). Live-tunable from Studio;
-    // persists to config right away (same rationale as surround_placement).
-    if addr == osc_contract::CONTROL_OUTPUT_CHANNEL_MAPPING {
-        if let Some(OscType::String(s)) = msg.args.first() {
-            if let Some(mapping) = renderer::live_params::OutputChannelMapping::from_str(s) {
-                control.live.write().output_channel_mapping = mapping;
-                control.mark_dirty();
-                persist_output_channel_mapping(control, mapping);
-                broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
-                log::info!("OSC output channel mapping set to {}", mapping.as_str());
-            } else {
-                log::warn!("OSC output channel mapping: unknown value '{}'", s);
-            }
-        }
         return;
     }
 
@@ -714,36 +644,73 @@ fn set_dirty(control: &Arc<RendererControl>, socket: &UdpSocket, clients: &OscCl
     broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
 }
 
-/// Persist `channel_render_mode` to the on-disk config so it survives a restart.
-///
-/// Targeted, side-effect-free write: load the existing config, set *only* this
-/// field (preserving every other key, including unknown ones via the config's
-/// flattened `extra`), save, then drop the live-handoff sidecar + overlay cache
-/// so a stale `host` sidecar — written when a previous instance fell back and
-/// tore down — cannot override `config.yaml` on the next boot. `Spatial` (the
-/// default) omits the key; `Host` writes it. Best-effort; logs on error.
-fn persist_channel_render_mode(
-    control: &Arc<RendererControl>,
-    mode: renderer::live_params::ChannelRenderMode,
-) {
-    let Some(path) = control.config_path() else {
-        return;
-    };
-    persist_channel_render_mode_to_path(&path, mode);
+/// Map a client-supplied OSC argument onto the registry's transport-agnostic
+/// raw value. `None` for shapes no option accepts (blobs, arrays, …).
+fn raw_option_value(arg: Option<&OscType>) -> Option<renderer::options::RawOptionValue<'_>> {
+    use renderer::options::RawOptionValue;
+    match arg? {
+        OscType::String(s) => Some(RawOptionValue::Str(s)),
+        OscType::Int(i) => Some(RawOptionValue::Number(*i as f64)),
+        OscType::Float(f) => Some(RawOptionValue::Number(*f as f64)),
+        OscType::Double(d) => Some(RawOptionValue::Number(*d)),
+        OscType::Bool(b) => Some(RawOptionValue::Bool(*b)),
+        _ => None,
+    }
 }
 
-fn persist_channel_render_mode_to_path(
+/// Registry-driven application of a declared live option: validate + apply via
+/// the spec, mark the config dirty, bump the replan epoch (`REPLAN`), commit to
+/// config.yaml (`PERSIST`), and notify clients. Invalid values are dropped with
+/// a warning, per the OSC contract.
+fn apply_live_option(
+    control: &Arc<RendererControl>,
+    spec: &'static renderer::options::OptionSpec,
+    raw: &renderer::options::RawOptionValue,
+    socket: &Arc<UdpSocket>,
+    clients: &Arc<OscClientRegistry>,
+) {
+    let applied = {
+        let mut live = control.live.write();
+        (spec.set)(&mut live, raw)
+    };
+    let Some(canonical) = applied else {
+        log::warn!("OSC option {}: rejected value", spec.key);
+        return;
+    };
+    control.mark_dirty();
+    if spec.flags.contains(renderer::options::OptionFlags::REPLAN) {
+        control.bump_options_epoch();
+    }
+    if spec.flags.contains(renderer::options::OptionFlags::PERSIST) {
+        if let Some(path) = control.config_path() {
+            persist_render_field_to_path(&path, spec.key, |render| {
+                let live = control.live.read();
+                (spec.config_store)(render, &live);
+            });
+        }
+    }
+    broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
+    log::info!("OSC option {} set to '{}'", spec.key, canonical);
+}
+
+/// Targeted, sidecar-clearing config write shared by every per-option persist.
+///
+/// Load the existing config, let `store` set *only* its field (preserving every
+/// other key, including unknown ones via the config's flattened `extra`), save,
+/// then drop the live-handoff sidecar + overlay cache so a stale sidecar —
+/// written when a previous instance fell back and tore down — cannot override
+/// `config.yaml` on the next boot. Skip-if-default descriptors keep a default
+/// value out of the file entirely. Best-effort; logs on error.
+fn persist_render_field_to_path(
     path: &Path,
-    mode: renderer::live_params::ChannelRenderMode,
+    what: &str,
+    store: impl FnOnce(&mut renderer::config::RenderConfig),
 ) {
     let mut config = renderer::config::Config::load_or_default(path);
     let render = config.render.get_or_insert_with(Default::default);
-    renderer::config_fields::channel_render_mode::store(render, mode);
+    store(render);
     if let Err(e) = config.save(path) {
-        log::warn!(
-            "failed to persist channel_render_mode to {}: {e}",
-            path.display()
-        );
+        log::warn!("failed to persist {what} to {}: {e}", path.display());
         return;
     }
     // A persisted change supersedes any pending live-handoff overlay.
@@ -751,62 +718,9 @@ fn persist_channel_render_mode_to_path(
     renderer::config::clear_live_overlay_cache();
 }
 
-/// Persist `surround_placement` to the on-disk config so it survives a restart.
-/// Same targeted, sidecar-clearing write as [`persist_channel_render_mode`].
-fn persist_surround_placement(
-    control: &Arc<RendererControl>,
-    placement: renderer::live_params::SurroundPlacement,
-) {
-    let Some(path) = control.config_path() else {
-        return;
-    };
-    persist_surround_placement_to_path(&path, placement);
-}
-
-fn persist_surround_placement_to_path(
-    path: &Path,
-    placement: renderer::live_params::SurroundPlacement,
-) {
-    let mut config = renderer::config::Config::load_or_default(path);
-    let render = config.render.get_or_insert_with(Default::default);
-    renderer::config_fields::surround_placement::store(render, placement);
-    if let Err(e) = config.save(path) {
-        log::warn!(
-            "failed to persist surround_placement to {}: {e}",
-            path.display()
-        );
-        return;
-    }
-    let _ = std::fs::remove_file(renderer::config::live_sidecar_path(path));
-    renderer::config::clear_live_overlay_cache();
-}
-
-/// Persist `output_channel_mapping` to the on-disk config so it survives a
-/// restart. Same targeted, sidecar-clearing write as [`persist_surround_placement`].
-fn persist_output_channel_mapping(
-    control: &Arc<RendererControl>,
-    mapping: renderer::live_params::OutputChannelMapping,
-) {
-    let Some(path) = control.config_path() else {
-        return;
-    };
-    let mut config = renderer::config::Config::load_or_default(&path);
-    let render = config.render.get_or_insert_with(Default::default);
-    renderer::config_fields::output_channel_mapping::store(render, mapping);
-    if let Err(e) = config.save(&path) {
-        log::warn!(
-            "failed to persist output_channel_mapping to {}: {e}",
-            path.display()
-        );
-        return;
-    }
-    let _ = std::fs::remove_file(renderer::config::live_sidecar_path(&path));
-    renderer::config::clear_live_overlay_cache();
-}
-
 /// Persist the head-tracking recenter reference to the on-disk config so the
 /// chosen "forward" survives an engine rebuild (mpv track change) and a restart.
-/// Same targeted, sidecar-clearing write as [`persist_surround_placement`].
+/// Same targeted, sidecar-clearing write as the live options.
 fn persist_head_center(control: &Arc<RendererControl>, reference_quat: [f32; 4]) {
     let Some(path) = control.config_path() else {
         return;
@@ -815,20 +729,14 @@ fn persist_head_center(control: &Arc<RendererControl>, reference_quat: [f32; 4])
 }
 
 fn persist_head_center_to_path(path: &Path, reference_quat: [f32; 4]) {
-    let mut config = renderer::config::Config::load_or_default(path);
-    let render = config.render.get_or_insert_with(Default::default);
-    let bin = render.binaural.get_or_insert_with(Default::default);
-    let ht = bin.head_tracking.get_or_insert_with(Default::default);
-    // Drop the key when back at identity so an "uncentered" tracker leaves a clean
-    // config rather than persisting a no-op quaternion.
-    let identity = renderer::binaural::HeadPose::identity().to_quat_array();
-    ht.reference_quat = (reference_quat != identity).then_some(reference_quat);
-    if let Err(e) = config.save(path) {
-        log::warn!("failed to persist head recenter to {}: {e}", path.display());
-        return;
-    }
-    let _ = std::fs::remove_file(renderer::config::live_sidecar_path(path));
-    renderer::config::clear_live_overlay_cache();
+    persist_render_field_to_path(path, "head recenter", |render| {
+        let bin = render.binaural.get_or_insert_with(Default::default);
+        let ht = bin.head_tracking.get_or_insert_with(Default::default);
+        // Drop the key when back at identity so an "uncentered" tracker leaves a
+        // clean config rather than persisting a no-op quaternion.
+        let identity = renderer::binaural::HeadPose::identity().to_quat_array();
+        ht.reference_quat = (reference_quat != identity).then_some(reference_quat);
+    });
 }
 
 fn apply_control_effects(
@@ -1157,7 +1065,9 @@ mod tests {
         let sidecar = renderer::config::live_sidecar_path(&path);
         std::fs::write(&sidecar, "render:\n  channel_render_mode: host\n").unwrap();
 
-        persist_channel_render_mode_to_path(&path, ChannelRenderMode::Host);
+        persist_render_field_to_path(&path, "channel_render_mode", |render| {
+            renderer::config_fields::channel_render_mode::store(render, ChannelRenderMode::Host)
+        });
 
         let written = std::fs::read_to_string(&path).unwrap();
         assert!(
@@ -1188,7 +1098,9 @@ mod tests {
         let sidecar = renderer::config::live_sidecar_path(&path);
         std::fs::write(&sidecar, "render:\n  channel_render_mode: host\n").unwrap();
 
-        persist_channel_render_mode_to_path(&path, ChannelRenderMode::Spatial);
+        persist_render_field_to_path(&path, "channel_render_mode", |render| {
+            renderer::config_fields::channel_render_mode::store(render, ChannelRenderMode::Spatial)
+        });
 
         let written = std::fs::read_to_string(&path).unwrap();
         // Spatial is the default → skip-if-default omits the key entirely.
@@ -1226,7 +1138,9 @@ mod tests {
         let sidecar = renderer::config::live_sidecar_path(&path);
         std::fs::write(&sidecar, "render:\n  surround_placement: back\n").unwrap();
 
-        persist_surround_placement_to_path(&path, SurroundPlacement::Back);
+        persist_render_field_to_path(&path, "surround_placement", |render| {
+            renderer::config_fields::surround_placement::store(render, SurroundPlacement::Back)
+        });
 
         let written = std::fs::read_to_string(&path).unwrap();
         assert!(
@@ -1306,7 +1220,9 @@ mod tests {
         let sidecar = renderer::config::live_sidecar_path(&path);
         std::fs::write(&sidecar, "render:\n  surround_placement: back\n").unwrap();
 
-        persist_surround_placement_to_path(&path, SurroundPlacement::Side);
+        persist_render_field_to_path(&path, "surround_placement", |render| {
+            renderer::config_fields::surround_placement::store(render, SurroundPlacement::Side)
+        });
 
         let written = std::fs::read_to_string(&path).unwrap();
         // Side is the default → skip-if-default omits the key entirely.

--- a/omniphony-renderer/orender_engine/src/phantom_extract.rs
+++ b/omniphony-renderer/orender_engine/src/phantom_extract.rs
@@ -26,7 +26,6 @@
 //! and never panics.
 
 use bridge_api::RChannelLabel;
-use renderer::live_params::SurroundPlacement;
 
 use crate::object_gen::{
     ObjectGenParamSpec, PrepareCtx, SynthObjectSpec, channel_top_position, input_has_back,
@@ -619,10 +618,12 @@ struct PlanSig {
     center: bool,
     sides: bool,
     spectral: bool,
-    /// The planned arc/sector positions depend on the Side/Back surround
-    /// placement; a live toggle must re-plan or the phantoms keep interpolating
-    /// between the stale source positions.
-    placement: SurroundPlacement,
+    /// `RendererControl::options_epoch` at plan time. Bumped whenever a
+    /// `REPLAN`-flagged registry option actually changes value (e.g. the
+    /// Side/Back surround placement, which moves the planned arc/sector
+    /// positions), so a live toggle re-plans without this signature
+    /// enumerating options field by field (see `renderer::options`).
+    options_epoch: u64,
 }
 
 /// Host-side state for the phantom-extraction stage.
@@ -688,14 +689,17 @@ impl PhantomExtractStage {
     /// (Re)build the pair plan if the selection/environment/`passes` changed, then
     /// refresh the dynamic phantom positions from the smoothed statistics (cheap,
     /// every frame). Returns the phantom count (`0` = inactive / no-op).
-    pub fn sync(&mut self, enabled: bool, ctx: &PrepareCtx) -> usize {
+    ///
+    /// `options_epoch` is `RendererControl::options_epoch()`: any change to a
+    /// `REPLAN`-flagged registry option re-plans through it.
+    pub fn sync(&mut self, enabled: bool, ctx: &PrepareCtx, options_epoch: u64) -> usize {
         let spectral = self.method == ExtractMethod::Spectral;
         // `passes`/`center`/`sides` only shape the broadband plan; ignore their
         // changes while the spectral method is active (no pointless re-prime).
         let changed = self.sig.enabled != enabled
             || self.sig.rate != ctx.sample_rate
             || self.sig.spectral != spectral
-            || self.sig.placement != ctx.surround_placement
+            || self.sig.options_epoch != options_epoch
             || (!spectral
                 && (self.sig.passes != self.passes
                     || self.sig.center != self.center_relocalize
@@ -708,7 +712,7 @@ impl PhantomExtractStage {
             self.sig.center = self.center_relocalize;
             self.sig.sides = self.sides_relocalize;
             self.sig.spectral = spectral;
-            self.sig.placement = ctx.surround_placement;
+            self.sig.options_epoch = options_epoch;
             self.sig.labels.clear();
             self.sig.labels.extend_from_slice(ctx.input_labels);
             self.rebuild(enabled, ctx);
@@ -1082,7 +1086,7 @@ mod tests {
     fn disabled_is_noop() {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
-        assert_eq!(st.sync(false, &ctx(&LABELS_5_1, &layout)), 0);
+        assert_eq!(st.sync(false, &ctx(&LABELS_5_1, &layout), 0), 0);
     }
 
     #[test]
@@ -1090,16 +1094,16 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         // 5 positionable channels (L,R,C,Ls,Rs; LFE excluded) → ring of 5 pairs.
-        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout)), 5);
+        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout), 0), 5);
     }
 
     #[test]
     fn passes_widen_the_pair_set() {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
-        let ring = st.sync(true, &ctx(&LABELS_5_1, &layout));
+        let ring = st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         st.set_param("passes", 2.0, 48_000);
-        let widened = st.sync(true, &ctx(&LABELS_5_1, &layout));
+        let widened = st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         assert!(
             widened > ring,
             "passes=2 ({widened}) should add pairs over ring ({ring})"
@@ -1111,7 +1115,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         // A correlated source panned between adjacent channels L and C (0.8 / 0.2).
         let c = 6usize;
         let n = 6000usize;
@@ -1144,7 +1148,7 @@ mod tests {
             "L should be largely emptied ({l_red} vs {in_l})"
         );
         // Position: refresh from the converged stats and check it sits toward L.
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let pos = st.specs()[k].position;
         assert!(
             pos[0] < -0.5,
@@ -1158,7 +1162,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let c = 6usize;
         let n = 6000usize;
         let (s1, s2) = (sine(700.0), sine(1130.0)); // independent tones
@@ -1198,7 +1202,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let c = 6usize;
         let n = 6000usize;
         let s = sine(700.0);
@@ -1235,7 +1239,7 @@ mod tests {
             (l_red - r_red).abs() < 0.1 * in_l + 1.0e-6,
             "L and R must be reduced symmetrically ({l_red} vs {r_red})"
         );
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let x_lc = st.specs()[i_lc].position[0];
         let x_cr = st.specs()[i_cr].position[0];
         assert!(
@@ -1254,7 +1258,7 @@ mod tests {
         let layout = dummy_layout();
         // front(2) + back(1) + left(2) + right(2); every ring distance-1 pair is
         // covered, so passes=1 yields exactly these 7.
-        let n_specs = st.sync(true, &ctx(&LABELS_7_1, &layout));
+        let n_specs = st.sync(true, &ctx(&LABELS_7_1, &layout), 0);
         assert_eq!(n_specs, 7);
         let names: Vec<&str> = st.specs().iter().map(|s| s.name.as_str()).collect();
         for want in [
@@ -1277,7 +1281,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_7_1, &layout));
+        st.sync(true, &ctx(&LABELS_7_1, &layout), 0);
         let c = 8usize; // L=0, Ls=4, Lb=6
         let n = 6000usize;
         let s = sine(700.0);
@@ -1313,7 +1317,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("center", 1.0, 48_000);
-        let n_specs = st.sync(true, &ctx(&LABELS_5_1, &layout));
+        let n_specs = st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let names: Vec<&str> = st.specs().iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Phantom_C"),
@@ -1338,7 +1342,7 @@ mod tests {
         let layout = dummy_layout();
         st.set_param("center", 1.0, 48_000);
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let c = 6usize;
         let n = 6000usize;
         let s = sine(700.0);
@@ -1373,7 +1377,7 @@ mod tests {
             "spread centre should be re-extracted, leaving L/R near silent ({lr_red} vs {in_c})"
         );
         // Position: symmetric centre → object sits near the centre line.
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let pos = st.specs()[k].position;
         assert!(
             pos[0].abs() < 0.15,
@@ -1390,7 +1394,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("sides", 1.0, 48_000);
-        let n_specs = st.sync(true, &ctx(&LABELS_7_1, &layout));
+        let n_specs = st.sync(true, &ctx(&LABELS_7_1, &layout), 0);
         let names: Vec<&str> = st.specs().iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Phantom_Ls"),
@@ -1423,7 +1427,7 @@ mod tests {
         let layout = dummy_layout();
         st.set_param("sides", 1.0, 48_000);
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_7_1, &layout));
+        st.sync(true, &ctx(&LABELS_7_1, &layout), 0);
         let c = 8usize;
         let n = 6000usize;
         let s = sine(700.0);
@@ -1457,7 +1461,7 @@ mod tests {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
         st.set_param("lift", 0.8, 48_000);
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         assert!(
             st.specs()
                 .iter()
@@ -1466,10 +1470,10 @@ mod tests {
     }
 
     #[test]
-    fn replans_on_surround_placement_change() {
+    fn replans_on_options_epoch_bump() {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
-        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout)), 5);
+        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout), 0), 5);
         let find_ls_y = |st: &PhantomExtractStage| {
             st.specs()
                 .iter()
@@ -1484,7 +1488,17 @@ mod tests {
             sample_rate: 48_000,
             surround_placement: renderer::live_params::SurroundPlacement::Back,
         };
-        assert_eq!(st.sync(true, &ctx_back), 5);
+        // The ctx value alone must NOT re-plan: the options epoch is the
+        // invalidator (a redundant state echo must not re-prime the stages).
+        assert_eq!(st.sync(true, &ctx_back, 0), 5);
+        assert_eq!(
+            find_ls_y(&st),
+            y_side,
+            "no epoch bump: the previous plan must be kept"
+        );
+        // The real flow: a live placement change is a REPLAN-flagged registry
+        // option, so it arrives together with an epoch bump → re-plan.
+        assert_eq!(st.sync(true, &ctx_back, 1), 5);
         let y_back = find_ls_y(&st);
         assert!(
             y_side > y_back + 0.5,
@@ -1497,9 +1511,9 @@ mod tests {
     fn method_switch_replans() {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
-        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout)), 5);
+        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout), 0), 5);
         st.set_param("method", 1.0, 48_000);
-        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout)), 8);
+        assert_eq!(st.sync(true, &ctx(&LABELS_5_1, &layout), 0), 8);
         let names: Vec<&str> = st.specs().iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Direct_F") && names.contains(&"Direct_FL"),
@@ -1507,7 +1521,7 @@ mod tests {
         );
         st.set_param("method", 0.0, 48_000);
         assert_eq!(
-            st.sync(true, &ctx(&LABELS_5_1, &layout)),
+            st.sync(true, &ctx(&LABELS_5_1, &layout), 0),
             5,
             "switching back must restore the broadband ring plan"
         );
@@ -1522,7 +1536,7 @@ mod tests {
         let layout = dummy_layout();
         st.set_param("method", 1.0, 48_000);
         st.set_param("strength", 1.0, 48_000);
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let c = 6usize;
         let n = 24_000usize;
         let s = sine(700.0);
@@ -1553,7 +1567,7 @@ mod tests {
             "C should be largely emptied ({c_res} vs {in_c})"
         );
         // Position: converged stats keep the object at the front centre.
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let pos = st.specs()[k].position;
         assert!(
             pos[0].abs() < 0.15 && pos[1] > 0.85,
@@ -1565,7 +1579,7 @@ mod tests {
     fn finite_output() {
         let mut st = PhantomExtractStage::new();
         let layout = dummy_layout();
-        st.sync(true, &ctx(&LABELS_5_1, &layout));
+        st.sync(true, &ctx(&LABELS_5_1, &layout), 0);
         let c = 6usize;
         let n = 2000usize;
         let s = sine(500.0);

--- a/omniphony-renderer/renderer/examples/dump_options_schema.rs
+++ b/omniphony-renderer/renderer/examples/dump_options_schema.rs
@@ -1,0 +1,9 @@
+//! Dump the declared live-options schema as JSON on stdout.
+//!
+//! CI pipes this into `omniphony-studio/scripts/check-options-schema.mjs`,
+//! which asserts every declared option has Studio i18n coverage — the
+//! options-schema contract check from `docs/live-options-registry.md`.
+
+fn main() {
+    println!("{}", renderer::options::schema_json());
+}

--- a/omniphony-renderer/renderer/src/lib.rs
+++ b/omniphony-renderer/renderer/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crossover;
 pub mod delay_line;
 pub mod live_params;
 pub mod metering;
+pub mod options;
 pub mod ramp_strategy;
 pub mod render_backend;
 pub mod spatial_renderer;

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -895,6 +895,12 @@ pub struct RendererControl {
     /// wrapper, avoiding re-triangulation. See `build_topology_reusing`.
     pub geometry_generation: std::sync::atomic::AtomicU64,
 
+    /// Monotonic counter bumped whenever a live option flagged `REPLAN` in the
+    /// declared registry ([`crate::options`]) changes. Plan signatures compare
+    /// this single epoch instead of enumerating options field by field, so a
+    /// new re-planning option cannot be forgotten in a signature.
+    pub options_epoch: std::sync::atomic::AtomicU64,
+
     /// Set by the gain stage whenever output clipping is detected (peak > 0 dBFS),
     /// independently of whether auto-gain is enabled. Holds the index of the speaker
     /// channel that held the peak, or `-1` when no clip is pending. The OSC listener
@@ -990,6 +996,7 @@ impl RendererControl {
             speaker_params_generation: std::sync::atomic::AtomicU64::new(1),
             live_state_generation: std::sync::atomic::AtomicU64::new(0),
             geometry_generation: std::sync::atomic::AtomicU64::new(0),
+            options_epoch: std::sync::atomic::AtomicU64::new(0),
             clip_pending: AtomicI32::new(-1),
             config_path: Mutex::new(None),
             config_status: Mutex::new(None),
@@ -1241,6 +1248,16 @@ impl RendererControl {
 
     pub fn geometry_generation(&self) -> u64 {
         self.geometry_generation.load(Ordering::Relaxed)
+    }
+
+    /// Bump the options epoch: a `REPLAN`-flagged live option changed, so the
+    /// synthesized-object plan signatures must invalidate (see [`crate::options`]).
+    pub fn bump_options_epoch(&self) {
+        self.options_epoch.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn options_epoch(&self) -> u64 {
+        self.options_epoch.load(Ordering::Relaxed)
     }
 
     /// Flag that output clipping was detected this frame on `speaker_idx`

--- a/omniphony-renderer/renderer/src/options.rs
+++ b/omniphony-renderer/renderer/src/options.rs
@@ -1,0 +1,433 @@
+//! The declared live-options registry (RFC: `docs/live-options-registry.md`).
+//!
+//! One [`OptionSpec`] row per live option; every other layer iterates the
+//! registry instead of naming options one by one:
+//!
+//! * the generic OSC handler (`/omniphony/control/option` — the legacy
+//!   per-option addresses stay as aliases),
+//! * config persistence (the targeted persist-on-change and the full
+//!   live-state save both call [`store_live_to_config`]),
+//! * config→live seeding ([`seed_live_from_config`], shared by the CLI
+//!   bootstrap and `Engine::from_paths` so FFI/CLI parity holds by
+//!   construction),
+//! * the `/state/renderer` snapshot (`options` block, [`options_json`]) and
+//!   the published schema ([`schema_json`], consumed by the Studio contract
+//!   check and, later, the `data-option` binder).
+//!
+//! `key` is the single canonical name: the `render.*` config key, the key
+//! argument of `/omniphony/control/option`, the key inside the snapshot
+//! `options` block, and the Studio binding id. Inside the `options` namespace
+//! the key travels verbatim (snake_case) — no per-layer renaming.
+//!
+//! The audio hot path does NOT read options through the registry: options
+//! remain typed fields on [`LiveParams`], read directly per frame. The
+//! registry is the declaration + plumbing layer, not the storage.
+//!
+//! Adding a live option = one row here (+ the `LiveParams`/`RenderConfig`
+//! fields it points at, + Studio i18n keys). The conformance net in
+//! `runtime_control/tests/live_options_conformance.rs` fails when a row is
+//! missing a layer.
+
+use crate::config::RenderConfig;
+use crate::live_params::{ChannelRenderMode, LiveParams, OutputChannelMapping, SurroundPlacement};
+
+/// What kind of value an option takes. Drives wire validation, the published
+/// schema, and (later) which Studio control the binder renders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionKind {
+    /// Boolean toggle; accepts int/float (0 = false) and bool on the wire.
+    Bool,
+    /// Closed set of canonical lowercase spellings. The option's setter may
+    /// accept extra legacy aliases (e.g. `direct`/`virtual` → `spatial`), but
+    /// it always reports back a canonical value.
+    Enum(&'static [&'static str]),
+    /// Free-form string (e.g. a registry id).
+    Str,
+}
+
+/// Behaviour flags, interpreted generically by the plumbing layers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OptionFlags(u8);
+
+impl OptionFlags {
+    pub const NONE: Self = Self(0);
+    /// Commit to config.yaml immediately when set over OSC (targeted,
+    /// sidecar-clearing write). Rationale: a host fallback can route the next
+    /// toggle to a *different* renderer instance, so the value must reach the
+    /// file — not just the memory of whichever instance received it.
+    pub const PERSIST: Self = Self(1 << 0);
+    /// A change re-plans synthesized-object stages: setting the option bumps
+    /// `RendererControl::options_epoch`, which plan signatures compare instead
+    /// of enumerating options field by field.
+    pub const REPLAN: Self = Self(1 << 1);
+
+    pub const fn or(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+/// An option's canonical default, as it appears on the wire.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OptionDefault {
+    Bool(bool),
+    Str(&'static str),
+}
+
+impl OptionDefault {
+    fn to_json(self) -> serde_json::Value {
+        match self {
+            Self::Bool(b) => b.into(),
+            Self::Str(s) => s.into(),
+        }
+    }
+}
+
+/// A raw, unvalidated option value as supplied by a client. The OSC layer
+/// maps `OscType` into this; other transports (FFI, CLI) can too.
+#[derive(Debug, Clone, Copy)]
+pub enum RawOptionValue<'a> {
+    Str(&'a str),
+    Number(f64),
+    Bool(bool),
+}
+
+/// One live option, declared once.
+pub struct OptionSpec {
+    /// The single canonical name (see the module docs).
+    pub key: &'static str,
+    pub kind: OptionKind,
+    /// Canonical default; the config key is omitted at this value.
+    pub default: OptionDefault,
+    pub flags: OptionFlags,
+    /// Studio i18n key for the control label.
+    pub i18n_key: &'static str,
+    /// Studio i18n key for the help text (`None` = no help entry yet).
+    pub help_i18n_key: Option<&'static str>,
+    /// The pre-registry dedicated control address, kept as an alias of
+    /// `/omniphony/control/option` so existing clients keep working.
+    pub legacy_control_addr: &'static str,
+    /// Validate and apply a client value. Returns the canonical value applied
+    /// (for logging/echo), or `None` when the value is invalid — the engine
+    /// drops bad input rather than erroring, per the OSC contract.
+    pub set: fn(&mut LiveParams, &RawOptionValue) -> Option<String>,
+    /// Current value, for the snapshot `options` block.
+    pub get_json: fn(&LiveParams) -> serde_json::Value,
+    /// Write the live value into the config (skip-if-default descriptors keep
+    /// the key out of the file at the default).
+    pub config_store: fn(&mut RenderConfig, &LiveParams),
+    /// Seed the live value from a loaded config; an absent key is a no-op
+    /// (the constructed default stays).
+    pub config_seed: fn(&mut LiveParams, &RenderConfig),
+}
+
+/// Every declared live option. Iterated by the OSC dispatcher, persistence,
+/// seeding, the snapshot, the schema dump, and the conformance net.
+pub static LIVE_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        key: "channel_render_mode",
+        kind: OptionKind::Enum(&["spatial", "host"]),
+        default: OptionDefault::Str("spatial"),
+        flags: OptionFlags::PERSIST,
+        i18n_key: "twoDSources.spatializeLabel",
+        help_i18n_key: Some("help.twoDSources"),
+        legacy_control_addr: "/omniphony/control/channel_render_mode",
+        set: |live, raw| match raw {
+            RawOptionValue::Str(s) => {
+                let mode = ChannelRenderMode::from_str(s)?;
+                live.channel_render_mode = mode;
+                Some(mode.as_str().to_string())
+            }
+            _ => None,
+        },
+        get_json: |live| live.channel_render_mode.as_str().into(),
+        config_store: |render, live| {
+            crate::config_fields::channel_render_mode::store(render, live.channel_render_mode)
+        },
+        config_seed: |live, render| {
+            if let Some(mode) = crate::config_fields::channel_render_mode::get(render) {
+                live.channel_render_mode = mode;
+            }
+        },
+    },
+    OptionSpec {
+        key: "surround_placement",
+        kind: OptionKind::Enum(&["side", "back"]),
+        default: OptionDefault::Str("side"),
+        flags: OptionFlags::PERSIST.or(OptionFlags::REPLAN),
+        i18n_key: "twoDSources.surroundLabel",
+        help_i18n_key: None,
+        legacy_control_addr: "/omniphony/control/surround_placement",
+        set: |live, raw| match raw {
+            RawOptionValue::Str(s) => {
+                let placement = SurroundPlacement::from_str(s)?;
+                live.surround_placement = placement;
+                Some(placement.as_str().to_string())
+            }
+            _ => None,
+        },
+        get_json: |live| live.surround_placement.as_str().into(),
+        config_store: |render, live| {
+            crate::config_fields::surround_placement::store(render, live.surround_placement)
+        },
+        config_seed: |live, render| {
+            if let Some(placement) = crate::config_fields::surround_placement::get(render) {
+                live.surround_placement = placement;
+            }
+        },
+    },
+    OptionSpec {
+        key: "output_channel_mapping",
+        kind: OptionKind::Enum(&["by_index", "by_name"]),
+        default: OptionDefault::Str("by_index"),
+        flags: OptionFlags::PERSIST,
+        i18n_key: "audio.channelMapping",
+        help_i18n_key: None,
+        legacy_control_addr: "/omniphony/control/output_channel_mapping",
+        set: |live, raw| match raw {
+            RawOptionValue::Str(s) => {
+                let mapping = OutputChannelMapping::from_str(s)?;
+                live.output_channel_mapping = mapping;
+                Some(mapping.as_str().to_string())
+            }
+            _ => None,
+        },
+        get_json: |live| live.output_channel_mapping.as_str().into(),
+        config_store: |render, live| {
+            crate::config_fields::output_channel_mapping::store(render, live.output_channel_mapping)
+        },
+        config_seed: |live, render| {
+            if let Some(mapping) = crate::config_fields::output_channel_mapping::get(render) {
+                live.output_channel_mapping = mapping;
+            }
+        },
+    },
+    OptionSpec {
+        key: "object_generator_id",
+        kind: OptionKind::Str,
+        default: OptionDefault::Str(""),
+        flags: OptionFlags::PERSIST.or(OptionFlags::REPLAN),
+        i18n_key: "twoDSources.objectGeneratorLabel",
+        help_i18n_key: Some("help.objectGenerator"),
+        legacy_control_addr: "/omniphony/control/object_generator",
+        set: |live, raw| match raw {
+            RawOptionValue::Str(s) => {
+                if live.object_generator_id != *s {
+                    // New generator: drop the previous one's param overrides so
+                    // the new generator starts at its declared defaults.
+                    live.object_generator_params.clear();
+                }
+                live.object_generator_id = s.to_string();
+                Some(s.to_string())
+            }
+            _ => None,
+        },
+        get_json: |live| live.object_generator_id.as_str().into(),
+        config_store: |render, live| {
+            crate::config_fields::object_generator_id::store(render, &live.object_generator_id)
+        },
+        config_seed: |live, render| {
+            if let Some(id) = crate::config_fields::object_generator_id::get(render) {
+                live.object_generator_id = id;
+            }
+        },
+    },
+    OptionSpec {
+        key: "phantom_enabled",
+        kind: OptionKind::Bool,
+        default: OptionDefault::Bool(false),
+        flags: OptionFlags::PERSIST.or(OptionFlags::REPLAN),
+        i18n_key: "twoDSources.phantomLabel",
+        help_i18n_key: Some("help.phantomExtract"),
+        legacy_control_addr: "/omniphony/control/phantom_extract",
+        set: |live, raw| {
+            let on = match raw {
+                RawOptionValue::Number(n) => *n != 0.0,
+                RawOptionValue::Bool(b) => *b,
+                RawOptionValue::Str(_) => return None,
+            };
+            live.phantom_enabled = on;
+            Some(if on { "1" } else { "0" }.to_string())
+        },
+        get_json: |live| live.phantom_enabled.into(),
+        config_store: |render, live| {
+            crate::config_fields::phantom_enabled::store(render, live.phantom_enabled)
+        },
+        config_seed: |live, render| {
+            if let Some(enabled) = crate::config_fields::phantom_enabled::get(render) {
+                live.phantom_enabled = enabled;
+            }
+        },
+    },
+];
+
+/// Look an option up by its canonical key (the `/control/option` key argument).
+pub fn find(key: &str) -> Option<&'static OptionSpec> {
+    LIVE_OPTIONS.iter().find(|spec| spec.key == key)
+}
+
+/// Look an option up by its pre-registry dedicated control address.
+pub fn find_by_legacy_addr(addr: &str) -> Option<&'static OptionSpec> {
+    LIVE_OPTIONS
+        .iter()
+        .find(|spec| spec.legacy_control_addr == addr)
+}
+
+/// Seed every declared live option — plus the document-valued companions the
+/// registry doesn't model (the two param bags and the virtual bed) — from a
+/// loaded config. Shared by the CLI bootstrap and `Engine::from_paths` so the
+/// two boot paths cannot drift (the FFI/CLI parity bug class).
+pub fn seed_live_from_config(live: &mut LiveParams, render: &RenderConfig) {
+    for spec in LIVE_OPTIONS {
+        (spec.config_seed)(live, render);
+    }
+    // Param bags: absent = the stage's declared defaults.
+    if let Some(params) = render.object_generator_params.clone() {
+        live.object_generator_params = params;
+    }
+    if let Some(params) = render.phantom_params.clone() {
+        live.phantom_params = params;
+    }
+    // Virtual bed: absent = the built-in canonical poses (LFE direct).
+    if let Some(bed) = render.virtual_bed.clone() {
+        live.virtual_bed = Some(bed);
+    }
+}
+
+/// Write every declared live option — plus the param bags and the virtual
+/// bed — into a config. Used by the full live-state save; the OSC targeted
+/// persist stores single options through `OptionSpec::config_store`.
+pub fn store_live_to_config(render: &mut RenderConfig, live: &LiveParams) {
+    for spec in LIVE_OPTIONS {
+        (spec.config_store)(render, live);
+    }
+    // Param bags: `None` keeps the key out of the file so each stage falls
+    // back to its declared defaults.
+    render.object_generator_params = if live.object_generator_params.is_empty() {
+        None
+    } else {
+        Some(live.object_generator_params.clone())
+    };
+    render.phantom_params = if live.phantom_params.is_empty() {
+        None
+    } else {
+        Some(live.phantom_params.clone())
+    };
+    // Virtual bed: persist verbatim (round the radius for stable diffs);
+    // `None` keeps the key out so the built-in canonical poses stay in effect.
+    render.virtual_bed = live.virtual_bed.clone().map(|mut bed| {
+        bed.radius_m = (bed.radius_m as f64 * 1e6).round() as f32 / 1e6;
+        bed
+    });
+}
+
+/// The current value of every declared option, keyed by canonical name — the
+/// `options` block of the `/state/renderer` snapshot. Emitted alongside the
+/// legacy flat keys during the migration.
+pub fn options_json(live: &LiveParams) -> serde_json::Value {
+    let mut map = serde_json::Map::with_capacity(LIVE_OPTIONS.len());
+    for spec in LIVE_OPTIONS {
+        map.insert(spec.key.to_string(), (spec.get_json)(live));
+    }
+    map.into()
+}
+
+/// The machine-readable schema of every declared option, for the Studio
+/// contract check (CI) and the `data-option` binder. Shape mirrors the
+/// object-generator/phantom param schemas: an array of specs with i18n keys.
+pub fn schema_json() -> String {
+    let specs: Vec<serde_json::Value> = LIVE_OPTIONS
+        .iter()
+        .map(|spec| {
+            let (kind, values) = match spec.kind {
+                OptionKind::Bool => ("bool", None),
+                OptionKind::Enum(values) => ("enum", Some(values)),
+                OptionKind::Str => ("string", None),
+            };
+            let mut flags = Vec::new();
+            if spec.flags.contains(OptionFlags::PERSIST) {
+                flags.push("persist");
+            }
+            if spec.flags.contains(OptionFlags::REPLAN) {
+                flags.push("replan");
+            }
+            let mut obj = serde_json::json!({
+                "key": spec.key,
+                "kind": kind,
+                "default": spec.default.to_json(),
+                "flags": flags,
+                "i18nKey": spec.i18n_key,
+            });
+            if let Some(values) = values {
+                obj["values"] = values.into();
+            }
+            if let Some(help) = spec.help_i18n_key {
+                obj["helpI18nKey"] = help.into();
+            }
+            obj
+        })
+        .collect();
+    serde_json::Value::Array(specs).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_are_unique_snake_case_and_flags_sane() {
+        let mut seen = std::collections::HashSet::new();
+        for spec in LIVE_OPTIONS {
+            assert!(seen.insert(spec.key), "duplicate option key {}", spec.key);
+            assert!(
+                spec.key.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "option key {} is not snake_case",
+                spec.key
+            );
+            assert!(
+                spec.legacy_control_addr.starts_with("/omniphony/control/"),
+                "{}: bad legacy address",
+                spec.key
+            );
+            // Every declared option persists today; a non-persisted option
+            // would need a dedicated review of the save/seed paths.
+            assert!(spec.flags.contains(OptionFlags::PERSIST), "{}", spec.key);
+        }
+    }
+
+    #[test]
+    fn enum_defaults_are_listed_in_their_values() {
+        for spec in LIVE_OPTIONS {
+            if let (OptionKind::Enum(values), OptionDefault::Str(default)) =
+                (spec.kind, spec.default)
+            {
+                assert!(
+                    values.contains(&default),
+                    "{}: default '{}' missing from values",
+                    spec.key,
+                    default
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_json_parses_and_covers_every_spec() {
+        let schema: serde_json::Value =
+            serde_json::from_str(&schema_json()).expect("schema is valid JSON");
+        let specs = schema.as_array().expect("schema is an array");
+        assert_eq!(specs.len(), LIVE_OPTIONS.len());
+        for (spec, entry) in LIVE_OPTIONS.iter().zip(specs) {
+            assert_eq!(entry["key"], spec.key);
+            assert!(entry["kind"].is_string());
+            assert!(entry["i18nKey"].is_string());
+            assert!(entry["flags"].is_array());
+            if matches!(spec.kind, OptionKind::Enum(_)) {
+                assert!(entry["values"].is_array(), "{}: missing values", spec.key);
+            }
+        }
+    }
+}

--- a/omniphony-renderer/renderer/src/options.rs
+++ b/omniphony-renderer/renderer/src/options.rs
@@ -269,6 +269,34 @@ pub fn find(key: &str) -> Option<&'static OptionSpec> {
     LIVE_OPTIONS.iter().find(|spec| spec.key == key)
 }
 
+/// Apply a client value to a control's live params through `spec`: validate +
+/// set, mark the config dirty, and bump the replan epoch when a
+/// `REPLAN`-flagged option **actually changed value** — a redundant re-send
+/// (Studio reconnecting, a client echoing state back) must not force a
+/// re-plan, which can carry an audible re-prime transient. Returns the
+/// canonical value applied, or `None` when the value was rejected.
+///
+/// Persistence and client notification stay with the transport layer (the OSC
+/// dispatcher), which alone knows the config path and the subscriber list.
+pub fn apply_to_control(
+    control: &crate::live_params::RendererControl,
+    spec: &OptionSpec,
+    raw: &RawOptionValue,
+) -> Option<String> {
+    let (canonical, changed) = {
+        let mut live = control.live.write();
+        let before = (spec.get_json)(&live);
+        let canonical = (spec.set)(&mut live, raw)?;
+        let changed = (spec.get_json)(&live) != before;
+        (canonical, changed)
+    };
+    control.mark_dirty();
+    if changed && spec.flags.contains(OptionFlags::REPLAN) {
+        control.bump_options_epoch();
+    }
+    Some(canonical)
+}
+
 /// Look an option up by its pre-registry dedicated control address.
 pub fn find_by_legacy_addr(addr: &str) -> Option<&'static OptionSpec> {
     LIVE_OPTIONS

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -148,6 +148,11 @@ pub const CONTROL_OUTPUT_CHANNEL_MAPPING: &str = "/omniphony/control/output_chan
 /// `SpeakerLayout` (one entry per channel label, `spatialize` = virtual/direct);
 /// an empty string resets to the built-in canonical poses (LFE direct).
 pub const CONTROL_VIRTUAL_BED: &str = "/omniphony/control/virtual_bed";
+/// Generic setter for any declared live option (`renderer::options`):
+/// args `[key (string), value]`. The per-option addresses listed above
+/// (`channel_render_mode`, `object_generator`, `phantom_extract`,
+/// `surround_placement`, `output_channel_mapping`) are legacy aliases of this.
+pub const CONTROL_OPTION: &str = "/omniphony/control/option";
 pub const CONTROL_OVERLAY_LABELS: &str = "/omniphony/control/overlay/labels";
 pub const CONTROL_OVERLAY_OBJECTS: &str = "/omniphony/control/overlay/objects";
 pub const CONTROL_OVERLAY_TAG: &str = "/omniphony/control/overlay/tag";
@@ -225,6 +230,9 @@ pub const STATE_LAYOUT: &str = "/omniphony/state/layout";
 pub const STATE_LOG_LEVEL: &str = "/omniphony/state/log_level";
 pub const STATE_LOUDNESS: &str = "/omniphony/state/loudness";
 pub const STATE_MONITORING: &str = "/omniphony/state/monitoring";
+/// Schema of the declared live options (`renderer::options` registry rows),
+/// as a JSON string. Same pattern as `/state/object_generators` / `/state/phantom`.
+pub const STATE_OPTIONS_SCHEMA: &str = "/omniphony/state/options_schema";
 pub const STATE_OSC_DIAG: &str = "/omniphony/state/osc/diag";
 pub const STATE_OSC_METERING: &str = "/omniphony/state/osc/metering";
 pub const STATE_REALTIME_MASTER_GAIN: &str = "/omniphony/state/realtime/master_gain";
@@ -298,6 +306,7 @@ pub const ALL_CONTROL: &[&str] = &[
     CONTROL_CHANNEL_RENDER_MODE,
     CONTROL_OBJECT_GENERATOR,
     CONTROL_OBJECT_GENERATOR_PARAM,
+    CONTROL_OPTION,
     CONTROL_PHANTOM_EXTRACT,
     CONTROL_PHANTOM_EXTRACT_PARAM,
     CONTROL_SURROUND_PLACEMENT,
@@ -410,6 +419,7 @@ pub const ALL_STATE: &[&str] = &[
     STATE_LOG_LEVEL,
     STATE_LOUDNESS,
     STATE_MONITORING,
+    STATE_OPTIONS_SCHEMA,
     STATE_OSC_DIAG,
     STATE_OSC_METERING,
     STATE_REALTIME_MASTER_GAIN,

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -145,32 +145,10 @@ pub fn save_live_config_to_path(
     render.spread_distance_curve = None;
     render.size_to_spread_mode = None;
     renderer::config_fields::use_loudness::store(render, live.use_loudness);
-    renderer::config_fields::channel_render_mode::store(render, live.channel_render_mode);
-    renderer::config_fields::surround_placement::store(render, live.surround_placement);
-    renderer::config_fields::output_channel_mapping::store(render, live.output_channel_mapping);
-    renderer::config_fields::object_generator_id::store(render, &live.object_generator_id);
-    // Active generator's live param overrides (declared-schema map). `None` keeps
-    // the key out of the file so each generator falls back to its declared
-    // defaults.
-    render.object_generator_params = if live.object_generator_params.is_empty() {
-        None
-    } else {
-        Some(live.object_generator_params.clone())
-    };
-    // Phantom-source extraction pre-stage: enable flag + its param overrides.
-    renderer::config_fields::phantom_enabled::store(render, live.phantom_enabled);
-    render.phantom_params = if live.phantom_params.is_empty() {
-        None
-    } else {
-        Some(live.phantom_params.clone())
-    };
-    // Parametrable virtual bed for channel content. Persist the live layout
-    // verbatim (round6 the radius for stable diffs); `None` keeps the key out of
-    // the file so the built-in canonical poses (LFE direct) stay in effect.
-    render.virtual_bed = live.virtual_bed.clone().map(|mut bed| {
-        bed.radius_m = round6(bed.radius_m);
-        bed
-    });
+    // Declared live options (registry rows) + their param bags and the virtual
+    // bed: one call covers what the OSC targeted persists cover, so the full
+    // save and the per-option writes cannot drift.
+    renderer::options::store_live_to_config(render, &live);
     renderer::config_fields::auto_gain::store(render, live.auto_gain);
     renderer::config_fields::auto_gain_ceiling_db::store(render, live.auto_gain_ceiling_db);
     renderer::config_fields::vbap_distance_model::store(render, live.distance_model.to_string());

--- a/omniphony-renderer/runtime_control/src/snapshot.rs
+++ b/omniphony-renderer/runtime_control/src/snapshot.rs
@@ -165,6 +165,10 @@ pub fn build_renderer_state_json(
         "surroundPlacement": live.surround_placement.as_str(),
         "outputChannelMapping": live.output_channel_mapping.as_str(),
         "outputChannelMappingUnroutable": unroutable_speaker_names,
+        // Declared live options, emitted generically from the registry under
+        // their canonical (snake_case) keys. The flat camelCase keys above are
+        // the legacy spellings, kept while clients migrate to this block.
+        "options": renderer::options::options_json(live),
         // Parametrable virtual bed for channel content (null = built-in
         // canonical poses, LFE direct). Reuses the speaker-layout schema so the
         // Studio 3D editor can target it.
@@ -395,6 +399,13 @@ pub fn build_live_state_bundle(
             args: vec![OscType::String(build_renderer_capabilities_json(
                 has_audio, has_input,
             ))],
+        }),
+        OscPacket::Message(OscMessage {
+            // Schema of the declared live options (registry rows: key, kind,
+            // default, flags, i18n keys) — same pattern as the generator /
+            // phantom param schemas, so clients can build controls from it.
+            addr: crate::osc_contract::STATE_OPTIONS_SCHEMA.to_string(),
+            args: vec![OscType::String(renderer::options::schema_json())],
         }),
         OscPacket::Message(OscMessage {
             addr: "/omniphony/state/renderer".to_string(),

--- a/omniphony-renderer/runtime_control/tests/live_options_conformance.rs
+++ b/omniphony-renderer/runtime_control/tests/live_options_conformance.rs
@@ -251,6 +251,146 @@ fn snapshot_carries_every_live_option() {
     }
 }
 
+/// Registry-driven nets (phase 1): the declared `renderer::options` rows must
+/// agree with the snapshot, the config round-trip, the schema, and the OSC
+/// catalogue — one non-default sample value per row exercises all of it.
+mod registry {
+    use super::*;
+    use renderer::options::{self, RawOptionValue};
+
+    /// A non-default sample per declared option, keyed by canonical name.
+    /// Extending the registry without extending this list fails loudly below.
+    fn non_default_samples() -> Vec<(&'static str, RawOptionValue<'static>)> {
+        vec![
+            ("channel_render_mode", RawOptionValue::Str("host")),
+            ("surround_placement", RawOptionValue::Str("back")),
+            ("output_channel_mapping", RawOptionValue::Str("by_name")),
+            ("object_generator_id", RawOptionValue::Str("copy_up")),
+            ("phantom_enabled", RawOptionValue::Number(1.0)),
+        ]
+    }
+
+    fn sample_for(key: &str) -> RawOptionValue<'static> {
+        non_default_samples()
+            .into_iter()
+            .find(|(k, _)| *k == key)
+            .unwrap_or_else(|| panic!("no non-default sample for registry option {key}"))
+            .1
+    }
+
+    #[test]
+    fn legacy_addresses_are_catalogued_and_resolvable() {
+        for spec in options::LIVE_OPTIONS {
+            assert!(
+                osc_contract::ALL_CONTROL.contains(&spec.legacy_control_addr),
+                "{}: legacy address missing from ALL_CONTROL",
+                spec.key
+            );
+            assert!(options::find(spec.key).is_some(), "{}", spec.key);
+            assert!(
+                options::find_by_legacy_addr(spec.legacy_control_addr).is_some(),
+                "{}",
+                spec.key
+            );
+        }
+        assert!(
+            osc_contract::ALL_CONTROL.contains(&osc_contract::CONTROL_OPTION),
+            "generic /control/option missing from ALL_CONTROL"
+        );
+    }
+
+    /// The snapshot `options` block carries every registry row, and its
+    /// defaults agree with the published schema defaults — a divergence means
+    /// the constructed `LiveParams` default and the declared default drifted.
+    #[test]
+    fn snapshot_options_block_matches_registry_and_schema_defaults() {
+        let control = fixture_control();
+        let snapshot = snapshot_json(&control);
+        let block = snapshot
+            .get("options")
+            .expect("snapshot has an options block");
+        let schema: serde_json::Value =
+            serde_json::from_str(&options::schema_json()).expect("valid schema");
+        for (spec, schema_entry) in options::LIVE_OPTIONS.iter().zip(schema.as_array().unwrap()) {
+            let value = block
+                .get(spec.key)
+                .unwrap_or_else(|| panic!("{}: missing from the options block", spec.key));
+            assert_eq!(
+                value, &schema_entry["default"],
+                "{}: snapshot default != declared schema default",
+                spec.key
+            );
+        }
+    }
+
+    /// set → store → seed round-trip: a value applied through the registry
+    /// setter survives a config save and re-seeds a fresh boot identically —
+    /// the CLI and FFI boot paths call the exact seed used here.
+    #[test]
+    fn set_store_seed_round_trips_every_option() {
+        let control = fixture_control();
+        {
+            let mut live = control.live.write();
+            for spec in options::LIVE_OPTIONS {
+                let raw = sample_for(spec.key);
+                assert!(
+                    (spec.set)(&mut live, &raw).is_some(),
+                    "{}: sample value rejected",
+                    spec.key
+                );
+            }
+        }
+        let mut render = RenderConfig::default();
+        {
+            let live = control.live.read();
+            options::store_live_to_config(&mut render, &live);
+        }
+
+        let fresh = fixture_control();
+        {
+            let mut live = fresh.live.write();
+            options::seed_live_from_config(&mut live, &render);
+        }
+        let changed = control.live.read();
+        let seeded = fresh.live.read();
+        for spec in options::LIVE_OPTIONS {
+            assert_eq!(
+                (spec.get_json)(&changed),
+                (spec.get_json)(&seeded),
+                "{}: value lost in the store→seed round-trip",
+                spec.key
+            );
+        }
+    }
+
+    /// Every declared option accepts its sample through the setter and reports
+    /// a canonical value; the setter rejects a shape no option accepts.
+    #[test]
+    fn setters_validate_and_report_canonical_values() {
+        let control = fixture_control();
+        let mut live = control.live.write();
+        for spec in options::LIVE_OPTIONS {
+            let raw = sample_for(spec.key);
+            let canonical = (spec.set)(&mut live, &raw);
+            assert!(canonical.is_some(), "{}: sample rejected", spec.key);
+            if let options::OptionKind::Enum(values) = spec.kind {
+                let canonical = canonical.unwrap();
+                assert!(
+                    values.contains(&canonical.as_str()),
+                    "{}: canonical '{}' not in declared values",
+                    spec.key,
+                    canonical
+                );
+                assert!(
+                    (spec.set)(&mut live, &RawOptionValue::Str("no_such_value_xyz")).is_none(),
+                    "{}: junk value accepted",
+                    spec.key
+                );
+            }
+        }
+    }
+}
+
 /// Config save persists every live option when non-default and omits its key
 /// when default (the value==default → key-absent contract). An option dropped
 /// from `persist.rs` silently loses user settings on save.

--- a/omniphony-renderer/runtime_control/tests/live_options_conformance.rs
+++ b/omniphony-renderer/runtime_control/tests/live_options_conformance.rs
@@ -363,6 +363,54 @@ mod registry {
         }
     }
 
+    /// `apply_to_control` bumps the replan epoch exactly when a REPLAN-flagged
+    /// option **changes value**: a redundant re-send (a client echoing state
+    /// back) must not force a re-plan, and non-REPLAN options never bump.
+    #[test]
+    fn apply_bumps_epoch_only_on_real_replan_change() {
+        let control = fixture_control();
+        let placement = options::find("surround_placement").expect("registered");
+        let mode = options::find("channel_render_mode").expect("registered");
+
+        let epoch = control.options_epoch();
+        assert_eq!(
+            options::apply_to_control(&control, placement, &RawOptionValue::Str("back")).as_deref(),
+            Some("back")
+        );
+        assert_eq!(control.options_epoch(), epoch + 1, "real change must bump");
+
+        assert!(
+            options::apply_to_control(&control, placement, &RawOptionValue::Str("back")).is_some()
+        );
+        assert_eq!(
+            control.options_epoch(),
+            epoch + 1,
+            "redundant re-send must not bump (it would re-prime the stages)"
+        );
+
+        assert!(
+            options::apply_to_control(&control, placement, &RawOptionValue::Str("bogus")).is_none()
+        );
+        assert_eq!(
+            control.options_epoch(),
+            epoch + 1,
+            "rejected value: no bump"
+        );
+
+        assert!(options::apply_to_control(&control, mode, &RawOptionValue::Str("host")).is_some());
+        assert_eq!(
+            control.options_epoch(),
+            epoch + 1,
+            "non-REPLAN option must not bump"
+        );
+        assert!(
+            control
+                .config_dirty
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "apply must mark the config dirty"
+        );
+    }
+
     /// Every declared option accepts its sample through the setter and reports
     /// a canonical value; the setter rejects a shape no option accepts.
     #[test]

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -422,6 +422,16 @@ fn init_osc_runtime(
 
         ctrl.set_requested_ramp_mode(args.ramp_mode.into());
         ctrl.live.write().ramp_mode = args.ramp_mode.into();
+
+        // Declared live options + their param-bag companions and the virtual
+        // bed: seeded from the effective config through the shared registry
+        // seed — the same call as the embedded host (`Engine::from_paths`), so
+        // the two boot paths cannot drift (FFI/CLI parity by construction).
+        // The flag-backed options are then overridden from the resolved CLI
+        // args, which already folded config through flag > config > default.
+        if let Some(render) = render_cfg.as_ref() {
+            renderer::options::seed_live_from_config(&mut ctrl.live.write(), render);
+        }
         ctrl.live.write().channel_render_mode = args.channel_render_mode.into();
         ctrl.live.write().surround_placement = args.surround_placement.into();
 

--- a/omniphony-studio/scripts/check-options-schema.mjs
+++ b/omniphony-studio/scripts/check-options-schema.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Options-schema contract check (registry RFC phase 1, docs/live-options-registry.md).
+//
+// The renderer dumps its declared live options (`cargo run -p renderer
+// --example dump_options_schema`); this script asserts every declared option
+// is actually surfaceable by the Studio:
+//   - the schema is well-formed (key, kind, default, flags),
+//   - every i18nKey / helpI18nKey resolves in src/i18n/en.json (the reference
+//     locale — per-locale parity is check-i18n.mjs's job).
+//
+// Unlike the warn-only i18n parity check, this is a hard gate: an option
+// declared engine-side but invisible to the UI is exactly the silent-omission
+// class the registry exists to kill.
+//
+// Usage: node scripts/check-options-schema.mjs <path-to-options-schema.json>
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const schemaPath = process.argv[2];
+if (!schemaPath) {
+  console.error('usage: check-options-schema.mjs <options-schema.json>');
+  process.exit(2);
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const en = JSON.parse(readFileSync(join(here, '..', 'src', 'i18n', 'en.json'), 'utf8'));
+
+// en.json uses flat, literally-dotted keys; tolerate nested objects too.
+function resolvesInEn(key) {
+  if (typeof en[key] === 'string') return true;
+  let node = en;
+  for (const part of key.split('.')) {
+    if (node === null || typeof node !== 'object' || !(part in node)) return false;
+    node = node[part];
+  }
+  return typeof node === 'string';
+}
+
+const KINDS = new Set(['bool', 'enum', 'string']);
+const failures = [];
+const fail = (msg) => {
+  failures.push(msg);
+  if (process.env.GITHUB_ACTIONS) console.log(`::error::options-schema: ${msg}`);
+};
+
+let schema;
+try {
+  schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+} catch (e) {
+  fail(`cannot read/parse ${schemaPath}: ${e.message}`);
+  report();
+}
+if (!Array.isArray(schema) || schema.length === 0) {
+  fail('schema is not a non-empty array');
+  report();
+}
+
+const seen = new Set();
+for (const spec of schema) {
+  const key = spec.key;
+  if (typeof key !== 'string' || !/^[a-z][a-z_]*$/.test(key)) {
+    fail(`bad option key: ${JSON.stringify(key)}`);
+    continue;
+  }
+  if (seen.has(key)) fail(`${key}: duplicate key`);
+  seen.add(key);
+  if (!KINDS.has(spec.kind)) fail(`${key}: unknown kind '${spec.kind}'`);
+  if (spec.kind === 'enum') {
+    if (!Array.isArray(spec.values) || spec.values.length < 2) {
+      fail(`${key}: enum without >= 2 values`);
+    } else if (!spec.values.includes(spec.default)) {
+      fail(`${key}: default '${spec.default}' not in values`);
+    }
+  }
+  if (spec.default === undefined) fail(`${key}: missing default`);
+  if (!Array.isArray(spec.flags)) fail(`${key}: missing flags`);
+  if (typeof spec.i18nKey !== 'string' || !resolvesInEn(spec.i18nKey)) {
+    fail(`${key}: i18nKey '${spec.i18nKey}' does not resolve in en.json`);
+  }
+  if (spec.helpI18nKey !== undefined && !resolvesInEn(spec.helpI18nKey)) {
+    fail(`${key}: helpI18nKey '${spec.helpI18nKey}' does not resolve in en.json`);
+  }
+}
+
+report();
+
+function report() {
+  if (failures.length) {
+    console.error(`options-schema contract: ${failures.length} failure(s)`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log(`options-schema contract: OK (${schema.length} declared options)`);
+  process.exit(0);
+}

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -331,6 +331,13 @@ pub struct AppState {
     /// the UI without a typed mirror here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub binaural: Option<serde_json::Value>,
+    /// Declared live options (`options` block of `/state/renderer`, canonical
+    /// snake_case keys straight from the renderer's registry). Passthrough
+    /// JSON: a registry row needs no typed mirror here (registry RFC phase 1).
+    /// The typed [`LiveOptionsState`] fields above remain the UI's consumers
+    /// until the `data-option` binder (phase 2) reads this instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<serde_json::Value>,
     #[serde(rename = "sourceLevels")]
     pub source_levels: HashMap<String, Meter>,
     #[serde(rename = "speakerLevels")]
@@ -701,6 +708,7 @@ impl Default for AppState {
             render_evaluation_mode_state: RenderEvaluationModeState::default(),
             object_size_intervals: 0,
             binaural: None,
+            options: None,
             vbap_allow_negative_z: None,
             adaptive_resampling: Some(0),
             adaptive_resampling_enable_far_mode: Some(1),

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -142,6 +142,9 @@ struct RendererDomainState {
     vbap_cartesian: Option<VbapCartesian>,
     vbap_polar: Option<VbapPolar>,
     render_backend_state: Option<RenderBackendState>,
+    /// Declared live options (registry RFC phase 1): the renderer's `options`
+    /// block, passed through verbatim — no typed mirror needed per option.
+    options: Option<serde_json::Value>,
     /// The live 2D-sources / routing options, collected by key (flatten) and
     /// mirrored into `AppState` verbatim — see [`LiveOptionsState`].
     #[serde(flatten)]
@@ -644,6 +647,9 @@ fn apply_renderer_domain_state(s: &mut AppState, value: &str) -> bool {
     }
     if let Some(render_backend_state) = parsed.render_backend_state {
         s.render_backend_state = render_backend_state;
+    }
+    if let Some(options) = parsed.options {
+        s.options = Some(options);
     }
     // The renderer domain always carries the full option set, so mirror it
     // wholesale (an explicit `virtualBed: null` must reach the UI — it means

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -556,6 +556,11 @@ export function applyInitState(payload) {
       materializeDefaultVirtualBed();
     }
   }
+  // Declared live options passthrough (registry RFC phase 1) — ingested
+  // generically; no per-option line needed here for registry options.
+  if (payload.options && typeof payload.options === 'object') {
+    Object.assign(app.options, payload.options);
+  }
   if (typeof payload.audioOutputDevice === 'string') {
     app.audioOutputDevice = payload.audioOutputDevice.trim() || null;
   }

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -263,6 +263,11 @@ export const app = {
   // Parametrable virtual bed for 2D sources (a SpeakerLayout-shaped object, or
   // null = built-in canonical poses). Edited by the virtual-bed editor.
   virtualBed: null,
+  // Declared live options passthrough (registry RFC phase 1): the renderer's
+  // `options` snapshot block, keyed by canonical snake_case option key. The
+  // camelCase fields above stay the UI's consumers until the data-option
+  // binder (phase 2) reads this instead.
+  options: {},
   // One-shot guard: once we've materialised the canonical bed into the
   // renderer/config (when none was saved), don't push it again this session.
   virtualBedMaterialized: false,


### PR DESCRIPTION
Phase 1 of the live-options registry RFC (`docs/live-options-registry.md`). **Stacked on #180** — merge #180 first; the first two commits here are its content and this diff shrinks to the last three once it lands (I'll rebase). Both branches are rebased on post-#178 main.

## What lands

**`renderer/src/options.rs` — one `OptionSpec` row per live option.** The 2D-sources family is migrated (`channel_render_mode`, `surround_placement`, `output_channel_mapping`, `object_generator_id`, `phantom_enabled`). Options stay typed `LiveParams` fields for the audio hot path (zero per-frame cost change); the registry is the declaration + plumbing layer:

- **OSC**: generic `/omniphony/control/option [key, value]`; the five dedicated addresses are exact aliases of the same path. Five hand-written handlers (~120 lines) and three copy-pasted targeted-persist helpers collapse into one registry-driven apply + one shared sidecar-clearing writer.
- **Seeding**: one `seed_live_from_config()` shared by the CLI bootstrap and `Engine::from_paths`. **Fixes a real parity bug**: the standalone (CLI) renderer never seeded `output_channel_mapping`, `object_generator_*`, `phantom_*` or the virtual bed from config — those settings silently reverted on a service restart while working fine in mpv. CLI flags still win for the two flag-backed options.
- **Persistence**: full save and targeted writes share `store_live_to_config()`. `object_generator_id` / `phantom_enabled` now persist immediately on OSC like the other three (uniform PERSIST semantics; previously deferred to the dirty flush).
- **Snapshot/schema**: generic `options` block (canonical snake_case keys) beside the legacy flat keys; `/state/options_schema` publishes the registry (param-schema pattern).
- **Replan epoch — now fully wired** (post-#178): both `PlanSig`s compare `RendererControl::options_epoch` instead of enumerating options; the placement field #178 added to them is subsumed. The epoch bumps in `options::apply_to_control` **only when a REPLAN-flagged option actually changes value** — a redundant re-send (Studio reconnect, state echo) cannot force a re-plan, which would carry an audible re-prime transient on the spectral phantom method. `PrepareCtx` (the contributor-facing generator API) is untouched; the epoch rides as a `sync()` argument. Param-derived plan inputs (`method`/`passes`/`center`/`sides`) stay in the phantom signature by design (params are not registry options; strength drags must not re-plan).
- **Studio**: single `options` JSON passthrough (Tauri) + one generic JS ingestion line. The typed `LiveOptionsState` mirror stays until the phase-2 `data-option` binder.
- **CI contract gate**: the renderer dumps its schema (`dump_options_schema` example); `check-options-schema.mjs` hard-fails when a declared option's i18n keys don't resolve in `en.json`. All five options reuse existing i18n keys — no locale churn.

## Contributor cost after this PR

`LiveParams` field + `config_fields` descriptor + **one registry row** (+ i18n). OSC, persistence, CLI/FFI seeding, snapshot, schema, replan invalidation and the CI gates derive from the row; the conformance net fails on any missing layer. UI wiring stays hand-written until phase 2.

## Verification

- 416 workspace tests green — incl. the #178 placement-replan tests reworked onto the epoch contract (with the negative case: a ctx flip without a bump keeps the plan) and a new `apply_to_control` semantics net (bump on change; no bump on redundant, rejected, or non-REPLAN sets).
- `cargo fmt --check`, src-tauri `cargo check`, vite build, knip, and the contract check all green locally.

## Not in this PR

- Phase 2: the `data-option` binder + deletion of the typed mirror and hand-written listeners.
- CLI flags for the newly-seeded options (tracked by `docs/option-surface-parity.fr.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)