### PR TITLE
Docs: per-band phantom walkthrough + design rationale

### DIFF
--- a/docs/phantom-extraction-methods.md
+++ b/docs/phantom-extraction-methods.md
@@ -45,6 +45,63 @@ residual never drops below `1 − strength`).
   not compensated anywhere.
 - **Passes** and the **Relocalize** switches have no effect in this mode.
 
+### How the per-band analysis works (walkthrough)
+
+The method never reasons about *channels* — it reconstructs the **sound
+field**: "standing at the centre of the room while the bed speakers play,
+where does the sound come from?" `Direct_F` means *the front direction*, not
+the centre channel. Step by step, once per hop (512 samples):
+
+1. **Three virtual microphones.** Every positionable bed channel has a known
+   canonical azimuth (C at 0°, L at −30°, the surrounds at their side/back
+   corners…), so three imaginary coincident microphones at the centre can be
+   synthesized as plain weighted sums of the channel spectra:
+   `W` (omni) = Σ spectra; `F` (front-facing figure-8) = Σ spectra·cos(az);
+   `R` (right-facing figure-8) = Σ spectra·sin(az). No extra FFTs — the
+   dipoles are linear combinations of the per-channel spectra.
+2. **Per frequency bin** (smoothed over ~80 ms so estimates don't jitter),
+   the three signals combine into the **active intensity vector** — the
+   direction the energy of *that band* flows through the centre:
+   `i_front = Re(W*·F)`, `i_right = Re(W*·R)`.
+   - Direction of arrival: `az = atan2(i_right, i_front)` (0° = front).
+   - Diffuseness `ψ`: when the intensity magnitude matches the bin energy,
+     the band arrives from one clear direction (`ψ ≈ 0`); when the channels
+     cancel each other (decorrelated ambience), the vector shrinks
+     (`ψ ≈ 1`). The extraction depth is `d = strength · (1 − ψ)`.
+3. **Routing.** The fraction `d` of the bin — taken from `W`, the omni mix —
+   is credited to the sector object covering its DOA: eight 45° slices,
+   `Direct_F` at ±22.5° around straight ahead, `Direct_FR` around 45°, and so
+   on. Assignment is soft between the two adjacent sectors (a source at 20°
+   splits F/FR proportionally — no click when it crosses a boundary). The
+   remaining `1 − d` of the bin stays in the original bed channels.
+4. **A sector object's audio** is the inverse FFT of everything credited to
+   its slice this frame: all bands, from all channels jointly, whose
+   direction points its way.
+5. **A sector object's position** is the energy-weighted mean DOA of those
+   same bands (smoothed ~80 ms), projected on the room perimeter, `z` set by
+   **Lift**. An empty sector falls back to its static slice centre. The
+   object therefore *moves inside its 45° slice*, tracking where its current
+   content actually comes from.
+
+Worked example — a film mix:
+
+- Dialogue in C: its bands arrive from 0° exactly → credited to `Direct_F`,
+  which hovers at front-centre, right next to the bed's C object. **Seeing
+  both a static `C` and a moving `Direct_F` is the expected picture**: the
+  bed channel keeps the residual `1 − d` (extraction never removes a channel,
+  it drains its directional energy — bounded by **Extraction**), while the
+  sector object carries the extracted direct part. Raise **Extraction**
+  toward 1 and the bed C fades in favour of `Direct_F`; lower it for the
+  opposite.
+- A stereo phantom centre (dialogue panned equally L/R) *also* arrives from
+  ≈0° → same `Direct_F`. That is the point of the feature: the phantom image
+  *between* two speakers becomes a real object at its perceived position.
+- A guitar panned L-to-C points at −15…−20° → mostly `Direct_F`, pulling its
+  mean DOA leftward: the "wandering F".
+- Meanwhile a bright effect in the surrounds has its *own* bins pointing
+  backwards → `Direct_B`, simultaneously and independently — the case the
+  broadband method averages away.
+
 ### Model limits
 
 - The diffuseness split is exact only for direction-balanced content.
@@ -54,6 +111,43 @@ residual never drops below `1 − strength`).
 - Two sources overlapping in the same time-frequency bin share a single DOA
   (the usual W-disjointness assumption); they get placed between their true
   positions. Spectrally disjoint sources are the case this method wins on.
+
+## Design notes — why not "the broadband principle, per band"?
+
+A natural question: the broadband method's *shape* (pairwise Wiener between
+adjacent speakers, one phantom panned by the level ratio) could have been kept
+and simply run **per frequency band** — a classic pan-frequency upmix
+(Avendano/Jot style). It was considered and rejected; the per-band method
+deliberately switches to DirAC's global-field formulation instead:
+
+- **Pairwise doesn't compose.** Pairs and arcs overlap on shared speakers
+  (C, the surround corners), so the broadband code needs an explicit claiming
+  order; per band, that ordering problem multiplies by the number of bins.
+  Sources spanning three or more speakers still confuse every pairwise
+  estimate. The intensity vector reads **all channels jointly** and gives one
+  consistent 360° answer per band, for any channel count, with no ordering.
+- **Object count.** Per-band pairwise either keeps one moving object per pair
+  (re-importing the averaging problem inside each pair, just narrower) or
+  needs several objects per pair to keep simultaneous sources apart —
+  an unbounded plan. The field formulation lands on a **fixed set of eight
+  sector objects** regardless of input layout: stable renderer channel slots,
+  no allocation, realtime-friendly.
+- **Cost.** Pairwise-per-band needs its own spectral estimate per pair;
+  the field analysis reuses the *same* per-channel FFTs for everything —
+  the three virtual microphones are linear combinations, not extra
+  transforms.
+- **Diffuseness comes for free.** The same intensity vector that gives the
+  DOA gives `ψ`, the principled direct/diffuse split — exactly what the
+  downstream height generators want (the `dirac` backend uses the same
+  virtual B-format model, so the two stages agree on what "diffuse" means).
+- **Why keep broadband at all:** zero latency and lower cost. When one
+  dominant source moves between two speakers, the per-pair pan ratio tracks
+  it just as well — the default stays broadband; per-band is the opt-in for
+  complex, layered mixes.
+
+The one thing the pairwise shape did that the field method gives up is the
+per-pair *placement between exact speaker positions*; the sector DOA mean
+recovers it in practice (step 5 above) without being tied to pairs.
 
 ## Interaction with the object generators
 


### PR DESCRIPTION
Docs-only. Extends `docs/phantom-extraction-methods.md` with:

- **How the per-band analysis works** — the field-reconstruction walkthrough (three virtual microphones as linear combinations of the channel spectra, per-bin intensity vector → DOA + diffuseness, soft 45°-sector routing, residual, energy-weighted sector positions), plus a worked film-mix example that answers the "why do I see a static `C` *and* a moving `Direct_F`" question directly.
- **Design notes** — why the broadband pairwise principle was not simply re-run per band (Avendano/Jot-style pan-frequency upmix was considered): pairwise claiming doesn't compose across shared speakers, object plan becomes unbounded vs the fixed 8-sector set, per-pair spectral cost vs shared FFTs, and the intensity vector gives the direct/diffuse split for free — consistent with the `dirac` height backend's model. Also why broadband stays the default (zero latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)