### PR TITLE
fix(sofa): pin patched sofar so ASH Toolset SOFA files load

### DIFF
--- a/omniphony-renderer/Cargo.toml
+++ b/omniphony-renderer/Cargo.toml
@@ -95,3 +95,9 @@ asio = []
 
 # Legacy compatibility alias. PipeWire support is compiled by default on Linux.
 pipewire = []
+
+# sofar 0.3.0 drops variables from netCDF4-written SOFA files (ASH Toolset
+# exports, issue #185). Drop once https://github.com/andreiltd/sofar/pull/29
+# ships in a release.
+[patch.crates-io]
+sofar = { git = "https://github.com/mgth/sofar", rev = "c03ff5cfd997d316ae330e2735e82311769b45a3" }

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -3852,8 +3852,7 @@ dependencies = [
 [[package]]
 name = "sofar"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060ea9e290d57f909c19dfd5673a489cfedf4fdcf02eeae65a470a4923225be2"
+source = "git+https://github.com/mgth/sofar?rev=c03ff5cfd997d316ae330e2735e82311769b45a3#c03ff5cfd997d316ae330e2735e82311769b45a3"
 dependencies = [
  "arrayvec",
  "audioadapter-buffers",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -60,3 +60,9 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+
+# sofar 0.3.0 drops variables from netCDF4-written SOFA files (ASH Toolset
+# exports, issue #185). Drop once https://github.com/andreiltd/sofar/pull/29
+# ships in a release.
+[patch.crates-io]
+sofar = { git = "https://github.com/mgth/sofar", rev = "c03ff5cfd997d316ae330e2735e82311769b45a3" }


### PR DESCRIPTION
## Summary

SOFA files exported by the ASH Toolset (issue #185) failed to load with `LookupBuildFailed`, or loaded with silently missing variables. Root cause is not the files: `sofar` 0.3.0's hand-rolled HDF5 parser mis-parses object headers written by recent netCDF4/HDF5 (the writer stack behind SOFASonix, which ASH uses):

1. trailing gaps in header chunks were read as messages (breaks with attribute creation order tracking, which netCDF4 always enables) — the affected variable is silently dropped;
2. header continuation blocks past 32 MiB were rejected (netCDF4 appends them at end of file), losing e.g. `Data.SamplingRate` on large sets;
3. unlimited dimensions (`S`) failed a dimension-size sanity check.

Because the reader defaults unparsable variables, symptoms depended on file layout: `LookupBuildFailed` when `SourcePosition` was hit, silent data loss otherwise.

## Change

Pin `sofar` via `[patch.crates-io]` to a dependency-neutral fixed fork (`v0.3.0` + fix) in both the renderer workspace and the Studio SOFA browser. Upstream PR: [andreiltd/sofar#29](https://github.com/andreiltd/sofar/pull/29) — drop the pin once it ships in a release.

## Testing

- Faithful replicas of ASH Toolset exports (SOFASonix writer, SimpleFreeFieldHRIR and GeneralFIR conventions, 1800-direction "High" grid, plus a 127 MB long-IR variant) now load through `hrir_set_from_sofa` in this workspace; verified with a transient `cargo test -p renderer --features sofa` smoke test.
- MIT KEMAR (classic layout): interpolated filters bit-identical with pristine vs patched sofar.
- `cargo build -p orender_ffi` (default `sofa` feature) and `cargo check` in `omniphony-studio/src-tauri` pass; lock updates touch only the sofar source (125 resp. 160 deps unchanged).
- Upstream fork carries a 20 kB regression fixture + tests (`cargo test --test netcdf4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
