### PR TITLE
refactor: one shared channel-label alias table (contract phase 1)

### DIFF
--- a/omniphony-renderer/bridge_api/src/labels.rs
+++ b/omniphony-renderer/bridge_api/src/labels.rs
@@ -1,0 +1,222 @@
+//! Canonical naming and alias matching for [`RChannelLabel`].
+//!
+//! Single source of truth relating a channel label to its canonical short
+//! name and to the spellings accepted from layout YAMLs, hand-edited configs
+//! and format channel tables. Every mapping between speaker names, channel
+//! labels and display names in the stack must go through this module — see
+//! `docs/channel-object-contract.md` ("Naming").
+//!
+//! Matching is alias-tolerant: names are normalised by uppercasing and
+//! stripping whitespace, `_` and `-`, so `"Top Front Left"`,
+//! `"TOP_FRONT_LEFT"` and `"TFL"` all resolve to [`RChannelLabel::Tfl`].
+
+use crate::RChannelLabel;
+
+/// Accepted spellings per label, in normalised form (uppercase, no
+/// whitespace/`_`/`-`). The first entry of each list is only an alias like
+/// the others; canonical display names come from [`canonical_name`].
+///
+/// This table is the union of the historical matchers it replaces
+/// (`orender_engine::channel_layout::label_for_speaker_name` and
+/// `renderer::speaker_layout::bed_to_speaker_mapping`); parity with both is
+/// pinned by tests here and in the consuming crates.
+const ALIASES: &[(RChannelLabel, &[&str])] = &[
+    (RChannelLabel::L, &["FL", "L", "FRONTLEFT", "LEFTFRONT"]),
+    (RChannelLabel::R, &["FR", "R", "FRONTRIGHT", "RIGHTFRONT"]),
+    (
+        RChannelLabel::C,
+        &["C", "FC", "CENTER", "CENTRE", "FRONTCENTER"],
+    ),
+    (
+        RChannelLabel::LFE,
+        &["LFE", "LFE1", "SUB", "SUBWOOFER", "SW"],
+    ),
+    (RChannelLabel::LFE2, &["LFE2"]),
+    (
+        RChannelLabel::Ls,
+        &["SL", "LS", "SIDELEFT", "SURROUNDLEFT", "LEFTSURROUND"],
+    ),
+    (
+        RChannelLabel::Rs,
+        &["SR", "RS", "SIDERIGHT", "SURROUNDRIGHT", "RIGHTSURROUND"],
+    ),
+    (
+        RChannelLabel::Lb,
+        &[
+            "BL", "LB", "LRS", "BACKLEFT", "LEFTBACK", "REARLEFT", "LEFTREAR",
+        ],
+    ),
+    (
+        RChannelLabel::Rb,
+        &[
+            "BR",
+            "RB",
+            "RRS",
+            "BACKRIGHT",
+            "RIGHTBACK",
+            "REARRIGHT",
+            "RIGHTREAR",
+        ],
+    ),
+    (
+        RChannelLabel::Cb,
+        &["RC", "BC", "CB", "BACKCENTER", "REARCENTER", "CENTERBACK"],
+    ),
+    // Front-left/right of center (wide-front center pair).
+    (
+        RChannelLabel::Lsc,
+        &["LSC", "FLC", "FRONTLEFTCENTER", "LEFTCENTER"],
+    ),
+    (
+        RChannelLabel::Rsc,
+        &["RSC", "FRC", "FRONTRIGHTCENTER", "RIGHTCENTER"],
+    ),
+    // Front wide.
+    (
+        RChannelLabel::Lw,
+        &["FWL", "LW", "WL", "WIDELEFT", "FRONTWIDELEFT"],
+    ),
+    (
+        RChannelLabel::Rw,
+        &["FWR", "RW", "WR", "WIDERIGHT", "FRONTWIDERIGHT"],
+    ),
+    // Side direct (between side surround and back), where layouts use it.
+    (RChannelLabel::Lsd, &["LSD"]),
+    (RChannelLabel::Rsd, &["RSD"]),
+    // Height / top tier.
+    (
+        RChannelLabel::Tfl,
+        &[
+            "TFL",
+            "TPFL",
+            "TOPFRONTLEFT",
+            "UFL",
+            "LTF",
+            "LEFTTOPFRONT",
+            "HEIGHTLEFT",
+            "HL",
+        ],
+    ),
+    (
+        RChannelLabel::Tfr,
+        &[
+            "TFR",
+            "TPFR",
+            "TOPFRONTRIGHT",
+            "UFR",
+            "RTF",
+            "RIGHTTOPFRONT",
+            "HEIGHTRIGHT",
+            "HR",
+        ],
+    ),
+    (RChannelLabel::Tsl, &["TSL", "TPSL", "TOPSIDELEFT", "USL"]),
+    (RChannelLabel::Tsr, &["TSR", "TPSR", "TOPSIDERIGHT", "USR"]),
+    (
+        RChannelLabel::Tbl,
+        &["TBL", "TPBL", "TOPBACKLEFT", "UBL", "TRL"],
+    ),
+    (
+        RChannelLabel::Tbr,
+        &["TBR", "TPBR", "TOPBACKRIGHT", "UBR", "TRR"],
+    ),
+    (
+        RChannelLabel::Tc,
+        &["TC", "TPC", "TOPCENTER", "TOPMIDDLECENTER"],
+    ),
+    (RChannelLabel::Tfc, &["TFC", "TOPFRONTCENTER"]),
+];
+
+/// Canonical short name for a label — the form used in bundled layout YAMLs,
+/// Studio source lists and diagnostics. Lower-tier names follow the compact
+/// convention (`L`, `Ls`, `Lb`); the top tier keeps its uppercase trigrams
+/// (`TFL`, `TBR`) to match the bundled layouts.
+pub fn canonical_name(label: RChannelLabel) -> &'static str {
+    use RChannelLabel::*;
+    match label {
+        L => "L",
+        R => "R",
+        C => "C",
+        LFE => "LFE",
+        LFE2 => "LFE2",
+        Ls => "Ls",
+        Rs => "Rs",
+        Lb => "Lb",
+        Rb => "Rb",
+        Cb => "Cb",
+        Lsc => "Lsc",
+        Rsc => "Rsc",
+        Lw => "Lw",
+        Rw => "Rw",
+        Lsd => "Lsd",
+        Rsd => "Rsd",
+        Tfl => "TFL",
+        Tfr => "TFR",
+        Tsl => "TSL",
+        Tsr => "TSR",
+        Tbl => "TBL",
+        Tbr => "TBR",
+        Tc => "TC",
+        Tfc => "TFC",
+        Unknown => "Unknown",
+    }
+}
+
+/// Resolve a speaker/channel name to its label. Case-insensitive and
+/// separator-tolerant; returns [`RChannelLabel::Unknown`] for names that
+/// don't resolve (the caller then falls back to its own policy, e.g. a
+/// custom order or a plain count).
+pub fn label_for_name(name: &str) -> RChannelLabel {
+    let key = normalise(name);
+    for (label, aliases) in ALIASES {
+        if aliases.contains(&key.as_str()) {
+            return *label;
+        }
+    }
+    RChannelLabel::Unknown
+}
+
+fn normalise(name: &str) -> String {
+    name.chars()
+        .filter(|c| !c.is_whitespace() && *c != '_' && *c != '-')
+        .flat_map(|c| c.to_uppercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use RChannelLabel::*;
+
+    #[test]
+    fn canonical_names_resolve_back_to_their_label() {
+        for (label, _) in ALIASES {
+            assert_eq!(
+                label_for_name(canonical_name(*label)),
+                *label,
+                "canonical name of {label:?} must round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn aliases_are_unambiguous() {
+        let mut seen = std::collections::HashMap::new();
+        for (label, aliases) in ALIASES {
+            for alias in *aliases {
+                if let Some(prev) = seen.insert(*alias, *label) {
+                    panic!("alias {alias:?} claimed by both {prev:?} and {label:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn matching_tolerates_case_and_separators() {
+        assert_eq!(label_for_name("Top Front Left"), Tfl);
+        assert_eq!(label_for_name("TOP_FRONT_LEFT"), Tfl);
+        assert_eq!(label_for_name("tfl"), Tfl);
+        assert_eq!(label_for_name("height-right"), Tfr);
+        assert_eq!(label_for_name("nonsense"), Unknown);
+    }
+}

--- a/omniphony-renderer/bridge_api/src/lib.rs
+++ b/omniphony-renderer/bridge_api/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(non_local_definitions)]
 
+pub mod labels;
+
 use abi_stable::{
     StableAbi, declare_root_module_statics,
     library::RootModule,

--- a/omniphony-renderer/orender_engine/src/channel_layout.rs
+++ b/omniphony-renderer/orender_engine/src/channel_layout.rs
@@ -9,50 +9,11 @@
 
 use bridge_api::RChannelLabel;
 
-/// Resolve one speaker name to its channel label. Case-insensitive; tolerates
-/// the common naming variants found across the bundled layouts and hand-edited
-/// configs. Returns [`RChannelLabel::Unknown`] for names it can't place.
+/// Resolve one speaker name to its channel label. Thin wrapper over the
+/// shared alias table (`bridge_api::labels`) — the single source of truth
+/// for name↔label matching, per `docs/channel-object-contract.md` ("Naming").
 pub fn label_for_speaker_name(name: &str) -> RChannelLabel {
-    // Normalise: uppercase, drop spaces/underscores/hyphens so "Top Front Left",
-    // "TOP_FRONT_LEFT" and "TFL" all collapse to the same key.
-    let key: String = name
-        .chars()
-        .filter(|c| !c.is_whitespace() && *c != '_' && *c != '-')
-        .flat_map(|c| c.to_uppercase())
-        .collect();
-
-    use RChannelLabel::*;
-    match key.as_str() {
-        "FL" | "L" | "FRONTLEFT" | "LEFTFRONT" => L,
-        "FR" | "R" | "FRONTRIGHT" | "RIGHTFRONT" => R,
-        "C" | "FC" | "CENTER" | "CENTRE" | "FRONTCENTER" => C,
-        "LFE" | "LFE1" | "SUB" | "SUBWOOFER" | "SW" => LFE,
-        "LFE2" => LFE2,
-        "SL" | "LS" | "SIDELEFT" | "SURROUNDLEFT" | "LEFTSURROUND" => Ls,
-        "SR" | "RS" | "SIDERIGHT" | "SURROUNDRIGHT" | "RIGHTSURROUND" => Rs,
-        "BL" | "LB" | "LRS" | "BACKLEFT" | "LEFTBACK" | "REARLEFT" | "LEFTREAR" => Lb,
-        "BR" | "RB" | "RRS" | "BACKRIGHT" | "RIGHTBACK" | "REARRIGHT" | "RIGHTREAR" => Rb,
-        "RC" | "BC" | "CB" | "BACKCENTER" | "REARCENTER" | "CENTERBACK" => Cb,
-        // Front-left/right of center (wide-front center pair).
-        "LSC" | "FLC" | "FRONTLEFTCENTER" | "LEFTCENTER" => Lsc,
-        "RSC" | "FRC" | "FRONTRIGHTCENTER" | "RIGHTCENTER" => Rsc,
-        // Front wide.
-        "FWL" | "LW" | "WL" | "WIDELEFT" | "FRONTWIDELEFT" => Lw,
-        "FWR" | "RW" | "WR" | "WIDERIGHT" | "FRONTWIDERIGHT" => Rw,
-        // Side direct (between side surround and back), where layouts use it.
-        "LSD" => Lsd,
-        "RSD" => Rsd,
-        // Height / top tier.
-        "TFL" | "TPFL" | "TOPFRONTLEFT" | "UFL" => Tfl,
-        "TFR" | "TPFR" | "TOPFRONTRIGHT" | "UFR" => Tfr,
-        "TSL" | "TPSL" | "TOPSIDELEFT" | "USL" => Tsl,
-        "TSR" | "TPSR" | "TOPSIDERIGHT" | "USR" => Tsr,
-        "TBL" | "TPBL" | "TOPBACKLEFT" | "UBL" | "TRL" => Tbl,
-        "TBR" | "TPBR" | "TOPBACKRIGHT" | "UBR" | "TRR" => Tbr,
-        "TC" | "TPC" | "TOPCENTER" | "TOPMIDDLECENTER" => Tc,
-        "TFC" | "TOPFRONTCENTER" => Tfc,
-        _ => Unknown,
-    }
+    bridge_api::labels::label_for_name(name)
 }
 
 #[cfg(test)]

--- a/omniphony-renderer/renderer/Cargo.toml
+++ b/omniphony-renderer/renderer/Cargo.toml
@@ -10,6 +10,7 @@ name = "renderer"
 
 [dependencies]
 anyhow = "1"
+bridge_api = { version = "0.2.0", path = "../bridge_api" }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/omniphony-renderer/renderer/src/speaker_layout.rs
+++ b/omniphony-renderer/renderer/src/speaker_layout.rs
@@ -497,91 +497,44 @@ impl SpeakerLayout {
         self.speakers.iter().map(|s| s.name.as_str()).collect()
     }
 
-    /// Create mapping from bed channel ID to speaker index based on speaker names
+    /// Create mapping from bed channel ID to speaker index based on speaker names.
     ///
-    /// Bed channel IDs (0-9) are mapped to speakers by matching names:
-    /// - 0: L, FL, FrontLeft (Left Front)
-    /// - 1: R, FR, FrontRight (Right Front)
-    /// - 2: C, FC, Center (Center)
-    /// - 3: LFE, Sub (Low Frequency Effects)
-    /// - 4: Ls, SL, LeftSurround (Left Surround)
-    /// - 5: Rs, SR, RightSurround (Right Surround)
-    /// - 6: Lb, BL, Lrs, BackLeft (Left Back)
-    /// - 7: Rb, BR, Rrs, BackRight (Right Back)
-    /// - 8: Ltf, TFL, TopFrontLeft (Left Top Front)
-    /// - 9: Rtf, TFR, TopFrontRight (Right Top Front)
+    /// Speaker names are resolved to channel labels through the shared alias
+    /// table (`bridge_api::labels`), then labels to the legacy bed-id scheme:
     ///
-    /// Returns a HashMap<bed_id, speaker_idx> for beds found in the layout.
-    /// Beds not found are not included in the map.
+    /// - 0: L, 1: R, 2: C, 3: LFE, 4: Ls, 5: Rs, 6: Lb, 7: Rb, 8: TFL, 9: TFR
+    ///
+    /// The 0-9 scheme itself is scheduled to leave the bridge ABI (see
+    /// `docs/channel-object-contract.md`, phase 2); this mapping then becomes
+    /// label -> speaker index directly.
+    ///
+    /// Returns a HashMap<bed_id, speaker_idx> for beds found in the layout;
+    /// beds without a matching speaker are absent. The first speaker matching
+    /// a label wins.
     pub fn bed_to_speaker_mapping(&self) -> std::collections::HashMap<usize, usize> {
-        // Bed channel ID → list of possible speaker name aliases (case-insensitive)
-        let bed_aliases: [(usize, &[&str]); 10] = [
-            (0, &["L", "FL", "FrontLeft", "LeftFront"]),
-            (1, &["R", "FR", "FrontRight", "RightFront"]),
-            (2, &["C", "FC", "Center", "Centre"]),
-            (3, &["LFE", "Sub", "Subwoofer", "SW"]),
-            (4, &["Ls", "SL", "LeftSurround", "SurroundLeft"]),
-            (5, &["Rs", "SR", "RightSurround", "SurroundRight"]),
-            (
-                6,
-                &[
-                    "Lb", "BL", "Lrs", "BackLeft", "LeftBack", "RearLeft", "LeftRear",
-                ],
-            ),
-            (
-                7,
-                &[
-                    "Rb",
-                    "BR",
-                    "Rrs",
-                    "BackRight",
-                    "RightBack",
-                    "RearRight",
-                    "RightRear",
-                ],
-            ),
-            (
-                8,
-                &[
-                    "Ltf",
-                    "TFL",
-                    "TopFrontLeft",
-                    "LeftTopFront",
-                    "HeightLeft",
-                    "HL",
-                ],
-            ),
-            (
-                9,
-                &[
-                    "Rtf",
-                    "TFR",
-                    "TopFrontRight",
-                    "RightTopFront",
-                    "HeightRight",
-                    "HR",
-                ],
-            ),
-        ];
-
-        let mut mapping = std::collections::HashMap::new();
-
-        for (bed_id, aliases) in &bed_aliases {
-            // Find speaker matching any alias (case-insensitive)
-            for (speaker_idx, speaker) in self.speakers.iter().enumerate() {
-                let speaker_name_lower = speaker.name.to_lowercase();
-                for alias in *aliases {
-                    if speaker_name_lower == alias.to_lowercase() {
-                        mapping.insert(*bed_id, speaker_idx);
-                        break;
-                    }
-                }
-                if mapping.contains_key(bed_id) {
-                    break;
-                }
+        use bridge_api::RChannelLabel as Label;
+        fn bed_id(label: Label) -> Option<usize> {
+            match label {
+                Label::L => Some(0),
+                Label::R => Some(1),
+                Label::C => Some(2),
+                Label::LFE => Some(3),
+                Label::Ls => Some(4),
+                Label::Rs => Some(5),
+                Label::Lb => Some(6),
+                Label::Rb => Some(7),
+                Label::Tfl => Some(8),
+                Label::Tfr => Some(9),
+                _ => None,
             }
         }
 
+        let mut mapping = std::collections::HashMap::new();
+        for (speaker_idx, speaker) in self.speakers.iter().enumerate() {
+            if let Some(id) = bed_id(bridge_api::labels::label_for_name(&speaker.name)) {
+                mapping.entry(id).or_insert(speaker_idx);
+            }
+        }
         mapping
     }
 
@@ -727,6 +680,87 @@ impl SpeakerLayout {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bed_mapping_accepts_every_legacy_alias() {
+        // Parity net for the shared-table rewrite: every spelling the old
+        // in-place alias table accepted must still resolve to the same bed id.
+        let legacy: [(usize, &[&str]); 10] = [
+            (0, &["L", "FL", "FrontLeft", "LeftFront"]),
+            (1, &["R", "FR", "FrontRight", "RightFront"]),
+            (2, &["C", "FC", "Center", "Centre"]),
+            (3, &["LFE", "Sub", "Subwoofer", "SW"]),
+            (4, &["Ls", "SL", "LeftSurround", "SurroundLeft"]),
+            (
+                6,
+                &[
+                    "Lb", "BL", "Lrs", "BackLeft", "LeftBack", "RearLeft", "LeftRear",
+                ],
+            ),
+            (
+                7,
+                &[
+                    "Rb",
+                    "BR",
+                    "Rrs",
+                    "BackRight",
+                    "RightBack",
+                    "RearRight",
+                    "RightRear",
+                ],
+            ),
+            (
+                8,
+                &[
+                    "Ltf",
+                    "TFL",
+                    "TopFrontLeft",
+                    "LeftTopFront",
+                    "HeightLeft",
+                    "HL",
+                ],
+            ),
+            (
+                9,
+                &[
+                    "Rtf",
+                    "TFR",
+                    "TopFrontRight",
+                    "RightTopFront",
+                    "HeightRight",
+                    "HR",
+                ],
+            ),
+            (5, &["Rs", "SR", "RightSurround", "SurroundRight"]),
+        ];
+        for (bed_id, aliases) in legacy {
+            for alias in aliases {
+                let layout = SpeakerLayout::from_speakers(vec![
+                    Speaker::new("A", -30.0, 0.0),
+                    Speaker::new(*alias, 30.0, 0.0),
+                    Speaker::new("B", 110.0, 0.0),
+                ])
+                .expect("parity layout");
+                let mapping = layout.bed_to_speaker_mapping();
+                assert_eq!(
+                    mapping.get(&bed_id),
+                    Some(&1),
+                    "legacy alias {alias:?} no longer maps to bed id {bed_id}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bed_mapping_first_matching_speaker_wins() {
+        let layout = SpeakerLayout::from_speakers(vec![
+            Speaker::new("FL", -30.0, 0.0),
+            Speaker::new("FrontLeft", -31.0, 0.0),
+            Speaker::new("FR", 30.0, 0.0),
+        ])
+        .expect("dup layout");
+        assert_eq!(layout.bed_to_speaker_mapping().get(&0), Some(&0));
+    }
 
     #[test]
     fn test_speaker_creation() {


### PR DESCRIPTION
## Summary

Phase 1 of [docs/channel-object-contract.md](https://github.com/mgth/Omniphony/blob/main/docs/channel-object-contract.md): a single source of truth for channel-label naming and alias matching.

- New `bridge_api::labels`: canonical short name per `RChannelLabel` + alias-tolerant `label_for_name` (union of the two historical matchers).
- `orender_engine::channel_layout::label_for_speaker_name` becomes a thin delegate.
- `renderer::speaker_layout::bed_to_speaker_mapping` becomes a view: speaker name → label (shared table) → legacy bed id via a local shim that leaves with the 0–9 scheme in phase 2. New workspace-internal dep `renderer` → `bridge_api`.
- No ABI change, no behavior change for previously-accepted spellings.

## Tests

- `bridge_api::labels`: canonical round-trip, alias ambiguity check, case/separator tolerance.
- `renderer`: parity net asserting every legacy bed-alias spelling still maps to the same bed id; first-speaker-wins tie-break pinned.
- Full workspace suite green locally (29 suites), `cargo fmt --check` clean.

Note: matching is now uniformly separator/case-tolerant, so a few spellings the old bed table rejected (e.g. `Top Front Left`) now also map — an intentional superset, aligned with `label_for_speaker_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)