### PR TITLE
refactor: bridge ABI v2 — labeled fixed channels + declared objects (phase 2a)

### DIFF
--- a/docs/channel-object-contract.md
+++ b/docs/channel-object-contract.md
@@ -118,12 +118,20 @@ pub struct RMetadataFrame {
     /// Sparse declaration: which PCM channel carries which object.
     /// Emitted on the first metadata frame, on any change, and after reset().
     pub object_channels: RVec<RObjectChannel>,   // { id: u32, channel: u32 }
+    /// Gain automation for fixed channels (e.g. OAMD bed gains).
+    pub channel_gains: RVec<RChannelGain>,       // { channel: u32, gain_db: i8 }
     /// Sparse object-name updates, keyed by object id.
     pub name_updates: RVec<RNameUpdate>,
     pub sample_pos: u64,
     pub ramp_duration: u32,
 }
 ```
+
+Amendment (phase 2a): "objects only" was too strict — OAMD applies live
+gains to bed members too, and dropping them would have changed behavior.
+Fixed channels therefore keep metadata-driven **gain** automation
+(`channel_gains`, keyed by channel index); their *position* remains
+exclusively the renderer's decision.
 
 Removed: `bed_indices`, the 0–9 bed-id scheme, positionless bed events, and
 the `id ≥ 10 → channel num_beds + (id − 10)` arithmetic. `REvent.has_pos`

--- a/omniphony-renderer/Cargo.toml
+++ b/omniphony-renderer/Cargo.toml
@@ -22,7 +22,7 @@ renderer = { version = "0.2.4", path = "renderer" }
 audio_output = { version = "0.2.4", path = "audio_output" }
 audio_input = { version = "0.2.4", path = "audio_input" }
 sys = { version = "0.1.0", path = "sys" }
-bridge_api = { version = "0.2.0", path = "bridge_api" }
+bridge_api = { version = "0.3.0", path = "bridge_api" }
 spdif = { version = "0.1.0", path = "spdif" }
 runtime_control = { version = "0.2.4", path = "runtime_control" }
 orender_engine = { version = "0.2.2", path = "orender_engine" }

--- a/omniphony-renderer/bridge_api/Cargo.toml
+++ b/omniphony-renderer/bridge_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge_api"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 

--- a/omniphony-renderer/bridge_api/src/labels.rs
+++ b/omniphony-renderer/bridge_api/src/labels.rs
@@ -158,6 +158,7 @@ pub fn canonical_name(label: RChannelLabel) -> &'static str {
         Tbr => "TBR",
         Tc => "TC",
         Tfc => "TFC",
+        Object => "Object",
         Unknown => "Unknown",
     }
 }

--- a/omniphony-renderer/bridge_api/src/lib.rs
+++ b/omniphony-renderer/bridge_api/src/lib.rs
@@ -38,7 +38,8 @@ pub type BridgeHostLogSink = extern "C" fn(level: RLogLevel, target: RStr<'_>, m
 pub struct REvent {
     pub id: u32,
     pub sample_pos: u64,
-    /// True when `pos` contains valid 3-D coordinates (bed channels have no position).
+    /// True when `pos` contains valid 3-D coordinates. A `false` event is a
+    /// gain/ramp-only update for its object.
     pub has_pos: bool,
     /// Position payload, interpreted according to [`FormatBridge::coordinate_format`]:
     /// - Cartesian: `[x, y, z]` (ADM convention)
@@ -56,7 +57,8 @@ pub struct REvent {
     pub ramp_duration: u32,
 }
 
-/// Sparse object-name update keyed by object ID (same ID space as `REvent.id`).
+/// Sparse object-name update keyed by object id (same id space as `REvent.id`
+/// and `RObjectChannel.id`). Fixed channels are named by their label instead.
 #[repr(C)]
 #[derive(StableAbi, Clone)]
 pub struct RNameUpdate {
@@ -92,18 +94,51 @@ pub enum RChannelLabel {
     Rw = 21,
     Tfc = 22,
     LFE2 = 23,
+    /// The channel carries dynamic-object audio; its position comes from the
+    /// metadata events of the object bound to it via `RObjectChannel`.
+    Object = 24,
     Unknown = 255,
 }
 
+/// Sparse declaration binding a dynamic object to the PCM channel that
+/// carries its audio. Object ids are opaque, bridge-chosen and stable for the
+/// lifetime of the object; this mapping is the only link between an id and
+/// its channel. See `docs/channel-object-contract.md` ("ABI").
+#[repr(C)]
+#[derive(StableAbi, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RObjectChannel {
+    pub id: u32,
+    pub channel: u32,
+}
+
+/// Metadata-driven gain automation for one fixed channel (e.g. OAMD bed
+/// gains). Applied with the frame's `ramp_duration`.
+#[repr(C)]
+#[derive(StableAbi, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RChannelGain {
+    pub channel: u32,
+    pub gain_db: i8,
+}
+
 /// Spatial metadata for one payload within a decoded frame.
+///
+/// Describes dynamic objects only; fixed channels are fully described by
+/// [`RDecodedFrame::channel_labels`] (channels carrying object audio are
+/// labeled [`RChannelLabel::Object`]). Emitted only by formats that carry
+/// dynamic objects — a fixed-only presentation sends no metadata frames.
 #[repr(C)]
 #[derive(StableAbi)]
 pub struct RMetadataFrame {
-    /// Spatial events for the renderer (one per object).
+    /// Position/gain/size events, keyed by object id.
     pub events: RVec<REvent>,
-    /// Format-provided bed channel IDs (in the same ID space as `REvent.id`).
-    pub bed_indices: RVec<usize>,
-    /// Sparse object-name updates for this frame.
+    /// Sparse object↔channel declaration: emitted on the first metadata
+    /// frame, on any change, and after [`FormatBridge::reset`]. Consumers
+    /// cache it unconditionally.
+    pub object_channels: RVec<RObjectChannel>,
+    /// Gain automation for fixed channels (empty when the format has none).
+    pub channel_gains: RVec<RChannelGain>,
+    /// Sparse object-name updates for this frame (same emission rules as
+    /// `object_channels`).
     pub name_updates: RVec<RNameUpdate>,
     /// Base sample position for this metadata (= decoded_samples at frame start,
     /// without evo_sample_offset). Used for OSC timestamping.
@@ -201,11 +236,14 @@ pub trait FormatBridge: Send + Sync + 'static {
     /// `true` once at least one frame has been successfully decoded.
     fn is_ready(&self) -> bool;
 
-    /// `true` if the current presentation may contain spatial objects.
+    /// `true` while the current presentation carries dynamic objects.
     ///
-    /// Must be called after [`configure`] and before [`push_packet`].
-    /// Drives output-format decisions in the host (e.g. whether to force CAF).
-    fn is_spatial(&self) -> bool;
+    /// A live, observable fact about the stream: it may flip in either
+    /// direction mid-stream (e.g. an extension substream appearing after a
+    /// few frames, or disappearing) and must not be latched by callers.
+    /// Before the first decoded frame it reports the best container-level
+    /// guess. See `docs/channel-object-contract.md`.
+    fn has_objects(&self) -> bool;
 
     /// Set a bridge-specific configuration option.
     ///

--- a/omniphony-renderer/orender_engine/Cargo.toml
+++ b/omniphony-renderer/orender_engine/Cargo.toml
@@ -13,7 +13,7 @@ renderer = { version = "0.2.4", path = "../renderer" }
 example_backend = { path = "../example_backend" }
 # User-scriptable (Lua) render backend, registered at startup.
 script_backend = { path = "../script_backend" }
-bridge_api = { version = "0.2.0", path = "../bridge_api" }
+bridge_api = { version = "0.3.0", path = "../bridge_api" }
 runtime_control = { version = "0.2.4", path = "../runtime_control" }
 sys = { version = "0.1.0", path = "../sys" }
 # Audio output/input belong to the host_audio crate and reach the OSC server

--- a/omniphony-renderer/orender_engine/examples/perf_probe.rs
+++ b/omniphony-renderer/orender_engine/examples/perf_probe.rs
@@ -90,7 +90,7 @@ fn main() {
         "perf_probe: stream={} ramp={ramp} max_mb={max_mb} channels={} spatial={}",
         stream.display(),
         engine.channel_count(),
-        engine.is_spatial(),
+        engine.has_objects(),
     );
 
     let mut file = std::fs::File::open(&stream).expect("open stream");

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -53,6 +53,9 @@ pub struct Engine {
 
     // ── per-stream spatial state ──
     bed_indices: Option<Vec<usize>>,
+    /// Cached object↔channel declaration from the bridge (sparse emission),
+    /// sorted by channel. See `docs/channel-object-contract.md`.
+    object_channels: Vec<(u32, usize)>,
     has_objects: bool,
     loudness_applied: bool,
     decoded_samples: u64,
@@ -224,6 +227,7 @@ impl Engine {
             sample_rate,
             coordinate_format,
             bed_indices: None,
+            object_channels: Vec::new(),
             has_objects: false,
             loudness_applied: false,
             decoded_samples: 0,
@@ -525,11 +529,10 @@ impl Engine {
             .collect()
     }
 
-    /// Whether the current presentation may carry spatial objects. Valid after
-    /// the bridge has been configured; drives the host's spatial-vs-plain
-    /// fallback decision.
-    pub fn is_spatial(&self) -> bool {
-        self.bridge.bridge.is_spatial()
+    /// Whether the current presentation carries dynamic objects. A live fact
+    /// about the stream (it may flip mid-stream); hosts must not latch it.
+    pub fn has_objects(&self) -> bool {
+        self.bridge.bridge.has_objects()
     }
 
     /// Dynamic object count of the last rendered frame (decoded `channel_count`
@@ -641,6 +644,7 @@ impl Engine {
     fn reset_segment_state(&mut self) {
         self.has_objects = false;
         self.bed_indices = None;
+        self.object_channels.clear();
         self.frame_events.clear();
         self.loudness_applied = false;
         self.object_names.clear();
@@ -784,20 +788,34 @@ impl Engine {
         // Spatial metadata → bed config + per-channel events (+ OSC objects).
         for meta in frame.metadata.iter() {
             self.has_objects = true;
-            if !meta.bed_indices.is_empty() {
-                let new_bed: Vec<usize> = meta.bed_indices.iter().copied().collect();
-                if self.bed_indices.as_ref() != Some(&new_bed) {
-                    self.bed_indices = Some(new_bed);
-                    self.renderer
-                        .configure_beds(self.bed_indices.as_deref().unwrap_or(&[]));
+            // Cache the sparse object↔channel declaration.
+            if !meta.object_channels.is_empty() {
+                let mut decl: Vec<(u32, usize)> = meta
+                    .object_channels
+                    .iter()
+                    .map(|oc| (oc.id, oc.channel as usize))
+                    .collect();
+                decl.sort_unstable_by_key(|&(_, channel)| channel);
+                if self.object_channels != decl {
+                    self.object_channels = decl;
                 }
             }
+            // Renderer bed set = legacy bed ids of the fixed-channel labels
+            // (the 0-9 scheme leaves with the unified channel plan, phase 2b).
+            let new_bed = spatial::derive_bed_indices(&frame.channel_labels);
+            if self.bed_indices.as_ref() != Some(&new_bed) {
+                self.bed_indices = Some(new_bed);
+                self.renderer
+                    .configure_beds(self.bed_indices.as_deref().unwrap_or(&[]));
+            }
             let conf = Configuration::from(meta);
-            let bed = self.bed_indices.as_deref().unwrap_or(&[]);
             spatial::build_spatial_channel_events(
                 &conf,
                 self.coordinate_format,
-                bed,
+                &self.object_channels,
+                &meta.channel_gains,
+                meta.sample_pos,
+                meta.ramp_duration,
                 &mut self.frame_events,
             );
 
@@ -813,6 +831,8 @@ impl Engine {
                     self.coordinate_format,
                     Some(&layout),
                     &self.object_names,
+                    &frame.channel_labels,
+                    &meta.channel_gains,
                 );
                 if want_osc {
                     let coord_fmt = match self.coordinate_format {

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -3,7 +3,7 @@
 
 use crate::events::{Configuration, Event};
 use crate::osc::ObjectMeta;
-use bridge_api::RCoordinateFormat;
+use bridge_api::{RChannelGain, RChannelLabel, RCoordinateFormat};
 use renderer::spatial_renderer::SpatialChannelEvent;
 use renderer::speaker_layout::SpeakerLayout;
 use std::collections::HashMap;
@@ -30,87 +30,120 @@ pub fn event_pos_raw(event: &Event) -> Option<[f64; 3]> {
     Some([p[0], p[1], p[2]])
 }
 
+/// Renderer bed set for a frame: the legacy 0-9 bed id of each fixed
+/// channel's label, in PCM-channel order, stopping at the first
+/// object-carrying channel. Labels outside the legacy scheme keep their slot
+/// with `usize::MAX` (no speaker routing), mirroring the historical behavior
+/// for beds absent from the layout. The scheme leaves with phase 2b.
+pub fn derive_bed_indices(channel_labels: &[RChannelLabel]) -> Vec<usize> {
+    channel_labels
+        .iter()
+        .take_while(|l| **l != RChannelLabel::Object)
+        .map(|l| renderer::speaker_layout::legacy_bed_id(*l).unwrap_or(usize::MAX))
+        .collect()
+}
+
+fn channel_gain_db(channel_gains: &[RChannelGain], channel: u32) -> i32 {
+    channel_gains
+        .iter()
+        .find(|g| g.channel == channel)
+        .map_or(0, |g| g.gain_db as i32)
+}
+
 /// Build the OSC broadcast objects for one metadata payload.
 ///
-/// Bed objects (id `< 10`) are reported at their layout speaker position with
-/// `direct_speaker_index` set; dynamic objects report their raw event position
-/// in the bridge's coordinate format. Names come from the accumulated
-/// `object_names` map (falling back to `Obj_<id>`).
+/// Fixed channels (labels before the first `Object` channel) are reported at
+/// their layout speaker position with `direct_speaker_index` set and named by
+/// their label; dynamic objects report their raw event position in the
+/// bridge's coordinate format, named from the accumulated `object_names` map
+/// (falling back to `Obj_<id>`).
 pub fn build_object_metas(
     conf: &Configuration,
     coordinate_format: RCoordinateFormat,
     layout: Option<&SpeakerLayout>,
     object_names: &HashMap<u32, String>,
+    channel_labels: &[RChannelLabel],
+    channel_gains: &[RChannelGain],
 ) -> Vec<ObjectMeta> {
     let bed_to_speaker = layout
         .map(|l| l.bed_to_speaker_mapping())
         .unwrap_or_default();
-    conf.events
-        .iter()
-        .enumerate()
-        .map(|(idx, event)| {
-            let logical_id = event.id().unwrap_or(idx as u32);
-            let direct_speaker_index = if logical_id < 10 {
-                bed_to_speaker
-                    .get(&(logical_id as usize))
-                    .copied()
-                    .map(|i| i as u32)
-            } else {
-                None
-            };
-            let (ox, oy, oz, coord_mode) = direct_speaker_index
-                .and_then(|spk| {
-                    layout.and_then(|l| {
-                        l.speakers.get(spk as usize).map(|speaker| {
-                            if speaker.coord_mode.eq_ignore_ascii_case("cartesian") {
-                                (
-                                    speaker.x as f64,
-                                    speaker.y as f64,
-                                    speaker.z as f64,
-                                    "cartesian".to_string(),
-                                )
-                            } else {
-                                (
-                                    speaker.azimuth as f64,
-                                    speaker.elevation as f64,
-                                    speaker.distance as f64,
-                                    "polar".to_string(),
-                                )
-                            }
-                        })
-                    })
-                })
-                .unwrap_or_else(|| {
-                    let [x, y, z] = event_pos_raw(event).unwrap_or([0.0; 3]);
+    let fallback_coord_mode = || match coordinate_format {
+        RCoordinateFormat::Cartesian => "cartesian".to_string(),
+        RCoordinateFormat::Polar => "polar".to_string(),
+    };
+    let speaker_pose = |spk: u32| {
+        layout.and_then(|l| {
+            l.speakers.get(spk as usize).map(|speaker| {
+                if speaker.coord_mode.eq_ignore_ascii_case("cartesian") {
                     (
-                        x,
-                        y,
-                        z,
-                        match coordinate_format {
-                            RCoordinateFormat::Cartesian => "cartesian".to_string(),
-                            RCoordinateFormat::Polar => "polar".to_string(),
-                        },
+                        speaker.x as f64,
+                        speaker.y as f64,
+                        speaker.z as f64,
+                        "cartesian".to_string(),
                     )
-                });
+                } else {
+                    (
+                        speaker.azimuth as f64,
+                        speaker.elevation as f64,
+                        speaker.distance as f64,
+                        "polar".to_string(),
+                    )
+                }
+            })
+        })
+    };
+
+    // Fixed channels first, in PCM order — matches the historical bed-first
+    // event order over OSC.
+    let fixed = channel_labels
+        .iter()
+        .take_while(|l| **l != RChannelLabel::Object)
+        .enumerate()
+        .map(|(channel, label)| {
+            let direct_speaker_index = renderer::speaker_layout::legacy_bed_id(*label)
+                .and_then(|id| bed_to_speaker.get(&id).copied())
+                .map(|i| i as u32);
+            let (ox, oy, oz, coord_mode) = direct_speaker_index
+                .and_then(speaker_pose)
+                .unwrap_or_else(|| (0.0, 0.0, 0.0, fallback_coord_mode()));
             ObjectMeta {
-                name: object_names
-                    .get(&logical_id)
-                    .cloned()
-                    .unwrap_or_else(|| format!("Obj_{logical_id}")),
+                name: bridge_api::labels::canonical_name(*label).to_string(),
                 x: ox as f32,
                 y: oy as f32,
                 z: oz as f32,
                 coord_mode,
                 direct_speaker_index,
-                gain: event.gain_db().map_or(-128, |g| g as i32),
+                gain: channel_gain_db(channel_gains, channel as u32),
                 priority: 0.0,
-                size: event
-                    .size()
-                    .map(|s| [s[0] as f32, s[1] as f32, s[2] as f32])
-                    .unwrap_or([0.0, 0.0, 0.0]),
+                size: [0.0, 0.0, 0.0],
             }
+        });
+
+    // Then the dynamic objects, in event order.
+    let objects = conf.events.iter().filter_map(|event| {
+        let id = event.id()?;
+        let [x, y, z] = event_pos_raw(event).unwrap_or([0.0; 3]);
+        Some(ObjectMeta {
+            name: object_names
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| format!("Obj_{id}")),
+            x: x as f32,
+            y: y as f32,
+            z: z as f32,
+            coord_mode: fallback_coord_mode(),
+            direct_speaker_index: None,
+            gain: event.gain_db().map_or(-128, |g| g as i32),
+            priority: 0.0,
+            size: event
+                .size()
+                .map(|s| [s[0] as f32, s[1] as f32, s[2] as f32])
+                .unwrap_or([0.0, 0.0, 0.0]),
         })
-        .collect()
+    });
+
+    fixed.chain(objects).collect()
 }
 
 /// Resolve an event's position to ADM Cartesian `[x, y, z]`, converting from the
@@ -140,38 +173,41 @@ pub fn event_pos_as_adm_cartesian(
 /// Build the renderer's per-channel events from one metadata payload and append
 /// them to `out`.
 ///
-/// Object IDs `< 10` are bed channels: they map to a PCM channel index via
-/// `bed_indices` (events for beds not present in the layout are skipped). IDs
-/// `>= 10` are dynamic objects, placed after the beds in PCM order.
+/// Object events map to their PCM channel through the cached
+/// `object_channels` declaration (events for undeclared ids are skipped);
+/// `channel_gains` yields one gain/ramp-only event per listed fixed channel.
 pub fn build_spatial_channel_events(
     conf: &Configuration,
     coordinate_format: RCoordinateFormat,
-    bed_indices: &[usize],
+    object_channels: &[(u32, usize)],
+    channel_gains: &[RChannelGain],
+    sample_pos: u64,
+    ramp_duration: u32,
     out: &mut Vec<SpatialChannelEvent>,
 ) {
-    let bed_id_to_channel: HashMap<usize, usize> = bed_indices
-        .iter()
-        .enumerate()
-        .map(|(idx, &bid)| (bid, idx))
-        .collect();
-    let num_beds = bed_indices.len();
+    for gain in channel_gains {
+        out.push(SpatialChannelEvent {
+            channel_idx: gain.channel as usize,
+            is_bed: true,
+            gain_db: Some(gain.gain_db),
+            ramp_length: Some(ramp_duration),
+            size: None,
+            position: None,
+            sample_pos: Some(sample_pos),
+        });
+    }
 
     for event in &conf.events {
-        let object_id = match event.id() {
-            Some(id) => id as usize,
-            None => continue,
+        let Some(object_id) = event.id() else {
+            continue;
         };
-        let (channel_idx, is_bed) = if object_id < 10 {
-            match bed_id_to_channel.get(&object_id) {
-                Some(&ch) => (ch, true),
-                None => continue,
-            }
-        } else {
-            (num_beds + (object_id - 10), false)
+        let Some(&(_, channel_idx)) = object_channels.iter().find(|(id, _)| *id == object_id)
+        else {
+            continue;
         };
         out.push(SpatialChannelEvent {
             channel_idx,
-            is_bed,
+            is_bed: false,
             gain_db: event.gain_db(),
             ramp_length: event.ramp_length(),
             size: event
@@ -180,5 +216,110 @@ pub fn build_spatial_channel_events(
             position: event_pos_as_adm_cartesian(coordinate_format, event),
             sample_pos: event.sample_pos(),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bridge_api::RChannelLabel::*;
+    use renderer::speaker_layout::{Speaker, SpeakerLayout};
+
+    fn labels_5_1_2_plus_objects() -> Vec<RChannelLabel> {
+        vec![L, R, C, LFE, Ls, Rs, Object, Object]
+    }
+
+    #[test]
+    fn derive_bed_indices_maps_labels_and_stops_at_objects() {
+        assert_eq!(
+            derive_bed_indices(&labels_5_1_2_plus_objects()),
+            vec![0, 1, 2, 3, 4, 5]
+        );
+        // A fixed label outside the legacy scheme keeps its slot unroutable.
+        assert_eq!(derive_bed_indices(&[L, Tbl, R]), vec![0, usize::MAX, 1]);
+    }
+
+    #[test]
+    fn channel_events_route_objects_through_the_declaration() {
+        let mut event = Event::with_id(11);
+        event.set_pos([0.5, 0.5, 0.0]);
+        let conf = Configuration::new(vec![event, Event::with_id(99)]);
+        let object_channels = [(11u32, 6usize)];
+        let gains = [bridge_api::RChannelGain {
+            channel: 2,
+            gain_db: -3,
+        }];
+
+        let mut out = Vec::new();
+        build_spatial_channel_events(
+            &conf,
+            RCoordinateFormat::Cartesian,
+            &object_channels,
+            &gains,
+            480,
+            32,
+            &mut out,
+        );
+
+        // One bed-gain event + one object event; the undeclared id 99 is skipped.
+        assert_eq!(out.len(), 2);
+        assert!(out[0].is_bed);
+        assert_eq!(out[0].channel_idx, 2);
+        assert_eq!(out[0].gain_db, Some(-3));
+        assert_eq!(out[0].ramp_length, Some(32));
+        assert_eq!(out[0].sample_pos, Some(480));
+        assert!(!out[1].is_bed);
+        assert_eq!(out[1].channel_idx, 6);
+    }
+
+    #[test]
+    fn object_metas_list_fixed_channels_first_with_label_names() {
+        let mut event = Event::with_id(10);
+        event.set_pos([0.1, 0.2, 0.3]);
+        let conf = Configuration::new(vec![event]);
+        let layout = SpeakerLayout::from_speakers(vec![
+            Speaker::new("FL", -30.0, 0.0),
+            Speaker::new("FR", 30.0, 0.0),
+            Speaker::new("SW", 0.0, -30.0),
+        ])
+        .expect("layout");
+        let names = HashMap::from([(10, "Music".to_string())]);
+        let gains = [bridge_api::RChannelGain {
+            channel: 2,
+            gain_db: -6,
+        }];
+
+        let metas = build_object_metas(
+            &conf,
+            RCoordinateFormat::Cartesian,
+            Some(&layout),
+            &names,
+            &[L, R, LFE, Object],
+            &gains,
+        );
+
+        let listed: Vec<&str> = metas.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(listed, ["L", "R", "LFE", "Music"]);
+        // Fixed channels carry their speaker routing; the LFE gain automation
+        // is reflected; the object keeps its raw event position.
+        assert_eq!(metas[0].direct_speaker_index, Some(0));
+        assert_eq!(metas[2].direct_speaker_index, Some(2));
+        assert_eq!(metas[2].gain, -6);
+        assert_eq!(metas[3].direct_speaker_index, None);
+        assert!((metas[3].x - 0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn unnamed_objects_fall_back_to_their_id() {
+        let conf = Configuration::new(vec![Event::with_id(12)]);
+        let metas = build_object_metas(
+            &conf,
+            RCoordinateFormat::Cartesian,
+            None,
+            &HashMap::new(),
+            &[],
+            &[],
+        );
+        assert_eq!(metas[0].name, "Obj_12");
     }
 }

--- a/omniphony-renderer/orender_engine/tests/parity.rs
+++ b/omniphony-renderer/orender_engine/tests/parity.rs
@@ -45,7 +45,7 @@ fn renders_real_truehd_atmos_stream() {
         .expect("enable_osc should start the OSC listener");
 
     let channels = engine.channel_count();
-    let spatial_before = engine.is_spatial();
+    let spatial_before = engine.has_objects();
 
     // Output channel-layout export: the 7.1.4 preset must map cleanly to labels
     // (no Unknown), one per speaker, in render order. This is what the FFI's
@@ -83,13 +83,13 @@ fn renders_real_truehd_atmos_stream() {
 
     eprintln!(
         "parity harness: channels={channels} spatial_before={spatial_before} \
-         is_spatial_after={} frames={total_frames} samples={total_samples} peak={peak:.6}",
-        engine.is_spatial()
+         has_objects_after={} frames={total_frames} samples={total_samples} peak={peak:.6}",
+        engine.has_objects()
     );
 
     assert!(
         spatial_before,
-        "Atmos stream must report is_spatial() = true"
+        "Atmos stream must report has_objects() = true"
     );
     assert_eq!(channels, 12, "7.1.4 preset must yield 12 speakers");
     // The engine only emits chunks for frames carrying spatial objects (the

--- a/omniphony-renderer/orender_ffi/Cargo.toml
+++ b/omniphony-renderer/orender_ffi/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = "0.11"
 
 [dev-dependencies]
 # The OrenderChannelLabel ↔ RChannelLabel discriminant-parity unit test.
-bridge_api = { version = "0.2.0", path = "../bridge_api" }
+bridge_api = { version = "0.3.0", path = "../bridge_api" }
 
 [features]
 # SOFA (personalised HRTF) support, on by default: liborender is the desktop

--- a/omniphony-renderer/orender_ffi/include/orender.h
+++ b/omniphony-renderer/orender_ffi/include/orender.h
@@ -55,6 +55,8 @@ enum OrenderChannelLabel {
     OrenderChannelLabel_Rw = 21,
     OrenderChannelLabel_Tfc = 22,
     OrenderChannelLabel_Lfe2 = 23,
+    // The channel carries dynamic-object audio (position driven by metadata).
+    OrenderChannelLabel_Object = 24,
     OrenderChannelLabel_Unknown = 255,
 };
 typedef uint8_t OrenderChannelLabel;

--- a/omniphony-renderer/orender_ffi/src/lib.rs
+++ b/omniphony-renderer/orender_ffi/src/lib.rs
@@ -207,6 +207,8 @@ pub enum OrenderChannelLabel {
     Rw = 21,
     Tfc = 22,
     Lfe2 = 23,
+    /// The channel carries dynamic-object audio (position driven by metadata).
+    Object = 24,
     Unknown = 255,
 }
 
@@ -409,7 +411,7 @@ pub unsafe extern "C" fn orender_is_spatial(r: *const OrenderRenderer) -> c_int 
             return -1;
         }
         let engine = &*(r as *const Engine);
-        if engine.is_spatial() {
+        if engine.has_objects() {
             1
         } else {
             0
@@ -913,6 +915,7 @@ mod tests {
             RChannelLabel::Rw => OrenderChannelLabel::Rw,
             RChannelLabel::Tfc => OrenderChannelLabel::Tfc,
             RChannelLabel::LFE2 => OrenderChannelLabel::Lfe2,
+            RChannelLabel::Object => OrenderChannelLabel::Object,
             RChannelLabel::Unknown => OrenderChannelLabel::Unknown,
         }
     }

--- a/omniphony-renderer/reference_bridge/Cargo.toml
+++ b/omniphony-renderer/reference_bridge/Cargo.toml
@@ -13,7 +13,7 @@ name = "reference_bridge"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bridge_api = { version = "0.2.0", path = "../bridge_api" }
+bridge_api = { version = "0.3.0", path = "../bridge_api" }
 abi_stable = "0.11"
 log = "0.4"
 

--- a/omniphony-renderer/reference_bridge/src/bridge.rs
+++ b/omniphony-renderer/reference_bridge/src/bridge.rs
@@ -238,8 +238,8 @@ impl FormatBridge for WavBridge {
         self.frames_emitted > 0
     }
 
-    fn is_spatial(&self) -> bool {
-        // A WAV file is a plain channel bed: no object payloads.
+    fn has_objects(&self) -> bool {
+        // A WAV file carries fixed channels only: no dynamic objects.
         false
     }
 
@@ -332,7 +332,7 @@ mod tests {
         let result = bridge.push_packet(RSlice::from_slice(&wav), RInputTransport::Raw, 0);
         assert!(result.error_message.is_empty());
         assert!(bridge.is_ready());
-        assert!(!bridge.is_spatial());
+        assert!(!bridge.has_objects());
         let total: u32 = result.frames.iter().map(|f| f.sample_count).sum();
         assert_eq!(total, 3);
         let f = &result.frames[0];

--- a/omniphony-renderer/renderer/Cargo.toml
+++ b/omniphony-renderer/renderer/Cargo.toml
@@ -10,7 +10,7 @@ name = "renderer"
 
 [dependencies]
 anyhow = "1"
-bridge_api = { version = "0.2.0", path = "../bridge_api" }
+bridge_api = { version = "0.3.0", path = "../bridge_api" }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/omniphony-renderer/renderer/src/speaker_layout.rs
+++ b/omniphony-renderer/renderer/src/speaker_layout.rs
@@ -64,6 +64,27 @@ fn map_depth_with_room_ratios(
     }
 }
 
+/// Legacy 0-9 bed id for a channel label, shared by every remaining consumer
+/// of the historical bed-id scheme (renderer bed routing, engine ingestion).
+/// Scheduled to disappear with the scheme itself in phase 2b of
+/// `docs/channel-object-contract.md`.
+pub fn legacy_bed_id(label: bridge_api::RChannelLabel) -> Option<usize> {
+    use bridge_api::RChannelLabel as Label;
+    match label {
+        Label::L => Some(0),
+        Label::R => Some(1),
+        Label::C => Some(2),
+        Label::LFE => Some(3),
+        Label::Ls => Some(4),
+        Label::Rs => Some(5),
+        Label::Lb => Some(6),
+        Label::Rb => Some(7),
+        Label::Tfl => Some(8),
+        Label::Tfr => Some(9),
+        _ => None,
+    }
+}
+
 /// A single speaker in the layout
 #[derive(Debug, Clone)]
 pub struct Speaker {
@@ -512,26 +533,9 @@ impl SpeakerLayout {
     /// beds without a matching speaker are absent. The first speaker matching
     /// a label wins.
     pub fn bed_to_speaker_mapping(&self) -> std::collections::HashMap<usize, usize> {
-        use bridge_api::RChannelLabel as Label;
-        fn bed_id(label: Label) -> Option<usize> {
-            match label {
-                Label::L => Some(0),
-                Label::R => Some(1),
-                Label::C => Some(2),
-                Label::LFE => Some(3),
-                Label::Ls => Some(4),
-                Label::Rs => Some(5),
-                Label::Lb => Some(6),
-                Label::Rb => Some(7),
-                Label::Tfl => Some(8),
-                Label::Tfr => Some(9),
-                _ => None,
-            }
-        }
-
         let mut mapping = std::collections::HashMap::new();
         for (speaker_idx, speaker) in self.speakers.iter().enumerate() {
-            if let Some(id) = bed_id(bridge_api::labels::label_for_name(&speaker.name)) {
+            if let Some(id) = legacy_bed_id(bridge_api::labels::label_for_name(&speaker.name)) {
                 mapping.entry(id).or_insert(speaker_idx);
             }
         }

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -214,7 +214,7 @@ fn prepare_render_run(args: &RenderArgs) -> Result<PreparedDecodeRun> {
             args.presentation
         ));
     }
-    let is_spatial_presentation = bridge.is_spatial();
+    let is_spatial_presentation = bridge.has_objects();
     let coordinate_format = bridge.coordinate_format();
     let vbap_cartesian_defaults = bridge.vbap_cartesian_defaults();
     let preferred_evaluation_mode = bridge.preferred_vbap_table_mode();

--- a/omniphony-renderer/src/cli/decode/spatial_metadata.rs
+++ b/omniphony-renderer/src/cli/decode/spatial_metadata.rs
@@ -1,6 +1,6 @@
 use super::state::SpatialState;
 use anyhow::Result;
-use bridge_api::{RCoordinateFormat, RMetadataFrame};
+use bridge_api::{RChannelLabel, RCoordinateFormat, RMetadataFrame};
 use orender_engine::events::{Configuration, Event};
 use orender_engine::osc::{ObjectMeta, OscSender};
 
@@ -36,25 +36,37 @@ impl<'a> SpatialMetadataCoordinator<'a> {
             let conf = Configuration::from(meta);
             self.spatial.has_objects = true;
 
-            if !meta.bed_indices.is_empty() {
-                let new_bed_indices: Vec<usize> = meta.bed_indices.iter().copied().collect();
-                let changed = self.spatial.bed_indices.as_ref() != Some(&new_bed_indices);
-                if changed {
-                    self.spatial.bed_indices = Some(new_bed_indices);
-                    log::debug!(
-                        "Extracted bed indices from bridge metadata: {:?}",
-                        self.spatial.bed_indices
-                    );
-
-                    if let (Some(renderer), Some(bed_indices)) =
-                        (self.spatial_renderer, &self.spatial.bed_indices)
-                    {
-                        renderer.configure_beds(bed_indices);
-                    }
+            // Cache the sparse object↔channel declaration.
+            if !meta.object_channels.is_empty() {
+                let mut decl: Vec<(u32, usize)> = meta
+                    .object_channels
+                    .iter()
+                    .map(|oc| (oc.id, oc.channel as usize))
+                    .collect();
+                decl.sort_unstable_by_key(|&(_, channel)| channel);
+                if self.spatial.object_channels != decl {
+                    self.spatial.object_channels = decl;
                 }
             }
 
-            self.handle_metadata_writing(meta, conf, sample_rate)?;
+            // Renderer bed set = legacy bed ids of the fixed-channel labels
+            // (the 0-9 scheme leaves with the unified channel plan, phase 2b).
+            let new_bed_indices =
+                orender_engine::spatial::derive_bed_indices(&frame.channel_labels);
+            if self.spatial.bed_indices.as_ref() != Some(&new_bed_indices) {
+                self.spatial.bed_indices = Some(new_bed_indices);
+                log::debug!(
+                    "Derived bed indices from channel labels: {:?}",
+                    self.spatial.bed_indices
+                );
+                if let (Some(renderer), Some(bed_indices)) =
+                    (self.spatial_renderer, &self.spatial.bed_indices)
+                {
+                    renderer.configure_beds(bed_indices);
+                }
+            }
+
+            self.handle_metadata_writing(meta, conf, &frame.channel_labels, sample_rate)?;
         }
         Ok(())
     }
@@ -62,6 +74,7 @@ impl<'a> SpatialMetadataCoordinator<'a> {
     pub fn reset_for_segment(&mut self) {
         self.spatial.has_objects = false;
         self.spatial.bed_indices = None;
+        self.spatial.object_channels.clear();
         self.spatial.object_names.clear();
         self.spatial.frame_events.clear();
         if let Some(renderer) = self.spatial_renderer {
@@ -73,6 +86,7 @@ impl<'a> SpatialMetadataCoordinator<'a> {
         &mut self,
         meta: &RMetadataFrame,
         conf: Configuration,
+        channel_labels: &[RChannelLabel],
         sample_rate: u32,
     ) -> Result<()> {
         let sample_pos = meta.sample_pos;
@@ -104,80 +118,14 @@ impl<'a> SpatialMetadataCoordinator<'a> {
             let active_layout = self
                 .spatial_renderer
                 .map(|renderer| renderer.speaker_layout());
-            let bed_to_speaker = active_layout
-                .as_ref()
-                .map(|layout| layout.bed_to_speaker_mapping())
-                .unwrap_or_default();
-            let objects: Vec<ObjectMeta> = conf
-                .events
-                .iter()
-                .enumerate()
-                .map(|(idx, event)| {
-                    let logical_id = event.id().unwrap_or(idx as u32);
-                    let direct_speaker_index = if logical_id < 10 {
-                        bed_to_speaker
-                            .get(&(logical_id as usize))
-                            .copied()
-                            .map(|idx| idx as u32)
-                    } else {
-                        None
-                    };
-                    let (ox, oy, oz, coord_mode) = direct_speaker_index
-                        .and_then(|speaker_idx| {
-                            active_layout.as_ref().and_then(|layout| {
-                                layout.speakers.get(speaker_idx as usize).map(|speaker| {
-                                    if speaker.coord_mode.eq_ignore_ascii_case("cartesian") {
-                                        (
-                                            speaker.x as f64,
-                                            speaker.y as f64,
-                                            speaker.z as f64,
-                                            "cartesian".to_string(),
-                                        )
-                                    } else {
-                                        (
-                                            speaker.azimuth as f64,
-                                            speaker.elevation as f64,
-                                            speaker.distance as f64,
-                                            "polar".to_string(),
-                                        )
-                                    }
-                                })
-                            })
-                        })
-                        .unwrap_or_else(|| {
-                            let [x, y, z] =
-                                Self::event_pos_raw(coordinate_format, event).unwrap_or([0.0; 3]);
-                            (
-                                x,
-                                y,
-                                z,
-                                match coordinate_format {
-                                    RCoordinateFormat::Cartesian => "cartesian".to_string(),
-                                    RCoordinateFormat::Polar => "polar".to_string(),
-                                },
-                            )
-                        });
-                    ObjectMeta {
-                        name: self
-                            .spatial
-                            .object_names
-                            .get(&logical_id)
-                            .cloned()
-                            .unwrap_or_else(|| format!("Obj_{logical_id}")),
-                        x: ox as f32,
-                        y: oy as f32,
-                        z: oz as f32,
-                        coord_mode,
-                        direct_speaker_index,
-                        gain: event.gain_db().map_or(-128, |g| g as i32),
-                        priority: 0.0,
-                        size: event
-                            .size()
-                            .map(|s| [s[0] as f32, s[1] as f32, s[2] as f32])
-                            .unwrap_or([0.0, 0.0, 0.0]),
-                    }
-                })
-                .collect();
+            let objects: Vec<ObjectMeta> = orender_engine::spatial::build_object_metas(
+                &conf,
+                coordinate_format,
+                active_layout.as_ref(),
+                &self.spatial.object_names,
+                channel_labels,
+                &meta.channel_gains,
+            );
             let ramp_duration = meta.ramp_duration;
             let osc_coord_format = match coordinate_format {
                 RCoordinateFormat::Cartesian => 0,
@@ -198,11 +146,13 @@ impl<'a> SpatialMetadataCoordinator<'a> {
         }
 
         if self.spatial_renderer.is_some() {
-            let bed_indices = self.spatial.bed_indices.as_deref().unwrap_or(&[]);
             orender_engine::spatial::build_spatial_channel_events(
                 &conf,
                 coordinate_format,
-                bed_indices,
+                &self.spatial.object_channels,
+                &meta.channel_gains,
+                meta.sample_pos,
+                meta.ramp_duration,
                 &mut self.spatial.frame_events,
             );
         }

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -111,6 +111,9 @@ impl Default for TelemetryState {
 pub struct SpatialState {
     pub has_objects: bool,
     pub bed_indices: Option<Vec<usize>>,
+    /// Cached object↔channel declaration from the bridge (sparse emission),
+    /// sorted by channel.
+    pub object_channels: Vec<(u32, usize)>,
     pub object_names: std::collections::HashMap<u32, String>,
     pub au_index: u64,
     pub segment_index: u32,
@@ -126,6 +129,7 @@ impl Default for SpatialState {
         Self {
             has_objects: false,
             bed_indices: None,
+            object_channels: Vec::new(),
             object_names: std::collections::HashMap::new(),
             au_index: 0,
             segment_index: 0,


### PR DESCRIPTION
## Summary

Phase 2a of [docs/channel-object-contract.md](https://github.com/mgth/Omniphony/blob/main/docs/channel-object-contract.md): the ABI reshape, with a mechanical renderer-side migration that keeps rendering behavior identical. Pair with harletty-bridge PR #10 — **merge this first**, then the bridge PR (its CI tracks Omniphony main).

### bridge_api 0.3.0
- `RChannelLabel::Object` marks object-carrying channels; `channel_labels` is now authoritative for fixed channels.
- `RMetadataFrame` v2: object events keyed by opaque stable ids + explicit sparse `object_channels {id, channel}` declaration + `channel_gains` for fixed-channel gain automation (OAMD bed gains — RFC amended accordingly). `bed_indices`, positionless bed events and the `id≥10` arithmetic are gone.
- `FormatBridge::is_spatial()` → `has_objects()` (live fact, not a mode).

### Renderer side (no behavior change)
- Engine + CLI derive the renderer bed set from fixed-channel labels via the shared `legacy_bed_id` shim (dies with phase 2b) and cache the sparse object declaration.
- `build_object_metas` lists fixed channels first (named from labels, `direct_speaker_index` from the layout) then objects; the CLI now uses the shared builder instead of its inline duplicate.
- `Engine::is_spatial()` → `has_objects()`; the `orender_is_spatial` C symbol is untouched (phase 3). `Object` added to the FFI mirror + `orender.h`.

## Tests
- Full workspace green (29 suites), fmt clean; new unit tests for v2 ingestion (bed derivation, declaration routing, fixed-first object metas).
- E2E parity harness run locally against the real bridge (`truehd_atmos_prefix_32k.mlp`): decode → OAMD objects → VBAP render → OSC, both tests green.

Known display-only change (OSC source names): canonical label names (`Ls`, `Lb`, `TSL`…) replace the OAMD debug names (`Lss`, `Lrs`, `Lts`…).

🤖 Generated with [Claude Code](https://claude.com/claude-code)