### PR TITLE
feat: unified channel plan — one placement policy for every stream (phase 2b)

### DIFF
--- a/docs/channel-object-contract.md
+++ b/docs/channel-object-contract.md
@@ -8,7 +8,27 @@ Companion review notes live in the bridge repo
 Progress:
 
 - **Phase 0 (this document)**: contract specification and migration plan.
-- Phases 1–5: not started (see "Migration plan" below).
+- **Phase 1 landed** (#188 + bridge #9): shared label table
+  (`bridge_api::labels`), plus a real push/PR CI gate on the bridge repo.
+- **Phase 2a landed** (#189 + bridge #10): ABI v2 (`RChannelLabel::Object`,
+  `RObjectChannel`, `channel_gains`, `has_objects()`); pipelines and
+  renderer migrated mechanically. Amendment: fixed channels keep
+  metadata-driven *gain* automation (`channel_gains`) — OAMD applies live
+  gains to bed members.
+- **Phase 2b landed**: unified channel plan. Decisions taken in review:
+  - fixed channels are **virtualized by default** for every stream kind
+    (placement layout + crossover apply); direct one-hot routing is a
+    per-entry opt-in via the layout `spatialize` flag (LFE default);
+  - the renderer routes by **label** (`ChannelRoute`), resolved against a
+    per-topology label→speaker map; the 0-9 scheme survives only as the
+    CLI file-export bed order (`legacy_bed_id`);
+  - plan transitions ride a **constant-rate gain slew**
+    (`GAIN_SLEW_SECS` = 20 ms full-scale) applied to every per-channel
+    gain step — no dedicated crossfade machinery;
+  - the CLI keeps a prep-time `has_objects` read for file-output format
+    decisions (inherently a prep-time choice); the render path no longer
+    latches anything.
+- Phases 3–5: not started.
 
 ## The incident
 
@@ -245,8 +265,6 @@ Each phase is one reviewable PR; the stack stays shippable between phases.
 
 ## Open questions
 
-- `PLAN_TRANSITION_RAMP` duration: fixed 20 ms vs. frame-quantised vs. a
-  (non-live) config constant.
 - How far to push the *placement layout* rename in code and UI (the
   `virtual_bed` module, YAML keys, Studio strings) — cosmetic, can trail.
 - Whether `object_channels` should also carry a per-object `RChannelLabel`

--- a/omniphony-renderer/bridge_api/src/labels.rs
+++ b/omniphony-renderer/bridge_api/src/labels.rs
@@ -16,10 +16,9 @@ use crate::RChannelLabel;
 /// whitespace/`_`/`-`). The first entry of each list is only an alias like
 /// the others; canonical display names come from [`canonical_name`].
 ///
-/// This table is the union of the historical matchers it replaces
-/// (`orender_engine::channel_layout::label_for_speaker_name` and
-/// `renderer::speaker_layout::bed_to_speaker_mapping`); parity with both is
-/// pinned by tests here and in the consuming crates.
+/// This table is the union of the historical matchers it replaces; parity
+/// with both is pinned by tests here and in the consuming crates
+/// (`renderer::speaker_layout` keeps the legacy-alias parity net).
 const ALIASES: &[(RChannelLabel, &[&str])] = &[
     (RChannelLabel::L, &["FL", "L", "FRONTLEFT", "LEFTFRONT"]),
     (RChannelLabel::R, &["FR", "R", "FRONTRIGHT", "RIGHTFRONT"]),

--- a/omniphony-renderer/bridge_api/src/lib.rs
+++ b/omniphony-renderer/bridge_api/src/lib.rs
@@ -68,7 +68,7 @@ pub struct RNameUpdate {
 
 /// ABI-stable channel label (speaker position), encoded as u8.
 #[repr(u8)]
-#[derive(StableAbi, Clone, Copy, Debug, PartialEq)]
+#[derive(StableAbi, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RChannelLabel {
     L = 0,
     R = 1,

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -52,7 +52,8 @@ pub struct Engine {
     coordinate_format: RCoordinateFormat,
 
     // ── per-stream spatial state ──
-    bed_indices: Option<Vec<usize>>,
+    /// Shared fixed-channel planner (routing + plan cache, both stream kinds).
+    fixed_planner: virtual_bed::FixedChannelPlanner,
     /// Cached object↔channel declaration from the bridge (sparse emission),
     /// sorted by channel. See `docs/channel-object-contract.md`.
     object_channels: Vec<(u32, usize)>,
@@ -226,7 +227,7 @@ impl Engine {
             renderer,
             sample_rate,
             coordinate_format,
-            bed_indices: None,
+            fixed_planner: virtual_bed::FixedChannelPlanner::new(),
             object_channels: Vec::new(),
             has_objects: false,
             loudness_applied: false,
@@ -643,7 +644,7 @@ impl Engine {
 
     fn reset_segment_state(&mut self) {
         self.has_objects = false;
-        self.bed_indices = None;
+        self.fixed_planner.reset();
         self.object_channels.clear();
         self.frame_events.clear();
         self.loudness_applied = false;
@@ -800,14 +801,16 @@ impl Engine {
                     self.object_channels = decl;
                 }
             }
-            // Renderer bed set = legacy bed ids of the fixed-channel labels
-            // (the 0-9 scheme leaves with the unified channel plan, phase 2b).
-            let new_bed = spatial::derive_bed_indices(&frame.channel_labels);
-            if self.bed_indices.as_ref() != Some(&new_bed) {
-                self.bed_indices = Some(new_bed);
-                self.renderer
-                    .configure_beds(self.bed_indices.as_deref().unwrap_or(&[]));
-            }
+            // Plan the fixed prefix through the shared channel planner:
+            // virtualized by default, per-entry direct opt-in via the
+            // placement layout — identically to fixed-only streams. Mode is
+            // always Spatial here (an object stream cannot pass through the
+            // host), and the plan is cached on (labels, options epoch).
+            self.fixed_planner.plan_object_stream_fixed(
+                &frame.channel_labels,
+                &self.renderer,
+                &mut self.frame_events,
+            );
             let conf = Configuration::from(meta);
             spatial::build_spatial_channel_events(
                 &conf,
@@ -821,19 +824,24 @@ impl Engine {
 
             // Outgoing: broadcast object positions/names to OSC clients and/or
             // feed the in-process mpv overlay.
-            if want_objects {
-                for upd in meta.name_updates.iter() {
+            // Declarations are cached even before an OSC/overlay consumer
+            // connects, so a later Studio attachment sees stable names.
+            for upd in meta.name_updates.iter() {
+                if self.object_names.get(&upd.id).map(String::as_str) != Some(upd.name.as_str()) {
                     self.object_names.insert(upd.id, upd.name.to_string());
                 }
-                let layout = self.renderer.speaker_layout();
-                let objects = spatial::build_object_metas(
+            }
+            if want_objects {
+                let mut objects = virtual_bed::build_fixed_channel_objects(
+                    &self.renderer,
+                    self.fixed_planner.fixed_labels(),
+                )
+                .unwrap_or_default();
+                objects.extend(spatial::build_object_metas(
                     &conf,
                     self.coordinate_format,
-                    Some(&layout),
                     &self.object_names,
-                    &frame.channel_labels,
-                    &meta.channel_gains,
-                );
+                ));
                 if want_osc {
                     let coord_fmt = match self.coordinate_format {
                         RCoordinateFormat::Cartesian => 0,
@@ -913,23 +921,12 @@ impl Engine {
                 room_ratio_center_blend,
                 surround_placement,
             ) {
-                virtual_bed::ChannelRenderPlan::Events {
-                    events,
-                    bed_indices,
-                } => {
-                    // Spatial mode mixes per channel: direct channels carry a
-                    // bed id, virtual channels carry the `usize::MAX` sentinel
-                    // (rendered as VBAP objects). Reconfigure only on change to
-                    // avoid per-frame churn.
-                    let desired: Vec<usize> = bed_indices.unwrap_or_default();
-                    if self.bed_indices.as_deref().unwrap_or(&[]) != desired.as_slice() {
-                        self.renderer.configure_beds(&desired);
-                        self.bed_indices = if desired.is_empty() {
-                            None
-                        } else {
-                            Some(desired)
-                        };
-                    }
+                virtual_bed::ChannelRenderPlan::Events { events, routes } => {
+                    // Spatial mode mixes per channel: direct channels route
+                    // one-hot by label, virtual channels render as VBAP
+                    // objects. Reconfigure only on change to avoid per-frame
+                    // churn.
+                    self.fixed_planner.apply_routes(&self.renderer, routes);
                     self.frame_events = events;
                 }
                 // Host: the mpv decoder declines at the spatial probe and falls
@@ -1129,9 +1126,10 @@ impl Engine {
         )?;
         let render_time_ms = render_started.elapsed().as_secs_f32() * 1000.0;
 
-        // Dynamic object count = decoded channels minus the bed channels. Only
-        // meaningful for object-based content; plain multichannel reports 0.
-        let num_beds = self.bed_indices.as_ref().map_or(0, |b| b.len());
+        // Dynamic object count = decoded channels minus the fixed channels.
+        // Only meaningful for object-based content; plain multichannel
+        // reports 0.
+        let num_beds = self.fixed_planner.fixed_labels().len();
         let n_objects = (channel_count as u32).saturating_sub(num_beds as u32);
         self.last_object_count = if self.has_objects { n_objects } else { 0 };
 

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -159,7 +159,6 @@ pub fn build_spatial_channel_events(
 mod tests {
     use super::*;
     use bridge_api::RChannelLabel::*;
-    use renderer::speaker_layout::{Speaker, SpeakerLayout};
 
     fn labels_5_1_2_plus_objects() -> Vec<RChannelLabel> {
         vec![L, R, C, LFE, Ls, Rs, Object, Object]

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -5,7 +5,7 @@ use crate::events::{Configuration, Event};
 use crate::osc::ObjectMeta;
 use bridge_api::{RChannelGain, RChannelLabel, RCoordinateFormat};
 use renderer::spatial_renderer::SpatialChannelEvent;
-use renderer::speaker_layout::SpeakerLayout;
+
 use std::collections::HashMap;
 
 /// Wrap an azimuth in degrees into `[-180, 180]`.
@@ -30,11 +30,10 @@ pub fn event_pos_raw(event: &Event) -> Option<[f64; 3]> {
     Some([p[0], p[1], p[2]])
 }
 
-/// Renderer bed set for a frame: the legacy 0-9 bed id of each fixed
-/// channel's label, in PCM-channel order, stopping at the first
-/// object-carrying channel. Labels outside the legacy scheme keep their slot
-/// with `usize::MAX` (no speaker routing), mirroring the historical behavior
-/// for beds absent from the layout. The scheme leaves with phase 2b.
+/// Legacy 0-9 bed ids of the fixed channels, in PCM order, stopping at the
+/// first object channel. EXPORT-order helper only (file-output bed
+/// conformance keeps the fixed 10-slot layout); rendering uses the channel
+/// plan instead.
 pub fn derive_bed_indices(channel_labels: &[RChannelLabel]) -> Vec<usize> {
     channel_labels
         .iter()
@@ -43,107 +42,44 @@ pub fn derive_bed_indices(channel_labels: &[RChannelLabel]) -> Vec<usize> {
         .collect()
 }
 
-fn channel_gain_db(channel_gains: &[RChannelGain], channel: u32) -> i32 {
-    channel_gains
-        .iter()
-        .find(|g| g.channel == channel)
-        .map_or(0, |g| g.gain_db as i32)
-}
-
-/// Build the OSC broadcast objects for one metadata payload.
-///
-/// Fixed channels (labels before the first `Object` channel) are reported at
-/// their layout speaker position with `direct_speaker_index` set and named by
-/// their label; dynamic objects report their raw event position in the
-/// bridge's coordinate format, named from the accumulated `object_names` map
-/// (falling back to `Obj_<id>`).
+/// Build the OSC broadcast objects for the dynamic objects of one metadata
+/// payload (fixed channels are displayed separately, from the channel plan —
+/// see `virtual_bed::build_fixed_channel_objects`). Objects report their raw
+/// event position in the bridge's coordinate format, named from the
+/// accumulated `object_names` map (falling back to `Obj_<id>`).
 pub fn build_object_metas(
     conf: &Configuration,
     coordinate_format: RCoordinateFormat,
-    layout: Option<&SpeakerLayout>,
     object_names: &HashMap<u32, String>,
-    channel_labels: &[RChannelLabel],
-    channel_gains: &[RChannelGain],
 ) -> Vec<ObjectMeta> {
-    let bed_to_speaker = layout
-        .map(|l| l.bed_to_speaker_mapping())
-        .unwrap_or_default();
     let fallback_coord_mode = || match coordinate_format {
         RCoordinateFormat::Cartesian => "cartesian".to_string(),
         RCoordinateFormat::Polar => "polar".to_string(),
     };
-    let speaker_pose = |spk: u32| {
-        layout.and_then(|l| {
-            l.speakers.get(spk as usize).map(|speaker| {
-                if speaker.coord_mode.eq_ignore_ascii_case("cartesian") {
-                    (
-                        speaker.x as f64,
-                        speaker.y as f64,
-                        speaker.z as f64,
-                        "cartesian".to_string(),
-                    )
-                } else {
-                    (
-                        speaker.azimuth as f64,
-                        speaker.elevation as f64,
-                        speaker.distance as f64,
-                        "polar".to_string(),
-                    )
-                }
+    conf.events
+        .iter()
+        .filter_map(|event| {
+            let id = event.id()?;
+            let [x, y, z] = event_pos_raw(event).unwrap_or([0.0; 3]);
+            Some(ObjectMeta {
+                name: object_names
+                    .get(&id)
+                    .cloned()
+                    .unwrap_or_else(|| format!("Obj_{id}")),
+                x: x as f32,
+                y: y as f32,
+                z: z as f32,
+                coord_mode: fallback_coord_mode(),
+                direct_speaker_index: None,
+                gain: event.gain_db().map_or(-128, |g| g as i32),
+                priority: 0.0,
+                size: event
+                    .size()
+                    .map(|s| [s[0] as f32, s[1] as f32, s[2] as f32])
+                    .unwrap_or([0.0, 0.0, 0.0]),
             })
         })
-    };
-
-    // Fixed channels first, in PCM order — matches the historical bed-first
-    // event order over OSC.
-    let fixed = channel_labels
-        .iter()
-        .take_while(|l| **l != RChannelLabel::Object)
-        .enumerate()
-        .map(|(channel, label)| {
-            let direct_speaker_index = renderer::speaker_layout::legacy_bed_id(*label)
-                .and_then(|id| bed_to_speaker.get(&id).copied())
-                .map(|i| i as u32);
-            let (ox, oy, oz, coord_mode) = direct_speaker_index
-                .and_then(speaker_pose)
-                .unwrap_or_else(|| (0.0, 0.0, 0.0, fallback_coord_mode()));
-            ObjectMeta {
-                name: bridge_api::labels::canonical_name(*label).to_string(),
-                x: ox as f32,
-                y: oy as f32,
-                z: oz as f32,
-                coord_mode,
-                direct_speaker_index,
-                gain: channel_gain_db(channel_gains, channel as u32),
-                priority: 0.0,
-                size: [0.0, 0.0, 0.0],
-            }
-        });
-
-    // Then the dynamic objects, in event order.
-    let objects = conf.events.iter().filter_map(|event| {
-        let id = event.id()?;
-        let [x, y, z] = event_pos_raw(event).unwrap_or([0.0; 3]);
-        Some(ObjectMeta {
-            name: object_names
-                .get(&id)
-                .cloned()
-                .unwrap_or_else(|| format!("Obj_{id}")),
-            x: x as f32,
-            y: y as f32,
-            z: z as f32,
-            coord_mode: fallback_coord_mode(),
-            direct_speaker_index: None,
-            gain: event.gain_db().map_or(-128, |g| g as i32),
-            priority: 0.0,
-            size: event
-                .size()
-                .map(|s| [s[0] as f32, s[1] as f32, s[2] as f32])
-                .unwrap_or([0.0, 0.0, 0.0]),
-        })
-    });
-
-    fixed.chain(objects).collect()
+        .collect()
 }
 
 /// Resolve an event's position to ADM Cartesian `[x, y, z]`, converting from the
@@ -273,53 +209,26 @@ mod tests {
     }
 
     #[test]
-    fn object_metas_list_fixed_channels_first_with_label_names() {
+    fn object_metas_report_named_objects_with_raw_positions() {
         let mut event = Event::with_id(10);
         event.set_pos([0.1, 0.2, 0.3]);
+        event.set_gain_db(-3);
         let conf = Configuration::new(vec![event]);
-        let layout = SpeakerLayout::from_speakers(vec![
-            Speaker::new("FL", -30.0, 0.0),
-            Speaker::new("FR", 30.0, 0.0),
-            Speaker::new("SW", 0.0, -30.0),
-        ])
-        .expect("layout");
         let names = HashMap::from([(10, "Music".to_string())]);
-        let gains = [bridge_api::RChannelGain {
-            channel: 2,
-            gain_db: -6,
-        }];
 
-        let metas = build_object_metas(
-            &conf,
-            RCoordinateFormat::Cartesian,
-            Some(&layout),
-            &names,
-            &[L, R, LFE, Object],
-            &gains,
-        );
+        let metas = build_object_metas(&conf, RCoordinateFormat::Cartesian, &names);
 
-        let listed: Vec<&str> = metas.iter().map(|m| m.name.as_str()).collect();
-        assert_eq!(listed, ["L", "R", "LFE", "Music"]);
-        // Fixed channels carry their speaker routing; the LFE gain automation
-        // is reflected; the object keeps its raw event position.
-        assert_eq!(metas[0].direct_speaker_index, Some(0));
-        assert_eq!(metas[2].direct_speaker_index, Some(2));
-        assert_eq!(metas[2].gain, -6);
-        assert_eq!(metas[3].direct_speaker_index, None);
-        assert!((metas[3].x - 0.1).abs() < 1e-6);
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].name, "Music");
+        assert_eq!(metas[0].direct_speaker_index, None);
+        assert_eq!(metas[0].gain, -3);
+        assert!((metas[0].x - 0.1).abs() < 1e-6);
     }
 
     #[test]
     fn unnamed_objects_fall_back_to_their_id() {
         let conf = Configuration::new(vec![Event::with_id(12)]);
-        let metas = build_object_metas(
-            &conf,
-            RCoordinateFormat::Cartesian,
-            None,
-            &HashMap::new(),
-            &[],
-            &[],
-        );
+        let metas = build_object_metas(&conf, RCoordinateFormat::Cartesian, &HashMap::new());
         assert_eq!(metas[0].name, "Obj_12");
     }
 }

--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -398,28 +398,37 @@ pub(crate) fn surround_placement_override(
     Some((sign, y, 0.0))
 }
 
-/// Bed id a *direct* (non-spatialized) surround channel routes to, honouring
-/// `surround_placement`. `Back` sends `Ls`/`Rs` to the back speaker (bed 6/7)
-/// when the output layout actually has one, otherwise it falls back to the side
-/// bed (4/5). All other labels keep [`bed_id_for_label`].
-fn direct_bed_id_for_label(
+/// Label a *direct* (non-spatialized) channel routes to, honouring
+/// `surround_placement`. `Back` sends `Ls`/`Rs` to the back speaker when the
+/// output layout actually has one, otherwise it keeps the side label. An
+/// `LFE2` without a matching speaker folds onto the `LFE` sub, as the legacy
+/// bed scheme did. `Object`/`Unknown` have no direct route.
+fn direct_route_label(
     label: RChannelLabel,
     use_7_1: bool,
     placement: SurroundPlacement,
-    output_bed_to_speaker: Option<&HashMap<usize, usize>>,
-) -> Option<usize> {
-    let base = bed_id_for_label(label)?;
+    label_to_speaker: Option<&HashMap<RChannelLabel, usize>>,
+) -> Option<RChannelLabel> {
+    let has_speaker = |l: RChannelLabel| label_to_speaker.is_some_and(|map| map.contains_key(&l));
+    match label {
+        RChannelLabel::Object | RChannelLabel::Unknown => return None,
+        RChannelLabel::LFE2 if !has_speaker(RChannelLabel::LFE2) => {
+            return Some(RChannelLabel::LFE);
+        }
+        _ => {}
+    }
     if use_7_1 || placement != SurroundPlacement::Back {
-        return Some(base);
+        return Some(label);
     }
     let back = match label {
-        RChannelLabel::Ls => 6, // Lb
-        RChannelLabel::Rs => 7, // Rb
-        _ => return Some(base),
+        RChannelLabel::Ls => RChannelLabel::Lb,
+        RChannelLabel::Rs => RChannelLabel::Rb,
+        _ => return Some(label),
     };
-    match output_bed_to_speaker {
-        Some(map) if map.contains_key(&back) => Some(back),
-        _ => Some(base),
+    if has_speaker(back) {
+        Some(back)
+    } else {
+        Some(label)
     }
 }
 
@@ -580,7 +589,7 @@ pub fn build_virtual_bed_objects(
 
     // Used to anchor a direct channel onto its output speaker so Studio shows it
     // snapped to that speaker (its `directSpeakerIndex` decoration).
-    let bed_to_speaker = output_layout.map(|layout| layout.bed_to_speaker_mapping());
+    let label_to_speaker = output_layout.map(|layout| layout.label_to_speaker_mapping());
 
     let mut objects: Vec<ObjectMeta> = Vec::with_capacity(channel_labels.len());
     for label in channel_labels {
@@ -604,12 +613,17 @@ pub fn build_virtual_bed_objects(
         let direct_speaker_index = if spatialize {
             None
         } else {
-            direct_bed_id_for_label(*label, use_7_1, surround_placement, bed_to_speaker.as_ref())
-                .and_then(|bed_id| {
-                    bed_to_speaker
-                        .as_ref()
-                        .and_then(|m| m.get(&bed_id).map(|&spk| spk as u32))
-                })
+            direct_route_label(
+                *label,
+                use_7_1,
+                surround_placement,
+                label_to_speaker.as_ref(),
+            )
+            .and_then(|route_label| {
+                label_to_speaker
+                    .as_ref()
+                    .and_then(|m| m.get(&route_label).map(|&spk| spk as u32))
+            })
         };
         // Per-channel gain from the virtual bed (dB); 0 = unity when unset.
         let gain = find_virtual_bed_entry(virtual_bed, *label, use_7_1)
@@ -698,14 +712,14 @@ pub enum ChannelRenderPlan {
     /// writes the decoded channels straight out; the embedded mpv decoder
     /// declines so mpv falls back to its native decoder.
     HostPassthrough,
-    /// Render the events through the virtual bed. `bed_indices` is always
-    /// `Some(..)` with one entry per input channel: a bed id (0–9) for a channel
-    /// routed direct to its speaker, or `usize::MAX` for a channel virtualized as
-    /// a VBAP object (its position is carried by the matching event). The
-    /// renderer must `configure_beds` to it.
+    /// Render the events through the virtual bed. `routes` has one entry per
+    /// input channel: `Direct(label)` for a channel routed one-hot to the
+    /// speaker its label resolves to, `Virtual` for a channel rendered as a
+    /// VBAP object (its position is carried by the matching event). The
+    /// renderer must `configure_channel_routing` to it.
     Events {
         events: Vec<renderer::spatial_renderer::SpatialChannelEvent>,
-        bed_indices: Option<Vec<usize>>,
+        routes: Vec<renderer::spatial_renderer::ChannelRoute>,
     },
     /// No renderable mapping for these labels → emit silence (advance the host
     /// by the frame's sample count without producing sound).
@@ -766,11 +780,12 @@ fn build_virtual_bed_plan(
         .any(|l| matches!(l, RChannelLabel::Lb | RChannelLabel::Rb | RChannelLabel::Cb));
     let use_7_1 = has_back;
 
-    // Bed-id → output-speaker map, so a direct surround can be rerouted to a
+    // Label → output-speaker map, so a direct surround can be rerouted to a
     // back speaker (Back placement) only when the layout actually has one.
-    let bed_to_speaker = output_layout.map(|layout| layout.bed_to_speaker_mapping());
+    let label_to_speaker = output_layout.map(|layout| layout.label_to_speaker_mapping());
 
-    let mut bed_indices: Vec<usize> = Vec::with_capacity(channel_labels.len());
+    let mut routes: Vec<renderer::spatial_renderer::ChannelRoute> =
+        Vec::with_capacity(channel_labels.len());
     let mut events: Vec<renderer::spatial_renderer::SpatialChannelEvent> =
         Vec::with_capacity(channel_labels.len());
 
@@ -789,7 +804,7 @@ fn build_virtual_bed_plan(
                 surround_placement,
             ) {
                 Some((_name, x, y, z)) => {
-                    bed_indices.push(usize::MAX);
+                    routes.push(renderer::spatial_renderer::ChannelRoute::Virtual);
                     events.push(renderer::spatial_renderer::SpatialChannelEvent {
                         channel_idx,
                         is_bed: false,
@@ -801,20 +816,22 @@ fn build_virtual_bed_plan(
                     });
                 }
                 // No resolvable pose: keep index alignment, route nowhere.
-                None => bed_indices.push(usize::MAX),
+                None => routes.push(renderer::spatial_renderer::ChannelRoute::Virtual),
             }
         } else {
-            // Direct: route to the matching output speaker (by bed id / name),
-            // honouring Back placement for a 4.x/5.x surround when a back speaker
-            // exists.
-            match direct_bed_id_for_label(
+            // Direct: route to the matching output speaker (by label),
+            // honouring Back placement for a 4.x/5.x surround when a back
+            // speaker exists.
+            match direct_route_label(
                 *label,
                 use_7_1,
                 surround_placement,
-                bed_to_speaker.as_ref(),
+                label_to_speaker.as_ref(),
             ) {
-                Some(bed_id) => {
-                    bed_indices.push(bed_id);
+                Some(route_label) => {
+                    routes.push(renderer::spatial_renderer::ChannelRoute::Direct(
+                        route_label,
+                    ));
                     events.push(renderer::spatial_renderer::SpatialChannelEvent {
                         channel_idx,
                         is_bed: true,
@@ -826,7 +843,7 @@ fn build_virtual_bed_plan(
                     });
                 }
                 // No direct slot for a channel asked to route direct: silent.
-                None => bed_indices.push(usize::MAX),
+                None => routes.push(renderer::spatial_renderer::ChannelRoute::Virtual),
             }
         }
     }
@@ -834,10 +851,161 @@ fn build_virtual_bed_plan(
     if events.is_empty() {
         ChannelRenderPlan::Silence
     } else {
-        ChannelRenderPlan::Events {
-            events,
-            bed_indices: Some(bed_indices),
+        ChannelRenderPlan::Events { events, routes }
+    }
+}
+
+/// Build the OSC display objects for an object stream's fixed prefix, using
+/// the renderer's live placement options so the displayed poses match the
+/// applied channel plan. `None` when the prefix is empty or unresolvable.
+pub fn build_fixed_channel_objects(
+    renderer: &renderer::spatial_renderer::SpatialRenderer,
+    fixed_labels: &[RChannelLabel],
+) -> Option<Vec<ObjectMeta>> {
+    if fixed_labels.is_empty() {
+        return None;
+    }
+    let control = renderer.renderer_control();
+    let (
+        virtual_bed_layout,
+        surround_placement,
+        room_ratio,
+        room_ratio_rear,
+        room_ratio_lower,
+        room_ratio_center_blend,
+    ) = {
+        let live = control.live.read();
+        (
+            live.virtual_bed.clone(),
+            live.surround_placement,
+            live.room_ratio,
+            live.room_ratio_rear,
+            live.room_ratio_lower,
+            live.room_ratio_center_blend,
+        )
+    };
+    let layout = renderer.speaker_layout();
+    build_virtual_bed_objects(
+        fixed_labels,
+        virtual_bed_layout.as_ref(),
+        Some(&layout),
+        room_ratio,
+        room_ratio_rear,
+        room_ratio_lower,
+        room_ratio_center_blend,
+        surround_placement,
+    )
+}
+
+/// Shared fixed-channel planner for object streams (engine + CLI decode
+/// paths). Plans the fixed prefix of the channel list through
+/// [`plan_channel_render`] — virtualized by default, per-entry direct opt-in
+/// via the placement layout — caches the result on `(labels, options_epoch)`,
+/// and applies the routing to the renderer only on change.
+#[derive(Default)]
+pub struct FixedChannelPlanner {
+    planned_labels: Vec<RChannelLabel>,
+    planned_epoch: Option<u64>,
+    applied_routes: Option<Vec<renderer::spatial_renderer::ChannelRoute>>,
+}
+
+impl FixedChannelPlanner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Forget everything (stream reset / new segment).
+    pub fn reset(&mut self) {
+        self.planned_labels.clear();
+        self.planned_epoch = None;
+        self.applied_routes = None;
+    }
+
+    /// Fixed labels of the last planned prefix.
+    pub fn fixed_labels(&self) -> &[RChannelLabel] {
+        &self.planned_labels
+    }
+
+    /// Apply a route set computed elsewhere (the fixed-only render path),
+    /// deduplicated against the last applied set.
+    pub fn apply_routes(
+        &mut self,
+        renderer: &renderer::spatial_renderer::SpatialRenderer,
+        routes: Vec<renderer::spatial_renderer::ChannelRoute>,
+    ) {
+        if self.applied_routes.as_deref() != Some(routes.as_slice()) {
+            renderer.configure_channel_routing(&routes);
+            self.applied_routes = Some(routes);
         }
+    }
+
+    /// Plan the fixed prefix (labels before the first `Object` channel) of an
+    /// object stream and apply it. Mode is always spatial here: an object
+    /// stream cannot pass through the host, so the live channel mode only
+    /// applies to fixed-only streams. On replan the fixed channels' pose/gain
+    /// events are appended to `out` (the renderer caches per-channel state,
+    /// so they are only needed when the plan changes).
+    #[allow(clippy::too_many_arguments)]
+    pub fn plan_object_stream_fixed(
+        &mut self,
+        channel_labels: &[RChannelLabel],
+        renderer: &renderer::spatial_renderer::SpatialRenderer,
+        out: &mut Vec<renderer::spatial_renderer::SpatialChannelEvent>,
+    ) {
+        let fixed_end = channel_labels
+            .iter()
+            .position(|l| *l == RChannelLabel::Object)
+            .unwrap_or(channel_labels.len());
+        let fixed = &channel_labels[..fixed_end];
+
+        let control = renderer.renderer_control();
+        let epoch = control.options_epoch();
+        if self.planned_epoch == Some(epoch) && self.planned_labels == fixed {
+            return;
+        }
+
+        let (
+            virtual_bed_layout,
+            surround_placement,
+            room_ratio,
+            room_ratio_rear,
+            room_ratio_lower,
+            room_ratio_center_blend,
+        ) = {
+            let live = control.live.read();
+            (
+                live.virtual_bed.clone(),
+                live.surround_placement,
+                live.room_ratio,
+                live.room_ratio_rear,
+                live.room_ratio_lower,
+                live.room_ratio_center_blend,
+            )
+        };
+        let output_layout = renderer.speaker_layout();
+
+        match plan_channel_render(
+            renderer::live_params::ChannelRenderMode::Spatial,
+            fixed,
+            virtual_bed_layout.as_ref(),
+            Some(&output_layout),
+            room_ratio,
+            room_ratio_rear,
+            room_ratio_lower,
+            room_ratio_center_blend,
+            surround_placement,
+        ) {
+            ChannelRenderPlan::Events { events, routes } => {
+                self.apply_routes(renderer, routes);
+                out.extend(events);
+            }
+            ChannelRenderPlan::HostPassthrough | ChannelRenderPlan::Silence => {
+                self.apply_routes(renderer, Vec::new());
+            }
+        }
+
+        self.planned_labels = fixed.to_vec();
+        self.planned_epoch = Some(epoch);
     }
 }
 
@@ -1255,68 +1423,68 @@ mod tests {
         // Back placement sends a direct (non-spatialized) surround to the back
         // bed (6/7) only when the output layout has that speaker; else the side
         // bed (4/5). Side never remaps, and 7.x is unaffected.
-        let mut with_back: HashMap<usize, usize> = HashMap::new();
-        with_back.insert(6, 10);
-        with_back.insert(7, 11);
-        let without_back: HashMap<usize, usize> = HashMap::new();
+        let mut with_back: HashMap<RChannelLabel, usize> = HashMap::new();
+        with_back.insert(RChannelLabel::Lb, 10);
+        with_back.insert(RChannelLabel::Rb, 11);
+        let without_back: HashMap<RChannelLabel, usize> = HashMap::new();
 
         assert_eq!(
-            direct_bed_id_for_label(
+            direct_route_label(
                 RChannelLabel::Ls,
                 false,
                 SurroundPlacement::Back,
                 Some(&with_back)
             ),
-            Some(6)
+            Some(RChannelLabel::Lb)
         );
         assert_eq!(
-            direct_bed_id_for_label(
+            direct_route_label(
                 RChannelLabel::Rs,
                 false,
                 SurroundPlacement::Back,
                 Some(&with_back)
             ),
-            Some(7)
+            Some(RChannelLabel::Rb)
         );
         assert_eq!(
-            direct_bed_id_for_label(
+            direct_route_label(
                 RChannelLabel::Ls,
                 false,
                 SurroundPlacement::Back,
                 Some(&without_back)
             ),
-            Some(4),
-            "no back speaker → side bed"
+            Some(RChannelLabel::Ls),
+            "no back speaker → side label"
         );
         assert_eq!(
-            direct_bed_id_for_label(
+            direct_route_label(
                 RChannelLabel::Ls,
                 false,
                 SurroundPlacement::Side,
                 Some(&with_back)
             ),
-            Some(4),
+            Some(RChannelLabel::Ls),
             "Side never remaps"
         );
         assert_eq!(
-            direct_bed_id_for_label(
+            direct_route_label(
                 RChannelLabel::Ls,
                 true,
                 SurroundPlacement::Back,
                 Some(&with_back)
             ),
-            Some(4),
+            Some(RChannelLabel::Ls),
             "7.x ignores the setting"
         );
         // LFE and front channels are never remapped.
         assert_eq!(
-            direct_bed_id_for_label(
+            direct_route_label(
                 RChannelLabel::LFE,
                 false,
                 SurroundPlacement::Back,
                 Some(&with_back)
             ),
-            Some(3)
+            Some(RChannelLabel::LFE)
         );
     }
 
@@ -1365,21 +1533,18 @@ mod tests {
             SurroundPlacement::Side,
         );
         match plan {
-            ChannelRenderPlan::Events {
-                events,
-                bed_indices,
-            } => {
-                let bi = bed_indices.expect("spatial mode configures bed_indices");
+            ChannelRenderPlan::Events { events, routes } => {
+                use renderer::spatial_renderer::ChannelRoute;
                 // One entry per channel: LFE (idx 3) is direct, the rest virtual.
                 assert_eq!(
-                    bi,
+                    routes,
                     vec![
-                        usize::MAX,
-                        usize::MAX,
-                        usize::MAX,
-                        3,
-                        usize::MAX,
-                        usize::MAX
+                        ChannelRoute::Virtual,
+                        ChannelRoute::Virtual,
+                        ChannelRoute::Virtual,
+                        ChannelRoute::Direct(RChannelLabel::LFE),
+                        ChannelRoute::Virtual,
+                        ChannelRoute::Virtual,
                     ]
                 );
                 // Six events: five virtual objects + the LFE bed.
@@ -1418,23 +1583,36 @@ mod tests {
             SurroundPlacement::Side,
         );
         match plan {
-            ChannelRenderPlan::Events { bed_indices, .. } => {
-                let bi = bed_indices.unwrap();
-                // C (idx 2) is now direct → bed id 2; LFE (idx 3) is virtual → MAX.
-                assert_eq!(bi[2], 2, "C explicitly direct");
-                assert_eq!(bi[3], usize::MAX, "LFE explicitly virtualized");
-                assert_eq!(bi[0], usize::MAX, "L keeps the virtual default");
+            ChannelRenderPlan::Events { routes, .. } => {
+                use renderer::spatial_renderer::ChannelRoute;
+                // C (idx 2) is now direct; LFE (idx 3) is virtual.
+                assert_eq!(
+                    routes[2],
+                    ChannelRoute::Direct(RChannelLabel::C),
+                    "C explicitly direct"
+                );
+                assert_eq!(
+                    routes[3],
+                    ChannelRoute::Virtual,
+                    "LFE explicitly virtualized"
+                );
+                assert_eq!(
+                    routes[0],
+                    ChannelRoute::Virtual,
+                    "L keeps the virtual default"
+                );
             }
             other => panic!("expected Events, got {:?}", PlanKind::from(&other)),
         }
     }
 
     #[test]
-    fn plan_spatial_keeps_alignment_for_unroutable_direct_channel() {
+    fn plan_spatial_routes_direct_channels_by_label() {
         use renderer::speaker_layout::Speaker;
-        // Back-centre (Cb) has no direct-speaker slot. Even if asked to route
-        // direct, it must keep index alignment with a sentinel and emit no event
-        // (silent), not shift the other channels.
+        // A direct back-centre routes by label: with the label language there
+        // is no "no slot in the scheme" case anymore — the route carries Cb
+        // and the renderer resolves (or silently skips) it against the active
+        // layout. Index alignment is preserved either way.
         let bed = vbed(vec![
             Speaker::new_with_spatialize("BC", 180.0, 0.0, false),
             Speaker::new_with_spatialize("FL", -30.0, 0.0, true),
@@ -1453,16 +1631,18 @@ mod tests {
             SurroundPlacement::Side,
         );
         match plan {
-            ChannelRenderPlan::Events {
-                events,
-                bed_indices,
-            } => {
-                let bi = bed_indices.unwrap();
-                assert_eq!(bi.len(), 3);
-                assert_eq!(bi[1], usize::MAX, "Cb direct but no slot → sentinel");
-                // L and R virtualize (objects); Cb produces no event.
-                assert!(events.iter().all(|e| e.channel_idx != 1));
-                assert_eq!(events.len(), 2);
+            ChannelRenderPlan::Events { events, routes } => {
+                use renderer::spatial_renderer::ChannelRoute;
+                assert_eq!(routes.len(), 3);
+                assert_eq!(
+                    routes[1],
+                    ChannelRoute::Direct(RChannelLabel::Cb),
+                    "Cb routes direct by label; the layout decides at render time"
+                );
+                // L and R virtualize (objects); Cb carries a direct (bed) event.
+                assert_eq!(events.len(), 3);
+                let cb = events.iter().find(|e| e.channel_idx == 1).unwrap();
+                assert!(cb.is_bed);
             }
             other => panic!("expected Events, got {:?}", PlanKind::from(&other)),
         }

--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -648,26 +648,6 @@ pub fn build_virtual_bed_objects(
     }
 }
 
-/// Bed id (0–9, the scheme used by [`SpeakerLayout::bed_to_speaker_mapping`])
-/// for a channel label, or `None` when the label has no direct-speaker slot in
-/// that scheme (e.g. back-centre / top-side channels). Used to route a channel
-/// the virtual bed marks `spatialize:false` direct to its output speaker.
-fn bed_id_for_label(label: RChannelLabel) -> Option<usize> {
-    match label {
-        RChannelLabel::L => Some(0),
-        RChannelLabel::R => Some(1),
-        RChannelLabel::C => Some(2),
-        RChannelLabel::LFE | RChannelLabel::LFE2 => Some(3),
-        RChannelLabel::Ls => Some(4),
-        RChannelLabel::Rs => Some(5),
-        RChannelLabel::Lb => Some(6),
-        RChannelLabel::Rb => Some(7),
-        RChannelLabel::Tfl => Some(8),
-        RChannelLabel::Tfr => Some(9),
-        _ => None,
-    }
-}
-
 /// Default placement for a channel label when the virtual bed has no entry for
 /// it (or no virtual bed is configured): every channel is virtualized except the
 /// LFE, which cannot be VBAP-panned and routes direct to the sub.

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -774,7 +774,6 @@ pub struct RenderTopology {
     pub speaker_layout: SpeakerLayout,
     pub backend: Arc<PreparedRenderEngine>,
     pub backend_to_speaker_mapping: Option<Vec<usize>>,
-    pub bed_to_speaker_mapping: HashMap<usize, usize>,
     /// Per-label speaker lookup for the channel-routing table (re-resolved on
     /// every topology rebuild, so stored labels survive layout swaps).
     pub label_to_speaker: HashMap<bridge_api::RChannelLabel, usize>,
@@ -816,7 +815,6 @@ impl RenderTopology {
         };
 
         Ok(Self {
-            bed_to_speaker_mapping: speaker_layout.bed_to_speaker_mapping(),
             label_to_speaker: speaker_layout.label_to_speaker_mapping(),
             num_speakers,
             num_spatializable,

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -775,6 +775,9 @@ pub struct RenderTopology {
     pub backend: Arc<PreparedRenderEngine>,
     pub backend_to_speaker_mapping: Option<Vec<usize>>,
     pub bed_to_speaker_mapping: HashMap<usize, usize>,
+    /// Per-label speaker lookup for the channel-routing table (re-resolved on
+    /// every topology rebuild, so stored labels survive layout swaps).
+    pub label_to_speaker: HashMap<bridge_api::RChannelLabel, usize>,
     pub num_speakers: usize,
     pub num_spatializable: usize,
     /// The `RendererControl::geometry_generation` this topology's gain models were
@@ -814,6 +817,7 @@ impl RenderTopology {
 
         Ok(Self {
             bed_to_speaker_mapping: speaker_layout.bed_to_speaker_mapping(),
+            label_to_speaker: speaker_layout.label_to_speaker_mapping(),
             num_speakers,
             num_spatializable,
             speaker_layout,

--- a/omniphony-renderer/renderer/src/spatial_renderer/components.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/components.rs
@@ -124,6 +124,13 @@ pub(super) struct ChannelState {
     /// Gain in dB
     pub(super) gain_db: i8,
 
+    /// Linear gain actually applied at the end of the last rendered block.
+    /// Every gain step (metadata jump, mute toggle, plan transition, stream
+    /// start) is slewed toward its target at a constant rate — full scale in
+    /// [`GAIN_SLEW_SECS`](super::GAIN_SLEW_SECS) — so routing/plan changes
+    /// never click. Starts silent: streams fade in over the slew time.
+    pub(super) slewed_gain: f32,
+
     pub(super) ramp: ChannelRampState,
 
     /// `RampMode::Interp` only: this channel's destination band gains from the
@@ -132,10 +139,38 @@ pub(super) struct ChannelState {
     pub(super) interp_prev_gains: Vec<Gains>,
 }
 
+impl ChannelState {
+    /// Advance the gain slew by one block toward `target`; returns the
+    /// block's `(start, per_sample_step)` so mix loops can interpolate
+    /// `start + step * sample_idx`.
+    pub(super) fn slew_gain(
+        &mut self,
+        target: f32,
+        sample_length: usize,
+        ramp_samples: f32,
+    ) -> (f32, f32) {
+        let start = self.slewed_gain;
+        let max_step = if ramp_samples > 0.0 {
+            sample_length as f32 / ramp_samples
+        } else {
+            f32::INFINITY
+        };
+        let delta = (target - start).clamp(-max_step, max_step);
+        self.slewed_gain = start + delta;
+        let step = if sample_length > 0 {
+            delta / sample_length as f32
+        } else {
+            0.0
+        };
+        (start, step)
+    }
+}
+
 impl Default for ChannelState {
     fn default() -> Self {
         Self {
             gain_db: -128, // -inf dB (muted)
+            slewed_gain: 0.0,
             ramp: ChannelRampState::default(),
             interp_prev_gains: Vec::new(),
         }

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -232,7 +232,7 @@ impl SpatialRenderer {
             distance_diffuse_curve,
             auto_gain,
             &excluded,
-            &topology.bed_to_speaker_mapping,
+            &topology.label_to_speaker,
         );
         let editable_layout = topology.speaker_layout.clone();
         let control = RendererControl::new(
@@ -311,7 +311,7 @@ impl SpatialRenderer {
         distance_diffuse_curve: f32,
         auto_gain: bool,
         excluded: &[&str],
-        bed_to_speaker_mapping: &std::collections::HashMap<usize, usize>,
+        label_to_speaker: &std::collections::HashMap<bridge_api::RChannelLabel, usize>,
     ) -> LiveParams {
         if !excluded.is_empty() {
             log::info!("Excluded from VBAP spatialization: {}", excluded.join(", "));
@@ -350,10 +350,7 @@ impl SpatialRenderer {
             master_gain,
             auto_gain
         );
-        log::info!(
-            "Bed to speaker mapping (by name): {:?}",
-            bed_to_speaker_mapping
-        );
+        log::info!("Label to speaker mapping (by name): {:?}", label_to_speaker);
 
         let mut speaker_live = std::collections::HashMap::new();
         for (idx, spk) in speaker_layout.speakers.iter().enumerate() {

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -573,7 +573,7 @@ impl SpatialRenderer {
         Ok(Self {
             num_speakers,
             spread_resolution,
-            bed_indices: arc_swap::ArcSwap::new(std::sync::Arc::new(Vec::new())),
+            channel_routing: arc_swap::ArcSwap::new(std::sync::Arc::new(Vec::new())),
             first_render: std::sync::atomic::AtomicBool::new(true),
             frame_counter: std::sync::atomic::AtomicU64::new(0),
             channel_states: parking_lot::Mutex::new(std::collections::HashMap::new()),

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -150,6 +150,12 @@ fn ensure_denormals_flushed() {
 }
 
 /// Spatial audio renderer using VBAP
+/// Time for a full-scale (0 → unity) gain change to complete, in seconds.
+/// Every per-channel gain step is slewed at this constant rate so metadata
+/// jumps, mute toggles and channel-plan transitions never click
+/// (`docs/channel-object-contract.md`, phase 2b).
+pub const GAIN_SLEW_SECS: f32 = 0.02;
+
 /// Per-input-channel routing decision, in the layout-independent label
 /// language of `docs/channel-object-contract.md`: a `Direct` channel is
 /// one-hot routed to the speaker its label resolves to in the active topology
@@ -701,7 +707,16 @@ impl SpatialRenderer {
                     } else {
                         10.0_f32.powf(gain_db as f32 / 20.0)
                     };
-                    self.binaural_gain_buf[c] = obj_gain * gain_linear;
+                    // Slewed like the VBAP path (block-end value: the binaural
+                    // stage updates per block anyway).
+                    let ramp_samples = self.sample_rate as f32 * GAIN_SLEW_SECS;
+                    if let Some(state) = states.get_mut(&c) {
+                        let (start, step) =
+                            state.slew_gain(obj_gain * gain_linear, sample_length, ramp_samples);
+                        self.binaural_gain_buf[c] = start + step * sample_length as f32;
+                    } else {
+                        self.binaural_gain_buf[c] = 0.0;
+                    }
                     // Same direct/virtual split as the VBAP path.
                     let direct_label = match channel_routing.get(c) {
                         Some(ChannelRoute::Direct(label)) if c < num_routed => Some(*label),
@@ -896,10 +911,8 @@ impl SpatialRenderer {
             };
 
             // Get gain from cached metadata (common for ALL channels - beds and objects)
-            let gain_db = channel_states
-                .get(&input_channel_idx)
-                .map(|s| s.gain_db)
-                .unwrap_or(-128);
+            let state = channel_states.entry(input_channel_idx).or_default();
+            let gain_db = state.gain_db;
 
             // Convert gain from dB to linear
             let gain_linear = if gain_db == -128 {
@@ -907,6 +920,11 @@ impl SpatialRenderer {
             } else {
                 10.0_f32.powf(gain_db as f32 / 20.0)
             };
+            // Slewed per-sample gain factor (includes the mute 0/1 factor):
+            // factor(s) = gain_start + gain_step * s.
+            let ramp_samples = self.sample_rate as f32 * GAIN_SLEW_SECS;
+            let (gain_start, gain_step) =
+                state.slew_gain(gain_linear * obj_gain, sample_length, ramp_samples);
 
             // A channel is directly routed when its routing entry is
             // `Direct` (channels beyond the routing table are trailing object
@@ -940,8 +958,7 @@ impl SpatialRenderer {
                 // used for objects, but with a one-hot routing table.
                 for sample_idx in 0..sample_length {
                     let sample = input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                        * gain_linear
-                        * obj_gain;
+                        * (gain_start + gain_step * sample_idx as f32);
                     let out_base = sample_idx * self.num_speakers;
                     for (speaker_idx, &gain) in self.bed_routing_gains_buf.iter().enumerate() {
                         output[out_base + speaker_idx] += sample * gain;
@@ -1040,8 +1057,7 @@ impl SpatialRenderer {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * gain_linear
-                                        * obj_gain
+                                        * (gain_start + gain_step * sample_idx as f32)
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -1058,8 +1074,7 @@ impl SpatialRenderer {
                             for sample_idx in 0..sample_length {
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * gain_linear
-                                    * obj_gain;
+                                    * (gain_start + gain_step * sample_idx as f32);
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,
@@ -1103,8 +1118,7 @@ impl SpatialRenderer {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * gain_linear
-                                        * obj_gain
+                                        * (gain_start + gain_step * sample_idx as f32)
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -1121,8 +1135,7 @@ impl SpatialRenderer {
                             for sample_idx in 0..sample_length {
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * gain_linear
-                                    * obj_gain;
+                                    * (gain_start + gain_step * sample_idx as f32);
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,
@@ -1156,8 +1169,7 @@ impl SpatialRenderer {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * gain_linear
-                                        * obj_gain
+                                        * (gain_start + gain_step * sample_idx as f32)
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -1229,8 +1241,7 @@ impl SpatialRenderer {
                                 }
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * gain_linear
-                                    * obj_gain;
+                                    * (gain_start + gain_step * sample_idx as f32);
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,
@@ -1293,8 +1304,7 @@ impl SpatialRenderer {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * gain_linear
-                                        * obj_gain
+                                        * (gain_start + gain_step * sample_idx as f32)
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -1329,8 +1339,7 @@ impl SpatialRenderer {
                                 }
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * gain_linear
-                                    * obj_gain;
+                                    * (gain_start + gain_step * sample_idx as f32);
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -150,6 +150,17 @@ fn ensure_denormals_flushed() {
 }
 
 /// Spatial audio renderer using VBAP
+/// Per-input-channel routing decision, in the layout-independent label
+/// language of `docs/channel-object-contract.md`: a `Direct` channel is
+/// one-hot routed to the speaker its label resolves to in the active topology
+/// (skipped when the layout has none); a `Virtual` channel renders through
+/// the VBAP/object path from its metadata events.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ChannelRoute {
+    Direct(bridge_api::RChannelLabel),
+    Virtual,
+}
+
 pub struct SpatialRenderer {
     /// Number of output speakers (total, including non-spatialized like LFE)
     num_speakers: usize,
@@ -159,7 +170,7 @@ pub struct SpatialRenderer {
 
     /// Bed channel IDs in PCM order (e.g. [3, 0, 1, 2, ...]).
     /// Updated when format metadata changes and read lock-free in the audio thread.
-    bed_indices: arc_swap::ArcSwap<Vec<usize>>,
+    channel_routing: arc_swap::ArcSwap<Vec<ChannelRoute>>,
 
     /// Flag for first render (for detailed logging)
     first_render: std::sync::atomic::AtomicBool,
@@ -328,10 +339,37 @@ impl SpatialRenderer {
     ///
     /// Must be called once when the first metadata arrives, before any call to `render_frame`.
     /// The mapping is stable for the lifetime of the stream.
+    pub fn configure_channel_routing(&self, routes: &[ChannelRoute]) {
+        self.channel_routing
+            .store(std::sync::Arc::new(routes.to_vec()));
+        log::debug!("Renderer channel routing configured: {:?}", routes);
+    }
+
+    /// Legacy adapter over [`configure_channel_routing`]: translates the
+    /// historical 0-9 bed-id scheme (with the `usize::MAX` "virtualize"
+    /// sentinel). Scheduled for removal with the scheme itself
+    /// (`docs/channel-object-contract.md`, phase 2b).
     pub fn configure_beds(&self, bed_indices: &[usize]) {
-        self.bed_indices
-            .store(std::sync::Arc::new(bed_indices.to_vec()));
-        log::debug!("Renderer bed_indices configured: {:?}", bed_indices);
+        use bridge_api::RChannelLabel as Label;
+        let routes: Vec<ChannelRoute> = bed_indices
+            .iter()
+            .map(|&id| match id {
+                0 => ChannelRoute::Direct(Label::L),
+                1 => ChannelRoute::Direct(Label::R),
+                2 => ChannelRoute::Direct(Label::C),
+                3 => ChannelRoute::Direct(Label::LFE),
+                4 => ChannelRoute::Direct(Label::Ls),
+                5 => ChannelRoute::Direct(Label::Rs),
+                6 => ChannelRoute::Direct(Label::Lb),
+                7 => ChannelRoute::Direct(Label::Rb),
+                8 => ChannelRoute::Direct(Label::Tfl),
+                9 => ChannelRoute::Direct(Label::Tfr),
+                usize::MAX => ChannelRoute::Virtual,
+                // Unroutable id: keep the slot, resolves to no speaker.
+                _ => ChannelRoute::Direct(Label::Unknown),
+            })
+            .collect();
+        self.configure_channel_routing(&routes);
     }
 
     /// Return the shared `RendererControl` Arc so that `OscSender` can hold it.
@@ -627,10 +665,11 @@ impl SpatialRenderer {
             0
         };
 
-        // Snapshot bed_indices once for this frame via ArcSwap: no mutex and no Vec clone.
-        let bed_indices = self.bed_indices.load_full();
+        // Snapshot the routing once for this frame via ArcSwap: no mutex and no
+        // Vec clone.
+        let channel_routing = self.channel_routing.load_full();
         let active_layout = &topology.speaker_layout;
-        let active_bed_to_speaker_mapping = &topology.bed_to_speaker_mapping;
+        let active_label_to_speaker = &topology.label_to_speaker;
 
         // ── Binaural branch ──────────────────────────────────────────────────
         // Build per-channel world positions (beds → speaker direction, objects →
@@ -644,7 +683,7 @@ impl SpatialRenderer {
             self.binaural_gain_buf.resize(input_channel_count, 0.0);
             self.binaural_direct_buf.clear();
             self.binaural_direct_buf.resize(input_channel_count, false);
-            let num_beds = bed_indices.len();
+            let num_routed = channel_routing.len();
             {
                 let mut states = self.channel_states.lock();
                 for c in 0..input_channel_count {
@@ -663,16 +702,18 @@ impl SpatialRenderer {
                         10.0_f32.powf(gain_db as f32 / 20.0)
                     };
                     self.binaural_gain_buf[c] = obj_gain * gain_linear;
-                    // Same bed/object split as the VBAP path: a `usize::MAX`
-                    // sentinel in the bed map means "virtualize" (object), so it
-                    // takes the ramp branch even though it is within `num_beds`.
-                    let routed_as_bed = c < num_beds && bed_indices[c] != usize::MAX;
-                    if routed_as_bed {
-                        // Bed channel: place it at its mapped speaker's direction.
-                        // A bed mapped to a non-spatialized speaker (the LFE)
-                        // keeps the direct-routing intent in headphone mode
-                        // too: fed to both ears equally, no HRTF (issue #156).
-                        if let Some(&spk) = active_bed_to_speaker_mapping.get(&bed_indices[c]) {
+                    // Same direct/virtual split as the VBAP path.
+                    let direct_label = match channel_routing.get(c) {
+                        Some(ChannelRoute::Direct(label)) if c < num_routed => Some(*label),
+                        _ => None,
+                    };
+                    if let Some(label) = direct_label {
+                        // Direct channel: place it at its resolved speaker's
+                        // direction. A channel routed to a non-spatialized
+                        // speaker (the LFE) keeps the direct-routing intent in
+                        // headphone mode too: fed to both ears equally, no
+                        // HRTF (issue #156).
+                        if let Some(&spk) = active_label_to_speaker.get(&label) {
                             if let Some(s) = active_layout.speakers.get(spk) {
                                 self.binaural_pos_buf[c] = [s.x as f64, s.y as f64, s.z as f64];
                                 self.binaural_direct_buf[c] = !s.spatialize;
@@ -825,9 +866,8 @@ impl SpatialRenderer {
         let mut crossover_elapsed = std::time::Duration::ZERO;
         let profile_crossover = measure_breakdown && self.crossover_filter_bank.is_some();
 
-        // Beds always come FIRST in PCM data, then objects.
-        // bed_indices contains bed channel IDs (e.g., [3] for LFE), NOT PCM channel indices.
-        let num_beds = bed_indices.len();
+        // Directly-routed channels always come FIRST in PCM data, then objects.
+        let num_routed = channel_routing.len();
 
         // Check if this is the first render for detailed logging
         let is_first = self
@@ -835,19 +875,12 @@ impl SpatialRenderer {
             .swap(false, std::sync::atomic::Ordering::Relaxed);
         if is_first {
             log::info!(
-                "VBAP render: {} total PCM channels, {} bed channels (PCM 0..{}), {} object channels (PCM {}..{})",
+                "VBAP render: {} total PCM channels, {} routed entries, {} trailing object channels",
                 input_channel_count,
-                num_beds,
-                num_beds.saturating_sub(1),
-                input_channel_count - num_beds,
-                num_beds,
-                input_channel_count - 1
+                num_routed,
+                input_channel_count.saturating_sub(num_routed),
             );
-            log::info!("  Bed IDs (spatial metadata): {:?}", bed_indices);
-            log::info!("  Mapping: channel_idx -> bed_id");
-            for (ch_idx, &bed_id) in bed_indices.iter().enumerate() {
-                log::info!("    PCM channel {} -> bed channel ID {}", ch_idx, bed_id);
-            }
+            log::info!("  Channel routing: {:?}", channel_routing);
         }
 
         // Hold channel metadata state lock once for the whole render pass.
@@ -875,29 +908,25 @@ impl SpatialRenderer {
                 10.0_f32.powf(gain_db as f32 / 20.0)
             };
 
-            // A channel is a bed when it has a bed-id entry that is not the
-            // `usize::MAX` "virtualize me" sentinel. Object-content beds list
-            // their ids as a prefix (so `idx < num_beds` ⇒ bed, the rest are
-            // objects); the parametrable virtual bed instead emits a full-length
-            // map that mixes real bed ids (direct, e.g. LFE) with `usize::MAX`
-            // (virtualized → VBAP object). The sentinel check unifies both: a
-            // prefix bed map has no sentinels, so its behaviour is unchanged.
-            let routed_as_bed =
-                input_channel_idx < num_beds && bed_indices[input_channel_idx] != usize::MAX;
-            if routed_as_bed {
-                // BED CHANNEL: Route to speaker based on bed_to_speaker_mapping (by name)
-                let bed_id = bed_indices[input_channel_idx];
-
-                // Look up speaker index from bed ID using name-based mapping
-                let speaker_idx = match active_bed_to_speaker_mapping.get(&bed_id) {
+            // A channel is directly routed when its routing entry is
+            // `Direct` (channels beyond the routing table are trailing object
+            // channels; `Virtual` entries render through the object path from
+            // their metadata events).
+            let direct_label = match channel_routing.get(input_channel_idx) {
+                Some(ChannelRoute::Direct(label)) => Some(*label),
+                _ => None,
+            };
+            if let Some(label) = direct_label {
+                // DIRECT CHANNEL: one-hot route to the speaker its label
+                // resolves to in the active topology.
+                let speaker_idx = match active_label_to_speaker.get(&label) {
                     Some(&idx) => idx,
                     None => {
-                        // Bed ID not found in speaker layout - skip this channel
+                        // No matching speaker in this layout — skip the channel.
                         if is_first {
                             log::warn!(
-                                "  Bed ch{} (ID={}) has no matching speaker in layout, skipping",
+                                "  Direct ch{} ({label:?}) has no matching speaker in layout, skipping",
                                 input_channel_idx,
-                                bed_id
                             );
                         }
                         continue;
@@ -928,9 +957,8 @@ impl SpatialRenderer {
                 if is_first {
                     let speaker_name = active_layout.speakers[speaker_idx].name.as_str();
                     log::info!(
-                        "  Bed ch{} (ID={}) → Speaker {} ({}) gain={}dB",
+                        "  Direct ch{} ({label:?}) → Speaker {} ({}) gain={}dB",
                         input_channel_idx,
-                        bed_id,
                         speaker_idx,
                         speaker_name,
                         gain_db

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -351,33 +351,6 @@ impl SpatialRenderer {
         log::debug!("Renderer channel routing configured: {:?}", routes);
     }
 
-    /// Legacy adapter over [`configure_channel_routing`]: translates the
-    /// historical 0-9 bed-id scheme (with the `usize::MAX` "virtualize"
-    /// sentinel). Scheduled for removal with the scheme itself
-    /// (`docs/channel-object-contract.md`, phase 2b).
-    pub fn configure_beds(&self, bed_indices: &[usize]) {
-        use bridge_api::RChannelLabel as Label;
-        let routes: Vec<ChannelRoute> = bed_indices
-            .iter()
-            .map(|&id| match id {
-                0 => ChannelRoute::Direct(Label::L),
-                1 => ChannelRoute::Direct(Label::R),
-                2 => ChannelRoute::Direct(Label::C),
-                3 => ChannelRoute::Direct(Label::LFE),
-                4 => ChannelRoute::Direct(Label::Ls),
-                5 => ChannelRoute::Direct(Label::Rs),
-                6 => ChannelRoute::Direct(Label::Lb),
-                7 => ChannelRoute::Direct(Label::Rb),
-                8 => ChannelRoute::Direct(Label::Tfl),
-                9 => ChannelRoute::Direct(Label::Tfr),
-                usize::MAX => ChannelRoute::Virtual,
-                // Unroutable id: keep the slot, resolves to no speaker.
-                _ => ChannelRoute::Direct(Label::Unknown),
-            })
-            .collect();
-        self.configure_channel_routing(&routes);
-    }
-
     /// Return the shared `RendererControl` Arc so that `OscSender` can hold it.
     pub fn renderer_control(&self) -> Arc<RendererControl> {
         Arc::clone(&self.control)

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -1318,6 +1318,12 @@ fn binaural_lfe_bed_feeds_both_ears_equally_and_dry() {
         position: None,
         sample_pos: Some(0),
     }];
+    // Warm up the per-channel gain slew (channels fade in over
+    // GAIN_SLEW_SECS from silence) with one long silent block, so the
+    // asserted block runs at settled gain.
+    let warmup = vec![0.0f32; 4096];
+    r.render_frame(&warmup, 1, &event, Vec::new(), false)
+        .unwrap();
     let out = r
         .render_frame(&pcm, 1, &event, Vec::new(), false)
         .unwrap()

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -484,12 +484,15 @@ fn virtual_bed_mixes_direct_and_virtualized_channels() {
         e
     };
 
-    // bed_indices: channel 0 = sentinel (object), channel 1 = bed id 3 (LFE).
-    let beds = [usize::MAX, 3usize];
+    // Routing: channel 0 = virtual (object), channel 1 = direct LFE.
+    let beds = [
+        ChannelRoute::Virtual,
+        ChannelRoute::Direct(bridge_api::RChannelLabel::LFE),
+    ];
 
     // Pass A: only the object channel (0) carries signal.
     let mut ra = build();
-    ra.configure_beds(&beds);
+    ra.configure_channel_routing(&beds);
     let pcm_a: Vec<f32> = (0..sample_length).flat_map(|_| [0.6f32, 0.0]).collect();
     let events_a = vec![
         SpatialChannelEvent {
@@ -528,7 +531,7 @@ fn virtual_bed_mixes_direct_and_virtualized_channels() {
 
     // Pass B: only the bed channel (1) carries signal → one-hot at the LFE.
     let mut rb = build();
-    rb.configure_beds(&beds);
+    rb.configure_channel_routing(&beds);
     let pcm_b: Vec<f32> = (0..sample_length).flat_map(|_| [0.0f32, 0.6]).collect();
     let eb = energy(
         &rb.render_frame(&pcm_b, 2, &events_a, Vec::new(), false)
@@ -691,8 +694,11 @@ fn spatialized_lfe_alone_in_low_band_routes_object_bass() {
     // The stream's own LFE bed channel still routes one-hot to the sub even
     // though the speaker is now spatialized.
     let mut r = build();
-    let beds = [usize::MAX, 3usize];
-    r.configure_beds(&beds);
+    let beds = [
+        ChannelRoute::Virtual,
+        ChannelRoute::Direct(bridge_api::RChannelLabel::LFE),
+    ];
+    r.configure_channel_routing(&beds);
     let bed_len = 8usize;
     let pcm: Vec<f32> = (0..bed_len).flat_map(|_| [0.0f32, 0.6]).collect();
     let events = vec![
@@ -1299,8 +1305,8 @@ fn binaural_lfe_bed_feeds_both_ears_equally_and_dry() {
         9,
     )
     .unwrap();
-    // Channel 0 = bed id 3 → the LFE speaker (index 3, spatialize:false).
-    r.configure_beds(&[3usize]);
+    // Channel 0 = direct LFE → the LFE speaker (index 3, spatialize:false).
+    r.configure_channel_routing(&[ChannelRoute::Direct(bridge_api::RChannelLabel::LFE)]);
     {
         let mut live = r.control.live.write();
         live.binaural.output_mode = crate::live_params::OutputMode::Binaural;

--- a/omniphony-renderer/renderer/src/speaker_layout.rs
+++ b/omniphony-renderer/renderer/src/speaker_layout.rs
@@ -532,6 +532,24 @@ impl SpeakerLayout {
     /// Returns a HashMap<bed_id, speaker_idx> for beds found in the layout;
     /// beds without a matching speaker are absent. The first speaker matching
     /// a label wins.
+    /// Per-label speaker lookup: each recognised speaker name (shared alias
+    /// table) maps its channel label to the speaker index; the first speaker
+    /// matching a label wins. This is the layout-independent routing language
+    /// of `docs/channel-object-contract.md` — a stored `RChannelLabel` stays
+    /// valid across layout swaps, the topology re-resolves it here.
+    pub fn label_to_speaker_mapping(
+        &self,
+    ) -> std::collections::HashMap<bridge_api::RChannelLabel, usize> {
+        let mut mapping = std::collections::HashMap::new();
+        for (speaker_idx, speaker) in self.speakers.iter().enumerate() {
+            let label = bridge_api::labels::label_for_name(&speaker.name);
+            if label != bridge_api::RChannelLabel::Unknown {
+                mapping.entry(label).or_insert(speaker_idx);
+            }
+        }
+        mapping
+    }
+
     pub fn bed_to_speaker_mapping(&self) -> std::collections::HashMap<usize, usize> {
         let mut mapping = std::collections::HashMap::new();
         for (speaker_idx, speaker) in self.speakers.iter().enumerate() {

--- a/omniphony-renderer/renderer/src/speaker_layout.rs
+++ b/omniphony-renderer/renderer/src/speaker_layout.rs
@@ -64,10 +64,10 @@ fn map_depth_with_room_ratios(
     }
 }
 
-/// Legacy 0-9 bed id for a channel label, shared by every remaining consumer
-/// of the historical bed-id scheme (renderer bed routing, engine ingestion).
-/// Scheduled to disappear with the scheme itself in phase 2b of
-/// `docs/channel-object-contract.md`.
+/// Legacy 0-9 bed id for a channel label. The renderer no longer routes by
+/// bed id — the only remaining consumer is the CLI file-export bed
+/// conformance, which keeps the fixed 10-slot export order
+/// (`docs/channel-object-contract.md`).
 pub fn legacy_bed_id(label: bridge_api::RChannelLabel) -> Option<usize> {
     use bridge_api::RChannelLabel as Label;
     match label {
@@ -518,20 +518,6 @@ impl SpeakerLayout {
         self.speakers.iter().map(|s| s.name.as_str()).collect()
     }
 
-    /// Create mapping from bed channel ID to speaker index based on speaker names.
-    ///
-    /// Speaker names are resolved to channel labels through the shared alias
-    /// table (`bridge_api::labels`), then labels to the legacy bed-id scheme:
-    ///
-    /// - 0: L, 1: R, 2: C, 3: LFE, 4: Ls, 5: Rs, 6: Lb, 7: Rb, 8: TFL, 9: TFR
-    ///
-    /// The 0-9 scheme itself is scheduled to leave the bridge ABI (see
-    /// `docs/channel-object-contract.md`, phase 2); this mapping then becomes
-    /// label -> speaker index directly.
-    ///
-    /// Returns a HashMap<bed_id, speaker_idx> for beds found in the layout;
-    /// beds without a matching speaker are absent. The first speaker matching
-    /// a label wins.
     /// Per-label speaker lookup: each recognised speaker name (shared alias
     /// table) maps its channel label to the speaker index; the first speaker
     /// matching a label wins. This is the layout-independent routing language
@@ -545,16 +531,6 @@ impl SpeakerLayout {
             let label = bridge_api::labels::label_for_name(&speaker.name);
             if label != bridge_api::RChannelLabel::Unknown {
                 mapping.entry(label).or_insert(speaker_idx);
-            }
-        }
-        mapping
-    }
-
-    pub fn bed_to_speaker_mapping(&self) -> std::collections::HashMap<usize, usize> {
-        let mut mapping = std::collections::HashMap::new();
-        for (speaker_idx, speaker) in self.speakers.iter().enumerate() {
-            if let Some(id) = legacy_bed_id(bridge_api::labels::label_for_name(&speaker.name)) {
-                mapping.entry(id).or_insert(speaker_idx);
             }
         }
         mapping
@@ -704,23 +680,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bed_mapping_accepts_every_legacy_alias() {
-        // Parity net for the shared-table rewrite: every spelling the old
-        // in-place alias table accepted must still resolve to the same bed id.
-        let legacy: [(usize, &[&str]); 10] = [
-            (0, &["L", "FL", "FrontLeft", "LeftFront"]),
-            (1, &["R", "FR", "FrontRight", "RightFront"]),
-            (2, &["C", "FC", "Center", "Centre"]),
-            (3, &["LFE", "Sub", "Subwoofer", "SW"]),
-            (4, &["Ls", "SL", "LeftSurround", "SurroundLeft"]),
+    fn label_mapping_accepts_every_legacy_alias() {
+        // Parity net kept from the bed-id era: every spelling the historical
+        // alias table accepted must still resolve, now to its channel label.
+        use bridge_api::RChannelLabel as L;
+        let legacy: [(L, &[&str]); 10] = [
+            (L::L, &["L", "FL", "FrontLeft", "LeftFront"]),
+            (L::R, &["R", "FR", "FrontRight", "RightFront"]),
+            (L::C, &["C", "FC", "Center", "Centre"]),
+            (L::LFE, &["LFE", "Sub", "Subwoofer", "SW"]),
+            (L::Ls, &["Ls", "SL", "LeftSurround", "SurroundLeft"]),
+            (L::Rs, &["Rs", "SR", "RightSurround", "SurroundRight"]),
             (
-                6,
+                L::Lb,
                 &[
                     "Lb", "BL", "Lrs", "BackLeft", "LeftBack", "RearLeft", "LeftRear",
                 ],
             ),
             (
-                7,
+                L::Rb,
                 &[
                     "Rb",
                     "BR",
@@ -732,7 +710,7 @@ mod tests {
                 ],
             ),
             (
-                8,
+                L::Tfl,
                 &[
                     "Ltf",
                     "TFL",
@@ -743,7 +721,7 @@ mod tests {
                 ],
             ),
             (
-                9,
+                L::Tfr,
                 &[
                     "Rtf",
                     "TFR",
@@ -753,9 +731,8 @@ mod tests {
                     "HR",
                 ],
             ),
-            (5, &["Rs", "SR", "RightSurround", "SurroundRight"]),
         ];
-        for (bed_id, aliases) in legacy {
+        for (label, aliases) in legacy {
             for alias in aliases {
                 let layout = SpeakerLayout::from_speakers(vec![
                     Speaker::new("A", -30.0, 0.0),
@@ -763,25 +740,30 @@ mod tests {
                     Speaker::new("B", 110.0, 0.0),
                 ])
                 .expect("parity layout");
-                let mapping = layout.bed_to_speaker_mapping();
+                let mapping = layout.label_to_speaker_mapping();
                 assert_eq!(
-                    mapping.get(&bed_id),
+                    mapping.get(&label),
                     Some(&1),
-                    "legacy alias {alias:?} no longer maps to bed id {bed_id}"
+                    "legacy alias {alias:?} no longer maps to {label:?}"
                 );
             }
         }
     }
 
     #[test]
-    fn bed_mapping_first_matching_speaker_wins() {
+    fn label_mapping_first_matching_speaker_wins() {
         let layout = SpeakerLayout::from_speakers(vec![
             Speaker::new("FL", -30.0, 0.0),
             Speaker::new("FrontLeft", -31.0, 0.0),
             Speaker::new("FR", 30.0, 0.0),
         ])
         .expect("dup layout");
-        assert_eq!(layout.bed_to_speaker_mapping().get(&0), Some(&0));
+        assert_eq!(
+            layout
+                .label_to_speaker_mapping()
+                .get(&bridge_api::RChannelLabel::L),
+            Some(&0)
+        );
     }
 
     #[test]

--- a/omniphony-renderer/src/cli/decode/sample_write.rs
+++ b/omniphony-renderer/src/cli/decode/sample_write.rs
@@ -398,24 +398,11 @@ impl<'a> SampleWriteCoordinator<'a> {
                         room_ratio_center_blend,
                         surround_placement,
                     ) {
-                        ChannelRenderPlan::Events {
-                            events,
-                            bed_indices,
-                        } => {
+                        ChannelRenderPlan::Events { events, routes } => {
                             // Spatial mode mixes per channel: direct channels
-                            // carry a bed id, virtual channels carry `usize::MAX`
-                            // (VBAP objects). Reconfigure only on change.
-                            let desired: Vec<usize> = bed_indices.unwrap_or_default();
-                            if self.spatial.bed_indices.as_deref().unwrap_or(&[])
-                                != desired.as_slice()
-                            {
-                                renderer.configure_beds(&desired);
-                                self.spatial.bed_indices = if desired.is_empty() {
-                                    None
-                                } else {
-                                    Some(desired)
-                                };
-                            }
+                            // route one-hot by label, virtual channels render
+                            // as VBAP objects. Reconfigure only on change.
+                            self.spatial.fixed_planner.apply_routes(renderer, routes);
                             events
                         }
                         ChannelRenderPlan::HostPassthrough => {

--- a/omniphony-renderer/src/cli/decode/spatial_metadata.rs
+++ b/omniphony-renderer/src/cli/decode/spatial_metadata.rs
@@ -1,8 +1,9 @@
 use super::state::SpatialState;
 use anyhow::Result;
-use bridge_api::{RChannelLabel, RCoordinateFormat, RMetadataFrame};
+use bridge_api::{RCoordinateFormat, RMetadataFrame};
 use orender_engine::events::{Configuration, Event};
 use orender_engine::osc::{ObjectMeta, OscSender};
+use orender_engine::virtual_bed::build_fixed_channel_objects;
 
 pub struct SpatialMetadataCoordinator<'a> {
     spatial: &'a mut SpatialState,
@@ -49,24 +50,27 @@ impl<'a> SpatialMetadataCoordinator<'a> {
                 }
             }
 
-            // Renderer bed set = legacy bed ids of the fixed-channel labels
-            // (the 0-9 scheme leaves with the unified channel plan, phase 2b).
+            // Legacy bed ids of the fixed-channel labels: EXPORT-order only
+            // (file-output bed conformance). Rendering goes through the
+            // shared planner below.
             let new_bed_indices =
                 orender_engine::spatial::derive_bed_indices(&frame.channel_labels);
             if self.spatial.bed_indices.as_ref() != Some(&new_bed_indices) {
+                log::debug!("Derived export bed ids from channel labels: {new_bed_indices:?}");
                 self.spatial.bed_indices = Some(new_bed_indices);
-                log::debug!(
-                    "Derived bed indices from channel labels: {:?}",
-                    self.spatial.bed_indices
-                );
-                if let (Some(renderer), Some(bed_indices)) =
-                    (self.spatial_renderer, &self.spatial.bed_indices)
-                {
-                    renderer.configure_beds(bed_indices);
-                }
             }
 
-            self.handle_metadata_writing(meta, conf, &frame.channel_labels, sample_rate)?;
+            // Plan the fixed prefix (virtualized by default, per-entry direct
+            // opt-in), identically to the embedded engine.
+            if let Some(renderer) = self.spatial_renderer {
+                self.spatial.fixed_planner.plan_object_stream_fixed(
+                    &frame.channel_labels,
+                    renderer,
+                    &mut self.spatial.frame_events,
+                );
+            }
+
+            self.handle_metadata_writing(meta, conf, sample_rate)?;
         }
         Ok(())
     }
@@ -74,6 +78,7 @@ impl<'a> SpatialMetadataCoordinator<'a> {
     pub fn reset_for_segment(&mut self) {
         self.spatial.has_objects = false;
         self.spatial.bed_indices = None;
+        self.spatial.fixed_planner.reset();
         self.spatial.object_channels.clear();
         self.spatial.object_names.clear();
         self.spatial.frame_events.clear();
@@ -86,7 +91,6 @@ impl<'a> SpatialMetadataCoordinator<'a> {
         &mut self,
         meta: &RMetadataFrame,
         conf: Configuration,
-        channel_labels: &[RChannelLabel],
         sample_rate: u32,
     ) -> Result<()> {
         let sample_pos = meta.sample_pos;
@@ -115,17 +119,17 @@ impl<'a> SpatialMetadataCoordinator<'a> {
                     .object_names
                     .insert(upd.id, upd.name.to_string());
             }
-            let active_layout = self
+            let mut objects: Vec<ObjectMeta> = self
                 .spatial_renderer
-                .map(|renderer| renderer.speaker_layout());
-            let objects: Vec<ObjectMeta> = orender_engine::spatial::build_object_metas(
+                .and_then(|renderer| {
+                    build_fixed_channel_objects(renderer, self.spatial.fixed_planner.fixed_labels())
+                })
+                .unwrap_or_default();
+            objects.extend(orender_engine::spatial::build_object_metas(
                 &conf,
                 coordinate_format,
-                active_layout.as_ref(),
                 &self.spatial.object_names,
-                channel_labels,
-                &meta.channel_gains,
-            );
+            ));
             let ramp_duration = meta.ramp_duration;
             let osc_coord_format = match coordinate_format {
                 RCoordinateFormat::Cartesian => 0,

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -110,7 +110,12 @@ impl Default for TelemetryState {
 
 pub struct SpatialState {
     pub has_objects: bool,
+    /// Fixed-channel bed ids in the legacy 0-9 EXPORT order (file-output
+    /// conformance only — rendering goes through `fixed_planner`).
     pub bed_indices: Option<Vec<usize>>,
+    /// Shared fixed-channel planner (routing + plan cache), mirroring the
+    /// embedded engine.
+    pub fixed_planner: orender_engine::virtual_bed::FixedChannelPlanner,
     /// Cached object↔channel declaration from the bridge (sparse emission),
     /// sorted by channel.
     pub object_channels: Vec<(u32, usize)>,
@@ -129,6 +134,7 @@ impl Default for SpatialState {
         Self {
             has_objects: false,
             bed_indices: None,
+            fixed_planner: orender_engine::virtual_bed::FixedChannelPlanner::new(),
             object_channels: Vec::new(),
             object_names: std::collections::HashMap::new(),
             au_index: 0,


### PR DESCRIPTION
## Summary

Phase 2b of [docs/channel-object-contract.md](https://github.com/mgth/Omniphony/blob/main/docs/channel-object-contract.md): object streams and fixed-only streams now share one placement policy, and the renderer stops speaking bed ids entirely. Four steps, one commit each:

1. **Label routing in the renderer** — `ChannelRoute::Direct(label) | Virtual` per input channel, resolved against a per-topology label→speaker map (stored routes survive layout swaps). `configure_beds` briefly became an adapter, then was deleted (step 4).
2. **Unified channel plan** — the fixed prefix of an object stream is planned through the same virtual-bed logic as flat streams: **virtualized by default** (placement layout + crossover apply), per-entry direct opt-in via the layout `spatialize` flag (LFE default). Shared `FixedChannelPlanner` (engine + CLI), cached on (labels, options epoch). OSC display shows the fixed prefix at its planned poses. Sparse-name caching re-landed in its intended form.
3. **Constant-rate gain slew** — every per-channel gain step (metadata jump, mute, plan transition, stream start) slews at 20 ms full-scale (`GAIN_SLEW_SECS`), per-sample interpolation in the VBAP paths. This is the plan-transition ramp mechanism: no dedicated crossfade machinery.
4. **0–9 scheme retired** — `configure_beds`, `bed_to_speaker_mapping`, dead lookups deleted; `legacy_bed_id` survives only as the CLI file-export bed order, documented as such.

Intentional behavior changes (per review decisions): Atmos/object-stream beds are now virtualized by default instead of one-hot (poses coincide with speakers on matching layouts); fixed channels without a matching speaker virtualize instead of going silent; direct routing is no longer capped to the 10-label scheme; all gain steps are de-zippered; streams fade in over 20 ms.

## Tests
- Full workspace green (29 suites), fmt clean; virtual-bed/renderer/speaker-layout tests migrated to the routes API; legacy-alias parity net kept (re-targeted at the label map).
- E2E parity harness against the real bridge (TrueHD Atmos fixture) green after every step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)