### PR TITLE
chore(release): prepare Omniphony 0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ or to **binaural headphones**, in real time. Open source, GPL-3.0.
 [![Website & Docs — omniphony.mgth.fr](https://img.shields.io/badge/Website%20%26%20Docs-omniphony.mgth.fr-56c9ff?style=for-the-badge&logo=astro&logoColor=white)](https://omniphony.mgth.fr)
 
 [![Download Omniphony Studio](https://img.shields.io/badge/Download-Omniphony-2ea44f?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/latest)
-[![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-2)
-[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.1-fel-beta.6)
+[![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.2)
+[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.2-fel-beta.1)
 
 ![Omniphony Studio rendering a spatial mix](Omniphony_capture.png)
 

--- a/omniphony-studio/package-lock.json
+++ b/omniphony-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniphony-studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniphony-studio",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@codemirror/language": "^6",
         "@codemirror/legacy-modes": "^6",

--- a/omniphony-studio/package.json
+++ b/omniphony-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniphony-studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Visualisation 3D d'objets audio spatialisés via OSC",
   "scripts": {
     "dev": "vite",

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "omniphony-studio"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "flate2",
  "image",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omniphony-studio"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [[bin]]

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fr.omniphony.studio",
   "productName": "Omniphony Studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",


### PR DESCRIPTION
## Summary

- bump Omniphony Studio metadata to `0.4.2` across npm, Cargo and Tauri
- update the download badges for mpv-omniphony `0.4.2` and `0.4.2-fel-beta.1`

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace` (all non-ignored tests passed)
- `npm run build`
- `npm run i18n:check` (existing leftover-key report, exit 0)
- `npm run lint:dead` (existing unused-export report, exit 0)
- `npm run prepare-sidecar`
- `cargo check --locked` for the Tauri application with the prepared sidecar

## Publish sequence

After review and green CI, promote `main` to `release`, then tag `v0.4.2` and `liborender-v0.4.2`. Player tags are created only after those engine tags exist.