### PR TITLE
ci(release): ad-hoc sign the macOS bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,9 @@ jobs:
           - platform: ubuntu-22.04
           - platform: windows-latest
           # macOS Apple Silicon: CoreAudio output backend, no extra system deps.
-          # tauri-action emits a .dmg/.app; the build is unsigned (ad-hoc) until
-          # signing secrets are configured.
+          # tauri-action emits a .dmg/.app; ad-hoc signed (see
+          # APPLE_SIGNING_IDENTITY below) until real signing secrets are
+          # configured.
           - platform: macos-14
 
     runs-on: ${{ matrix.platform }}
@@ -148,6 +149,14 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # "-" = ad-hoc codesign of the whole .app during bundling (before the
+          # .app.tar.gz/.dmg are packaged and uploaded — signing after this step
+          # would be too late). No Developer ID: Gatekeeper still blocks the
+          # quarantined download, but the bundle gets a coherent seal so a
+          # quarantine-cleared app launches instead of showing the "damaged"
+          # dialog (#201). Replace with a real identity + notarization once
+          # Apple signing secrets exist. Ignored on Linux/Windows.
+          APPLE_SIGNING_IDENTITY: '-'
         with:
           projectPath: omniphony-studio
           tagName: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

The macOS `.app` produced by `release.yml` ships with **no bundle-level signature at all** — only the automatic per-binary linker signatures (verified on the v0.4.2 asset: no `_CodeSignature/CodeResources`, empty CMS blobs). On recent macOS the quarantined download therefore shows the "damaged" dialog with no *Open Anyway* option ([#201](https://github.com/mgth/Omniphony/issues/201)).

This sets `APPLE_SIGNING_IDENTITY: "-"` on the tauri-action step so the Tauri bundler ad-hoc codesigns the whole bundle **during packaging** — signing after tauri-action would be too late, since it uploads the `.app.tar.gz`/`.dmg` in the same step.

## What this does / doesn't fix

- ✅ The bundle gets a coherent ad-hoc seal: after the user clears quarantine (`xattr -rd com.apple.quarantine`, documented in the v0.4.2 release notes), the app launches instead of being reported as damaged.
- ❌ This is **not** notarization: Gatekeeper still blocks the first launch of the quarantined download. Proper Developer ID signing + notarization (tauri-action `APPLE_CERTIFICATE`/`APPLE_ID` secrets) remains a follow-up.

No effect on the Linux/Windows matrix legs (the env var is ignored there).

## Testing

Not CI-verifiable outside a real `v*` tag build; the next release will confirm (inspect the asset for `_CodeSignature/` and CodeDirectory flags).

Closes nothing — #201 stays open until a fixed bundle ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)