### PR TITLE
Studio: switch to activate orender in the user's mpv config

### DIFF
--- a/omniphony-studio/src-tauri/src/commands/mod.rs
+++ b/omniphony-studio/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod engine;
 pub mod gain;
 pub mod input;
 pub mod layout_io;
+pub mod mpv_config;
 pub mod mpv_overlay;
 pub mod orender;
 pub mod render;

--- a/omniphony-studio/src-tauri/src/commands/mpv_config.rs
+++ b/omniphony-studio/src-tauri/src/commands/mpv_config.rs
@@ -1,0 +1,381 @@
+//! Toggle `ad=orender` in the user's mpv config.
+//!
+//! mpv only selects the orender decoder when asked to (`--ad=orender`), so a
+//! fresh install plays through mpv's own decoders and the engine is never used.
+//! The one-line opt-in lives in `mpv.conf`, which is why Studio can offer it.
+//!
+//! That file belongs to another application and is usually hand-maintained, so
+//! the rules here are deliberately conservative:
+//!
+//! * Everything Studio writes lives between two marker comments. Nothing outside
+//!   the block is ever reformatted, reordered or removed.
+//! * The block is inserted in the **global** section — before the first
+//!   `[profile]` header. Appending at the end of the file would land inside
+//!   whatever profile happens to be last, silently scoping `ad=orender` to it.
+//! * A pre-existing `ad=` written by the user is never touched. It wins, and the
+//!   toggle reports a conflict instead of fighting over the option.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+const BEGIN: &str = "# >>> omniphony (managed) >>>";
+const END: &str = "# <<< omniphony (managed) <<<";
+const OPTION: &str = "ad=orender";
+
+/// What the config currently says about the orender decoder.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub enum MpvOrenderState {
+    /// Managed block present, option active.
+    Enabled,
+    /// Managed block present, option commented out.
+    Disabled,
+    /// No managed block; nothing sets `ad=`.
+    Absent,
+    /// An `ad=` outside the managed block. Studio refuses to touch it.
+    Conflict,
+}
+
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MpvOrenderStatus {
+    /// Absolute path to the config, whether or not it exists yet.
+    pub path: String,
+    pub exists: bool,
+    pub state: MpvOrenderState,
+    /// 1-based line of the conflicting `ad=`, when `state` is `conflict`.
+    pub conflict_line: Option<usize>,
+    /// Verbatim conflicting line, so the UI can show what it found.
+    pub conflict_text: Option<String>,
+}
+
+/// `$MPV_HOME`, else `$XDG_CONFIG_HOME/mpv`, else `~/.config/mpv` — the lookup
+/// mpv itself does on Unix. Windows uses `%APPDATA%\mpv`.
+fn mpv_config_dir() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("MPV_HOME") {
+        return Some(PathBuf::from(home));
+    }
+    #[cfg(windows)]
+    {
+        std::env::var_os("APPDATA").map(|d| PathBuf::from(d).join("mpv"))
+    }
+    #[cfg(not(windows))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            return Some(PathBuf::from(xdg).join("mpv"));
+        }
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/mpv"))
+    }
+}
+
+fn mpv_config_path() -> Result<PathBuf, String> {
+    Ok(mpv_config_dir()
+        .ok_or("cannot determine the mpv config directory")?
+        .join("mpv.conf"))
+}
+
+/// Is this line an active (uncommented) `ad=` setting?
+fn is_active_ad_line(line: &str) -> bool {
+    let t = line.trim_start();
+    if t.starts_with('#') {
+        return false;
+    }
+    let Some(rest) = t.strip_prefix("ad") else {
+        return false;
+    };
+    rest.trim_start().starts_with('=')
+}
+
+/// Half-open range of the managed block, if present.
+fn managed_block(lines: &[String]) -> Option<(usize, usize)> {
+    let begin = lines.iter().position(|l| l.trim() == BEGIN)?;
+    let end = lines
+        .iter()
+        .skip(begin + 1)
+        .position(|l| l.trim() == END)
+        .map(|i| begin + 1 + i)?;
+    Some((begin, end))
+}
+
+fn classify(lines: &[String]) -> (MpvOrenderState, Option<usize>, Option<String>) {
+    let block = managed_block(lines);
+    // Any active `ad=` outside our block is the user's; it takes precedence.
+    for (i, line) in lines.iter().enumerate() {
+        if let Some((b, e)) = block {
+            if i >= b && i <= e {
+                continue;
+            }
+        }
+        if is_active_ad_line(line) {
+            return (MpvOrenderState::Conflict, Some(i + 1), Some(line.clone()));
+        }
+    }
+    let Some((b, e)) = block else {
+        return (MpvOrenderState::Absent, None, None);
+    };
+    let enabled = lines[b + 1..e].iter().any(|l| is_active_ad_line(l));
+    let state = if enabled {
+        MpvOrenderState::Enabled
+    } else {
+        MpvOrenderState::Disabled
+    };
+    (state, None, None)
+}
+
+fn read_lines(path: &Path) -> Result<Option<Vec<String>>, String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok(Some(text.lines().map(|l| l.to_string()).collect())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("cannot read {}: {e}", path.display())),
+    }
+}
+
+fn status_from(path: &Path, lines: Option<&Vec<String>>) -> MpvOrenderStatus {
+    let (state, conflict_line, conflict_text) = match lines {
+        Some(l) => classify(l),
+        None => (MpvOrenderState::Absent, None, None),
+    };
+    MpvOrenderStatus {
+        path: path.display().to_string(),
+        exists: lines.is_some(),
+        state,
+        conflict_line,
+        conflict_text,
+    }
+}
+
+/// Index to insert the managed block at: just before the first profile header,
+/// so the option lands in the global section. Trailing blank lines before that
+/// header are kept after the block rather than swallowed.
+fn global_section_end(lines: &[String]) -> usize {
+    let first_profile = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with('['))
+        .unwrap_or(lines.len());
+    let mut at = first_profile;
+    while at > 0 && lines[at - 1].trim().is_empty() {
+        at -= 1;
+    }
+    at
+}
+
+/// Add, enable or comment out the managed option in `lines`, in place.
+///
+/// Pure so the file surgery is testable on its own: this is the part that must
+/// never disturb a hand-maintained config.
+fn apply(lines: &mut Vec<String>, enabled: bool) {
+    let option_line = if enabled {
+        OPTION.to_string()
+    } else {
+        format!("#{OPTION}")
+    };
+    match managed_block(lines) {
+        Some((b, e)) => {
+            // Rewrite only the block's interior; the markers stay put.
+            lines.splice(b + 1..e, std::iter::once(option_line));
+        }
+        None => {
+            let at = global_section_end(lines);
+            let mut block = Vec::new();
+            // Keep one blank line of separation when inserting after content.
+            if at > 0 && !lines[at - 1].trim().is_empty() {
+                block.push(String::new());
+            }
+            block.push(BEGIN.to_string());
+            block.push(option_line);
+            block.push(END.to_string());
+            lines.splice(at..at, block);
+        }
+    }
+}
+
+/// Current state of `ad=orender` in the user's mpv config.
+#[tauri::command]
+pub fn mpv_orender_status() -> Result<MpvOrenderStatus, String> {
+    let path = mpv_config_path()?;
+    let lines = read_lines(&path)?;
+    Ok(status_from(&path, lines.as_ref()))
+}
+
+/// Add, enable or comment out `ad=orender`, and report the resulting state.
+///
+/// Creates `mpv.conf` when missing. Refuses when the user already sets `ad=`
+/// themselves: that line is theirs, and silently overriding it would change
+/// playback behind their back.
+#[tauri::command]
+pub fn mpv_orender_set(enabled: bool) -> Result<MpvOrenderStatus, String> {
+    let path = mpv_config_path()?;
+    let existing = read_lines(&path)?;
+    let mut lines = existing.clone().unwrap_or_default();
+
+    let (state, line_no, text) = classify(&lines);
+    if state == MpvOrenderState::Conflict {
+        return Err(format!(
+            "{} already sets the audio decoder at line {}: `{}`. \
+             Studio will not overwrite a line you wrote — remove or comment it \
+             out, then toggle this again.",
+            path.display(),
+            line_no.unwrap_or(0),
+            text.unwrap_or_default().trim(),
+        ));
+    }
+
+    apply(&mut lines, enabled);
+
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    }
+    let mut out = lines.join("\n");
+    out.push('\n');
+    std::fs::write(&path, out).map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+
+    let lines = read_lines(&path)?;
+    Ok(status_from(&path, lines.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Vec<String> {
+        s.lines().map(|l| l.to_string()).collect()
+    }
+
+    #[test]
+    fn detects_an_absent_option() {
+        assert_eq!(classify(&v("vo=gpu\nvolume=70")).0, MpvOrenderState::Absent);
+    }
+
+    #[test]
+    fn detects_enabled_and_disabled_inside_the_block() {
+        let on = format!("vo=gpu\n{BEGIN}\n{OPTION}\n{END}");
+        assert_eq!(classify(&v(&on)).0, MpvOrenderState::Enabled);
+        let off = format!("vo=gpu\n{BEGIN}\n#{OPTION}\n{END}");
+        assert_eq!(classify(&v(&off)).0, MpvOrenderState::Disabled);
+    }
+
+    /// A hand-written `ad=` is the user's call; the toggle must stand down.
+    #[test]
+    fn a_foreign_ad_line_is_a_conflict() {
+        let (state, line, text) = classify(&v("vo=gpu\nad=lavc\nvolume=70"));
+        assert_eq!(state, MpvOrenderState::Conflict);
+        assert_eq!(line, Some(2));
+        assert_eq!(text.as_deref(), Some("ad=lavc"));
+    }
+
+    #[test]
+    fn commented_and_lookalike_lines_are_not_conflicts() {
+        for s in [
+            "#ad=lavc",
+            "  # ad=lavc",
+            "adapter=1",
+            "vad=x",
+            "audio-display=no",
+        ] {
+            let src = format!("vo=gpu\n{s}");
+            assert_eq!(
+                classify(&v(&src)).0,
+                MpvOrenderState::Absent,
+                "misread as a conflict: {s}"
+            );
+        }
+    }
+
+    /// The whole point: a config ending inside a profile must not receive the
+    /// option at EOF, or it would only apply while that profile is active.
+    #[test]
+    fn the_block_goes_in_the_global_section_not_the_last_profile() {
+        let conf = v("vo=gpu\nvolume=70\n\n[hdr]\ntarget-peak=auto\ncontrast=0");
+        let at = global_section_end(&conf);
+        assert_eq!(at, 2, "must insert before the blank line preceding [hdr]");
+        assert!(conf[at..].iter().any(|l| l.starts_with('[')));
+    }
+
+    #[test]
+    fn a_config_with_no_profile_appends_at_the_end() {
+        let conf = v("vo=gpu\nvolume=70");
+        assert_eq!(global_section_end(&conf), 2);
+    }
+
+    #[test]
+    fn an_empty_config_inserts_at_the_top() {
+        assert_eq!(global_section_end(&[]), 0);
+    }
+
+    // A config shaped like a real one: global options, then profiles, ending
+    // inside the last profile. This is the layout that makes a naive append
+    // wrong.
+    fn realistic() -> Vec<String> {
+        v("vo=gpu\nhwdec=auto\nvolume=70\n\n[upscale-ravu-hq]\nglsl-shaders=ravu.hook\n\n[hdr-bright]\ntarget-peak=auto\ncontrast=0")
+    }
+
+    #[test]
+    fn enabling_puts_the_option_before_the_first_profile() {
+        let mut lines = realistic();
+        apply(&mut lines, true);
+        let opt = lines
+            .iter()
+            .position(|l| l == OPTION)
+            .expect("option written");
+        let first_profile = lines
+            .iter()
+            .position(|l| l.trim_start().starts_with('['))
+            .expect("profiles kept");
+        assert!(
+            opt < first_profile,
+            "option landed inside a profile: it would only apply while that profile is active"
+        );
+        assert_eq!(classify(&lines).0, MpvOrenderState::Enabled);
+    }
+
+    /// The user's own content must survive verbatim and in order. Blank-line
+    /// spacing around the inserted block is cosmetic and deliberately not
+    /// asserted; altering, reordering or dropping a real line is the failure
+    /// this guards against.
+    #[test]
+    fn no_user_line_is_altered_reordered_or_lost() {
+        let before = realistic();
+        let mut after = before.clone();
+        apply(&mut after, true);
+        let (b, e) = managed_block(&after).unwrap();
+
+        let significant = |src: &[String]| -> Vec<String> {
+            src.iter()
+                .filter(|l| !l.trim().is_empty())
+                .cloned()
+                .collect()
+        };
+        let mut outside: Vec<String> = after[..b].to_vec();
+        outside.extend_from_slice(&after[e + 1..]);
+
+        assert_eq!(
+            significant(&outside),
+            significant(&before),
+            "the surrounding config was modified"
+        );
+    }
+
+    #[test]
+    fn toggling_off_then_on_is_stable() {
+        let mut lines = realistic();
+        apply(&mut lines, true);
+        let enabled_once = lines.clone();
+        apply(&mut lines, false);
+        assert_eq!(classify(&lines).0, MpvOrenderState::Disabled);
+        apply(&mut lines, true);
+        assert_eq!(lines, enabled_once, "round-trip must not drift the file");
+        // And it must not grow a second block each time.
+        assert_eq!(lines.iter().filter(|l| l.trim() == BEGIN).count(), 1);
+    }
+
+    #[test]
+    fn an_empty_config_gets_a_block_with_no_leading_blank() {
+        let mut lines: Vec<String> = Vec::new();
+        apply(&mut lines, true);
+        assert_eq!(
+            lines,
+            vec![BEGIN.to_string(), OPTION.to_string(), END.to_string()]
+        );
+    }
+}

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -29,6 +29,7 @@ use commands::engine::*;
 use commands::gain::*;
 use commands::input::*;
 use commands::layout_io::*;
+use commands::mpv_config::*;
 use commands::mpv_overlay::*;
 use commands::orender::*;
 use commands::render::*;
@@ -366,6 +367,8 @@ fn main() {
             auto_tune_snapshot_save,
             auto_tune_snapshot_take,
             auto_tune_snapshot_peek,
+            mpv_orender_status,
+            mpv_orender_set,
             mpv_overlay_set_trail_prefs,
             mpv_overlay_set_active,
             mpv_overlay_set_labels,

--- a/omniphony-studio/src/controls/osc.js
+++ b/omniphony-studio/src/controls/osc.js
@@ -38,6 +38,8 @@ function getOscServiceBtnEl() { return inOscPanel('oscServiceBtn'); }
 function getOscRestartServiceBtnEl() { return inOscPanel('oscRestartServiceBtn'); }
 function getOscRestartPipewireBtnEl() { return inOscPanel('oscRestartPipewireBtn'); }
 function getOscLaunchRendererBtnEl() { return inOscPanel('oscLaunchRendererBtn'); }
+function getMpvOrenderToggleEl() { return inOscPanel('mpvOrenderToggle'); }
+function getMpvOrenderNoteEl() { return inOscPanel('mpvOrenderNote'); }
 
 // ---------------------------------------------------------------------------
 // OSC status rendering
@@ -175,6 +177,9 @@ export function openOscConfigPanel() {
   if (!oscConfigFormEl) return;
   oscConfigFormEl.classList.add('open');
   if (oscConfigToggleBtnEl) oscConfigToggleBtnEl.textContent = '\u2715';
+  // mpv.conf can change outside Studio (hand edit, another machine), so the
+  // switch is re-read every time the panel is opened rather than cached.
+  refreshMpvOrenderToggle();
 }
 
 export function closeOscConfigPanel() {
@@ -647,4 +652,71 @@ export function syncMeterRateFromRenderer(hz) {
   if (!Number.isFinite(rounded) || !METER_RATE_OPTIONS_HZ.includes(rounded)) return;
   applyMeterRateToSelect(rounded);
   try { localStorage.setItem(METER_RATE_STORAGE_KEY, String(rounded)); } catch (_) { /* ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// "Activate in mpv config" — the one-line opt-in that makes mpv actually use
+// the engine (`ad=orender`). Unlike the fields above this is not part of the
+// OSC form: it writes the user's mpv.conf straight away, so it has no Apply
+// step and is deliberately excluded from the dirty-state listeners.
+// ---------------------------------------------------------------------------
+
+function renderMpvOrenderToggle(status) {
+  const toggleEl = getMpvOrenderToggleEl();
+  const noteEl = getMpvOrenderNoteEl();
+  if (!toggleEl) return;
+
+  const conflict = status?.state === 'conflict';
+  toggleEl.checked = status?.state === 'enabled';
+  // A hand-written `ad=` wins: Studio never edits a line it did not write, so
+  // the switch is inert until the user resolves it themselves.
+  toggleEl.disabled = conflict;
+
+  if (!noteEl) return;
+  noteEl.classList.toggle('is-conflict', conflict);
+  if (conflict) {
+    noteEl.textContent = tf('osc.mpvOrenderConflict', {
+      line: status.conflictLine ?? '?',
+      text: (status.conflictText ?? '').trim(),
+    });
+  } else {
+    noteEl.textContent = tf('osc.mpvOrenderPath', { path: status?.path ?? '' });
+  }
+  noteEl.style.display = status ? 'block' : 'none';
+}
+
+export function refreshMpvOrenderToggle() {
+  return invoke('mpv_orender_status')
+    .then(renderMpvOrenderToggle)
+    .catch((e) => {
+      console.error('[mpv config]', e);
+      const noteEl = getMpvOrenderNoteEl();
+      if (noteEl) {
+        noteEl.classList.add('is-conflict');
+        noteEl.textContent = normalizeLogError(e);
+        noteEl.style.display = 'block';
+      }
+    });
+}
+
+const initialMpvOrenderToggleEl = getMpvOrenderToggleEl();
+if (initialMpvOrenderToggleEl) {
+  initialMpvOrenderToggleEl.addEventListener('change', () => {
+    const wanted = initialMpvOrenderToggleEl.checked;
+    initialMpvOrenderToggleEl.disabled = true;
+    invoke('mpv_orender_set', { enabled: wanted })
+      .then((status) => {
+        renderMpvOrenderToggle(status);
+        pushLog('info', tf(wanted ? 'log.mpvOrenderEnabled' : 'log.mpvOrenderDisabled', {
+          path: status?.path ?? '',
+        }));
+      })
+      .catch((e) => {
+        // Put the switch back where it was: the file was not changed. A refused
+        // conflict lands here too, which is how the warning gets shown.
+        pushLog('error', tf('log.mpvOrenderFailed', { error: normalizeLogError(e) }));
+        return refreshMpvOrenderToggle();
+      });
+  });
+  refreshMpvOrenderToggle();
 }

--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "UDP-Port, auf dem orender (der Renderer) Steuerung empfängt und Zustand sendet.",
   "help.osc.listenPort": "Lokaler UDP-Port, auf dem Studio auf OSC-Zustand lauscht. 0 lässt das System einen wählen.",
   "help.osc.autoStartRenderer": "Wenn auf einem lokalen Ziel (127.x) nichts antwortet, startet Studio automatisch einen Standby-Renderer. Er gibt den OSC-Port während der Wiedergabe an einen in mpv eingebetteten Renderer ab und kehrt zurück, wenn mpv beendet wird.",
+  "help.osc.mpvOrender": "mpv nutzt die Engine nur auf Anforderung (ad=orender). Dies schreibt diese Zeile in Ihre mpv.conf, in einen markierten Block vor allen Profilabschnitten, damit sie global gilt. Beim Deaktivieren wird die Zeile auskommentiert; sonst wird nichts verändert.",
   "help.osc.keepRendererAlive": "Den von Studio gestarteten Renderer nach dem Schließen von Studio weiterlaufen lassen. Aus (Standard): er beendet sich mit Studio.",
   "help.osc.metering": "Streamt Pegel pro Objekt und pro Lautsprecher über OSC, um die Anzeigen in der UI zu speisen. Die Rate (Hz) bestimmt, wie oft Pegel veröffentlicht werden — höher ist flüssiger, aber mehr Datenverkehr.",
   "help.display.language": "UI-Sprache. „Auto“ folgt deiner Systemsprache; andernfalls wird die gewählte Sprache für allen Studio-Text verwendet.",
@@ -126,6 +127,9 @@
   "osc.listenPort": "Listen-Port",
   "osc.autoStartRenderer": "Lokalen Renderer automatisch starten",
   "osc.keepRendererAlive": "Renderer beim Beenden weiterlaufen lassen",
+  "osc.mpvOrender": "In mpv-Konfiguration aktivieren",
+  "osc.mpvOrenderPath": "Verwaltet in {path}",
+  "osc.mpvOrenderConflict": "Zeile {line} legt bereits einen Decoder fest: {text}. Entfernen Sie sie, um diesen Schalter zu nutzen.",
   "osc.metering": "Pegelung",
   "osc.connect": "Verbinden",
   "osc.service.install": "Dienst installieren",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "Wie ein 3-D-Objektgrößen-Triplett (B, T, H) auf einen skalaren Spread reduziert wird. Objektgrößen-Spread wird live angewendet und nur in der Echtzeit-Auswertung berücksichtigt.",
   "backendParamOption.size_to_spread_mode.max": "Max. Achse",
   "backendParamOption.size_to_spread_mode.mean": "Mittel der Achsen",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Senkrechte Projektion"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Senkrechte Projektion",
+  "log.mpvOrenderEnabled": "orender in {path} aktiviert",
+  "log.mpvOrenderDisabled": "orender in {path} auskommentiert",
+  "log.mpvOrenderFailed": "Änderung der mpv-Konfiguration fehlgeschlagen: {error}"
 }

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "UDP port where orender (the renderer) receives control and sends state.",
   "help.osc.listenPort": "Local UDP port Studio listens on for OSC state. 0 lets the system choose one.",
   "help.osc.autoStartRenderer": "When nothing answers on a local (127.x) target, Studio launches a standby renderer automatically. It yields the OSC port to an mpv-embedded renderer during playback and comes back when mpv exits.",
+  "help.osc.mpvOrender": "mpv only uses the engine when asked to (ad=orender). This writes that line into your mpv.conf, in a marked block placed before any profile section so it applies globally. Turning it off comments the line out; nothing else in the file is touched.",
   "help.osc.keepRendererAlive": "Leave the Studio-launched renderer running after closing Studio. Off (default): it quits with Studio.",
   "help.osc.metering": "Stream per-object and per-speaker level meters over OSC to drive the meters in the UI. The rate (Hz) sets how often levels are published — higher is smoother but more traffic.",
   "help.display.language": "UI language. “Auto” follows your system locale; otherwise the chosen language is used for all Studio text.",
@@ -126,6 +127,9 @@
   "osc.listenPort": "Listen Port",
   "osc.autoStartRenderer": "Auto-start local renderer",
   "osc.keepRendererAlive": "Keep renderer alive on quit",
+  "osc.mpvOrender": "Activate in mpv config",
+  "osc.mpvOrenderPath": "Managed in {path}",
+  "osc.mpvOrenderConflict": "Line {line} already sets a decoder: {text}. Remove it to use this switch.",
   "osc.metering": "Metering",
   "osc.connect": "Connect",
   "osc.service.install": "Install service",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "How a 3-D object-size triplet (w, d, h) is reduced to a scalar spread. Object-size spread is applied live and is honoured only in realtime evaluation.",
   "backendParamOption.size_to_spread_mode.max": "Max axis",
   "backendParamOption.size_to_spread_mode.mean": "Mean of axes",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Perpendicular projection"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Perpendicular projection",
+  "log.mpvOrenderEnabled": "orender enabled in {path}",
+  "log.mpvOrenderDisabled": "orender commented out in {path}",
+  "log.mpvOrenderFailed": "mpv config change failed: {error}"
 }

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "Puerto UDP donde orender (el renderer) recibe control y envía estado.",
   "help.osc.listenPort": "Puerto UDP local en el que Studio escucha el estado OSC. 0 deja que el sistema elija uno.",
   "help.osc.autoStartRenderer": "Cuando nada responde en un destino local (127.x), Studio lanza automáticamente un renderer en espera. Cede el puerto OSC a un renderer incorporado en mpv durante la reproducción y vuelve cuando mpv termina.",
+  "help.osc.mpvOrender": "mpv solo usa el motor si se le pide (ad=orender). Esto escribe esa línea en su mpv.conf, dentro de un bloque marcado colocado antes de cualquier sección de perfil para que se aplique globalmente. Al desactivarlo se comenta la línea; no se toca nada más.",
   "help.osc.keepRendererAlive": "Dejar el renderer lanzado por Studio en marcha tras cerrar Studio. Desactivado (por defecto): se cierra con Studio.",
   "help.osc.metering": "Transmite los niveles por objeto y por altavoz vía OSC para alimentar los medidores de la interfaz. La tasa (Hz) fija con qué frecuencia se publican los niveles — más alta es más fluida pero genera más tráfico.",
   "help.display.language": "Idioma de la interfaz. «Auto» sigue el idioma de tu sistema; en caso contrario, el idioma elegido se usa para todo el texto de Studio.",
@@ -126,6 +127,9 @@
   "osc.listenPort": "Puerto de escucha",
   "osc.autoStartRenderer": "Iniciar renderer local automáticamente",
   "osc.keepRendererAlive": "Mantener el renderer activo al salir",
+  "osc.mpvOrender": "Activar en la configuración de mpv",
+  "osc.mpvOrenderPath": "Gestionado en {path}",
+  "osc.mpvOrenderConflict": "La línea {line} ya define un decodificador: {text}. Elimínela para usar este interruptor.",
   "osc.metering": "Medición",
   "osc.connect": "Conectar",
   "osc.service.install": "Instalar servicio",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "Cómo se reduce un triplete de tamaño de objeto 3D (an, pr, al) a un spread escalar. El spread por tamaño de objeto se aplica en vivo y solo se respeta en la evaluación en tiempo real.",
   "backendParamOption.size_to_spread_mode.max": "Eje máx.",
   "backendParamOption.size_to_spread_mode.mean": "Media de ejes",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Proyección perpendicular"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Proyección perpendicular",
+  "log.mpvOrenderEnabled": "orender activado en {path}",
+  "log.mpvOrenderDisabled": "orender comentado en {path}",
+  "log.mpvOrenderFailed": "Error al modificar la configuración de mpv: {error}"
 }

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "Port UDP sur lequel orender (le renderer) reçoit les contrôles et envoie l'état.",
   "help.osc.listenPort": "Port UDP local sur lequel Studio écoute l'état OSC. 0 laisse le système en choisir un.",
   "help.osc.autoStartRenderer": "Quand rien ne répond sur une cible locale (127.x), Studio lance automatiquement un renderer de veille. Il cède le port OSC à un renderer embarqué dans mpv pendant la lecture et revient quand mpv se ferme.",
+  "help.osc.mpvOrender": "mpv n'utilise le moteur que si on le lui demande (ad=orender). Cette option écrit cette ligne dans votre mpv.conf, dans un bloc balisé placé avant toute section de profil pour qu'elle s'applique globalement. La désactiver commente la ligne ; rien d'autre n'est modifié.",
   "help.osc.keepRendererAlive": "Laisser tourner le renderer lancé par Studio après la fermeture de Studio. Désactivé (défaut) : il s'arrête avec Studio.",
   "help.osc.metering": "Diffuse les niveaux par objet et par enceinte via OSC pour alimenter les vumètres de l'interface. Le débit (Hz) règle la fréquence de publication des niveaux — plus haut est plus fluide mais génère plus de trafic.",
   "help.display.language": "Langue de l'interface. « Auto » suit la langue de ton système ; sinon la langue choisie s'applique à tout le texte de Studio.",
@@ -126,6 +127,9 @@
   "osc.listenPort": "Port d'écoute",
   "osc.autoStartRenderer": "Démarrage auto du renderer local",
   "osc.keepRendererAlive": "Garder le renderer actif en quittant",
+  "osc.mpvOrender": "Activer dans la config mpv",
+  "osc.mpvOrenderPath": "Géré dans {path}",
+  "osc.mpvOrenderConflict": "La ligne {line} définit déjà un décodeur : {text}. Supprimez-la pour utiliser ce commutateur.",
   "osc.metering": "Mesure",
   "osc.connect": "Connecter",
   "osc.service.install": "Installer le service",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "Comment un triplet de taille d'objet 3D (l, p, h) est réduit à un spread scalaire. Le spread basé sur la taille d'objet est appliqué en direct et n'est honoré qu'en évaluation temps réel.",
   "backendParamOption.size_to_spread_mode.max": "Axe max",
   "backendParamOption.size_to_spread_mode.mean": "Moyenne des axes",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Projection perpendiculaire"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Projection perpendiculaire",
+  "log.mpvOrenderEnabled": "orender activé dans {path}",
+  "log.mpvOrenderDisabled": "orender commenté dans {path}",
+  "log.mpvOrenderFailed": "Échec de la modification de la config mpv : {error}"
 }

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "Porta UDP su cui orender (il renderer) riceve il controllo e invia lo stato.",
   "help.osc.listenPort": "Porta UDP locale su cui Studio ascolta lo stato OSC. 0 lascia che il sistema ne scelga una.",
   "help.osc.autoStartRenderer": "Quando nulla risponde su una destinazione locale (127.x), Studio avvia automaticamente un renderer di standby. Cede la porta OSC a un renderer incorporato in mpv durante la riproduzione e ritorna quando mpv esce.",
+  "help.osc.mpvOrender": "mpv usa il motore solo se richiesto (ad=orender). Questa opzione scrive quella riga nel tuo mpv.conf, in un blocco delimitato posto prima di ogni sezione di profilo perché valga globalmente. Disattivandola la riga viene commentata; nient'altro viene modificato.",
   "help.osc.keepRendererAlive": "Lascia in esecuzione il renderer avviato da Studio dopo la chiusura di Studio. Disattivato (predefinito): si chiude con Studio.",
   "help.osc.metering": "Trasmette i livelli per oggetto e per diffusore via OSC per alimentare gli indicatori nell'interfaccia. La frequenza (Hz) imposta ogni quanto i livelli vengono pubblicati — più alta è più fluida ma genera più traffico.",
   "help.display.language": "Lingua dell'interfaccia. «Auto» segue la lingua del sistema; altrimenti la lingua scelta viene usata per tutto il testo di Studio.",
@@ -126,6 +127,9 @@
   "osc.listenPort": "Porta di ascolto",
   "osc.autoStartRenderer": "Avvia automaticamente il renderer locale",
   "osc.keepRendererAlive": "Mantieni il renderer attivo all'uscita",
+  "osc.mpvOrender": "Attiva nella configurazione di mpv",
+  "osc.mpvOrenderPath": "Gestito in {path}",
+  "osc.mpvOrenderConflict": "La riga {line} imposta già un decodificatore: {text}. Rimuovila per usare questo interruttore.",
   "osc.metering": "Metering",
   "osc.connect": "Connetti",
   "osc.service.install": "Installa servizio",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "Come un triplet di dimensione oggetto 3D (l, p, a) viene ridotto a uno spread scalare. Lo spread per dimensione oggetto è applicato in tempo reale ed è rispettato solo nella valutazione realtime.",
   "backendParamOption.size_to_spread_mode.max": "Asse max",
   "backendParamOption.size_to_spread_mode.mean": "Media degli assi",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Proiezione perpendicolare"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Proiezione perpendicolare",
+  "log.mpvOrenderEnabled": "orender attivato in {path}",
+  "log.mpvOrenderDisabled": "orender commentato in {path}",
+  "log.mpvOrenderFailed": "Modifica della configurazione di mpv non riuscita: {error}"
 }

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "orender（レンダラー）が制御を受信し状態を送信する UDP ポート。",
   "help.osc.listenPort": "Studio が OSC 状態を待ち受けるローカル UDP ポート。0 でシステムが自動選択します。",
   "help.osc.autoStartRenderer": "ローカル（127.x）の宛先で何も応答しない場合、Studio はスタンバイレンダラーを自動起動します。再生中は mpv 内蔵レンダラーに OSC ポートを譲り、mpv 終了時に復帰します。",
+  "help.osc.mpvOrender": "mpv は指示があった場合のみエンジンを使用します（ad=orender）。この設定はその行を mpv.conf に書き込みます。全体に適用されるよう、プロファイルセクションより前の専用ブロックに配置されます。オフにすると行がコメントアウトされ、他の内容は変更されません。",
   "help.osc.keepRendererAlive": "Studio を閉じた後も、Studio が起動したレンダラーを動かし続けます。オフ（既定）: Studio と一緒に終了します。",
   "help.osc.metering": "オブジェクトごと・スピーカーごとのレベルメーターを OSC で配信し、UI のメーターを駆動します。レート（Hz）はレベルを配信する頻度を決めます — 高いほど滑らかですがトラフィックが増えます。",
   "help.display.language": "UI 言語。「自動」はシステムのロケールに従います。それ以外は選択した言語が Studio のすべてのテキストに使われます。",
@@ -126,6 +127,9 @@
   "osc.listenPort": "受信ポート",
   "osc.autoStartRenderer": "ローカルレンダラーを自動起動",
   "osc.keepRendererAlive": "終了後もレンダラーを起動したままにする",
+  "osc.mpvOrender": "mpv 設定で有効化",
+  "osc.mpvOrenderPath": "{path} で管理",
+  "osc.mpvOrenderConflict": "{line} 行目で既にデコーダーが指定されています: {text}。このスイッチを使うには削除してください。",
   "osc.metering": "メータリング",
   "osc.connect": "接続",
   "osc.service.install": "サービスをインストール",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "3D のオブジェクトサイズ三つ組（幅・奥行・高さ）をどのようにスカラーのスプレッドに縮約するか。オブジェクトサイズスプレッドはライブで適用され、リアルタイム評価でのみ反映されます。",
   "backendParamOption.size_to_spread_mode.max": "最大軸",
   "backendParamOption.size_to_spread_mode.mean": "軸の平均",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "垂直投影"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "垂直投影",
+  "log.mpvOrenderEnabled": "{path} で orender を有効化しました",
+  "log.mpvOrenderDisabled": "{path} で orender をコメントアウトしました",
+  "log.mpvOrenderFailed": "mpv 設定の変更に失敗しました: {error}"
 }

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "Porta UDP onde o orender (o renderer) recebe controle e envia estado.",
   "help.osc.listenPort": "Porta UDP local em que o Studio escuta o estado OSC. 0 deixa o sistema escolher uma.",
   "help.osc.autoStartRenderer": "Quando nada responde em um destino local (127.x), o Studio inicia automaticamente um renderer de espera. Ele cede a porta OSC a um renderer embutido no mpv durante a reprodução e retorna quando o mpv encerra.",
+  "help.osc.mpvOrender": "O mpv só usa o motor quando solicitado (ad=orender). Isso escreve essa linha no seu mpv.conf, em um bloco demarcado colocado antes de qualquer seção de perfil para que valha globalmente. Ao desativar, a linha é comentada; nada mais é alterado.",
   "help.osc.keepRendererAlive": "Deixar o renderer iniciado pelo Studio em execução após fechar o Studio. Desativado (padrão): ele encerra junto com o Studio.",
   "help.osc.metering": "Transmite os níveis por objeto e por caixa via OSC para alimentar os medidores na interface. A taxa (Hz) define com que frequência os níveis são publicados — mais alta é mais suave, mas gera mais tráfego.",
   "help.display.language": "Idioma da interface. «Auto» segue o idioma do seu sistema; caso contrário, o idioma escolhido é usado para todo o texto do Studio.",
@@ -126,6 +127,9 @@
   "osc.listenPort": "Porta de escuta",
   "osc.autoStartRenderer": "Iniciar renderer local automaticamente",
   "osc.keepRendererAlive": "Manter o renderer ativo ao sair",
+  "osc.mpvOrender": "Ativar na configuração do mpv",
+  "osc.mpvOrenderPath": "Gerenciado em {path}",
+  "osc.mpvOrenderConflict": "A linha {line} já define um decodificador: {text}. Remova-a para usar esta chave.",
   "osc.metering": "Medição",
   "osc.connect": "Conectar",
   "osc.service.install": "Instalar serviço",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "Como um triplet de tamanho de objeto 3D (l, p, a) é reduzido a um spread escalar. O spread por tamanho de objeto é aplicado ao vivo e só é respeitado na avaliação em tempo real.",
   "backendParamOption.size_to_spread_mode.max": "Eixo máx.",
   "backendParamOption.size_to_spread_mode.mean": "Média dos eixos",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Projeção perpendicular"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "Projeção perpendicular",
+  "log.mpvOrenderEnabled": "orender ativado em {path}",
+  "log.mpvOrenderDisabled": "orender comentado em {path}",
+  "log.mpvOrenderFailed": "Falha ao alterar a configuração do mpv: {error}"
 }

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -68,6 +68,7 @@
   "help.osc.omniphonyPort": "orender（渲染器）接收控制并发送状态的 UDP 端口。",
   "help.osc.listenPort": "Studio 监听 OSC 状态的本地 UDP 端口。0 让系统自动选择一个。",
   "help.osc.autoStartRenderer": "当本地（127.x）目标无响应时，Studio 会自动启动一个备用渲染器。播放期间它会把 OSC 端口让给 mpv 内置渲染器，并在 mpv 退出时返回。",
+  "help.osc.mpvOrender": "mpv 仅在被要求时使用引擎（ad=orender）。此选项会将该行写入你的 mpv.conf，放在所有配置档节之前的标记块中，以便全局生效。关闭时会注释掉该行，文件其余内容不会被改动。",
   "help.osc.keepRendererAlive": "关闭 Studio 后让 Studio 启动的渲染器继续运行。关闭（默认）：它随 Studio 一起退出。",
   "help.osc.metering": "通过 OSC 流式传输每对象与每扬声器的电平表，以驱动界面中的电平表。速率（Hz）设定电平发布的频率 — 越高越平滑，但流量越大。",
   "help.display.language": "界面语言。「自动」跟随你的系统区域设置；否则所选语言用于所有 Studio 文本。",
@@ -126,6 +127,9 @@
   "osc.listenPort": "监听端口",
   "osc.autoStartRenderer": "自动启动本地渲染器",
   "osc.keepRendererAlive": "退出后保持渲染器运行",
+  "osc.mpvOrender": "在 mpv 配置中启用",
+  "osc.mpvOrenderPath": "在 {path} 中管理",
+  "osc.mpvOrenderConflict": "第 {line} 行已设置解码器：{text}。请先删除它再使用此开关。",
   "osc.metering": "计量",
   "osc.connect": "连接",
   "osc.service.install": "安装服务",
@@ -784,5 +788,8 @@
   "backendParamHelp.size_to_spread_mode": "如何将 3D 对象尺寸三元组（宽、深、高）归约为标量扩散。基于对象尺寸的扩散实时应用，且仅在实时评估中生效。",
   "backendParamOption.size_to_spread_mode.max": "最大轴",
   "backendParamOption.size_to_spread_mode.mean": "轴的平均",
-  "backendParamOption.size_to_spread_mode.projection_perpendicular": "垂直投影"
+  "backendParamOption.size_to_spread_mode.projection_perpendicular": "垂直投影",
+  "log.mpvOrenderEnabled": "已在 {path} 中启用 orender",
+  "log.mpvOrenderDisabled": "已在 {path} 中注释掉 orender",
+  "log.mpvOrenderFailed": "修改 mpv 配置失败：{error}"
 }

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -92,6 +92,11 @@
           <span data-i18n="osc.keepRendererAlive" data-help-i18n="help.osc.keepRendererAlive" data-help-anchor=".switch-row">Keep renderer alive on quit</span>
           <input id="keepRendererAliveToggle" type="checkbox" />
         </label>
+        <label class="switch-row" style="font-size:13px;cursor:pointer">
+          <span data-i18n="osc.mpvOrender" data-help-i18n="help.osc.mpvOrender" data-help-anchor=".switch-row">Activate in mpv config</span>
+          <input id="mpvOrenderToggle" type="checkbox" />
+        </label>
+        <div id="mpvOrenderNote" class="mpv-orender-note" style="display:none"></div>
         <div class="osc-config-actions">
           <button id="oscConfigApplyBtn" class="ui-btn ui-btn-success" data-i18n="osc.connect">Connect</button>
           <button id="oscServiceBtn" type="button" class="ui-btn">Install service</button>

--- a/omniphony-studio/src/runtime-connection.js
+++ b/omniphony-studio/src/runtime-connection.js
@@ -24,7 +24,11 @@ const OSC_CONTROL_IDS = new Set([
   'oscRestartPipewireBtn',
   'oscLaunchRendererBtn',
   'oscInfoBtn',
-  'oscMeteringToggle'
+  'oscMeteringToggle',
+  // Edits the local mpv.conf, not the runtime: it must stay usable while
+  // nothing is connected. That is in fact when it is needed — the switch is
+  // what gets a first-time setup to the point where a renderer can connect.
+  'mpvOrenderToggle'
 ]);
 
 const PANEL_TOGGLE_IDS = [

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -856,6 +856,20 @@
         margin-top: 0.25rem;
       }
 
+      /* Status line under the "activate in mpv config" switch: says where the
+         file is, or why the toggle stood down (a hand-written `ad=` wins). */
+      .mpv-orender-note {
+        font-size: 12px;
+        line-height: 1.45;
+        margin: -0.1rem 0 0.35rem;
+        color: rgba(217, 236, 255, 0.62);
+        overflow-wrap: anywhere;
+      }
+
+      .mpv-orender-note.is-conflict {
+        color: #ffbf66;
+      }
+
       .clip-indicator {
         display: inline-block;
         width: 9px;


### PR DESCRIPTION
mpv only uses the engine when asked to (`ad=orender`), so a fresh install plays
through mpv's own decoders and the engine is never reached. The opt-in is a
single line in `mpv.conf`, which makes it something Studio can offer directly
instead of leaving to documentation.

Adds **"Activate in mpv config"** next to the other renderer switches in the OSC
panel, backed by two commands: read the current state, and add / comment out the
option.

## Writing into someone else's config

`mpv.conf` belongs to another application and is usually hand-maintained, so the
writer is deliberately narrow:

- Everything written lives between two marker comments. Nothing outside them is
  reformatted, reordered or removed.
- The block goes in the **global** section, before the first `[profile]` header.
  Appending at EOF would land inside whatever profile happens to be last and
  silently scope the option to it. This is not a hypothetical: a real 409-line
  config here has 18 profiles and ends inside the last one, so EOF is the wrong
  answer in the normal case.
- A hand-written `ad=` is never touched. The toggle reports the conflicting line
  and stands down rather than fighting over the option.

Verified against a copy of that real config: block inserted at lines 90-92, the
first profile section starts at line 94, and all 316 non-blank user lines come
through unchanged.

## Runtime lock

The switch is exempt from `syncRuntimeConnectionLock`. It edits a local file, and
a first-time setup — the case it exists for — has nothing connected yet, so
locking it would disable the control exactly when it is needed.

## Tests and i18n

The file surgery is split into pure helpers (`classify`, `global_section_end`,
`apply`) and tested directly: insertion point, the round-trip not drifting the
file or growing a second block, lookalike lines (`adapter=`, `#ad=`) not read as
conflicts, and no user line altered, reordered or lost.

Keys added to all eight locales; the parity gate reports 0 missing and 0
orphaned. `ja` and `zh-CN` would benefit from a native read, as usual.

## Not yet verified

The switch was checked in a browser (renders as a switch, correct label, exempt
from the lock), but not yet in the real Tauri build — the browser has no
`invoke`, so the happy path is still unexercised end to end.

Depends on nothing, but pairs with `feat/system-bridge-discovery`: that branch
makes a packaged install find its bridge, this one makes mpv ask for it.
