### PR TITLE
Give the mirror-axis switches the recompute watchdog

### DIFF
--- a/omniphony-studio/src/listeners/renderer-panel-listeners.js
+++ b/omniphony-studio/src/listeners/renderer-panel-listeners.js
@@ -83,8 +83,7 @@ export function setupRendererPanelListeners() {
     el.addEventListener('change', () => {
       app.distanceDiffuseState.mirrorAxes[axis] = el.checked === true;
       updateDistanceDiffuseUI();
-      app.vbapRecomputing = true;
-      renderVbapStatus();
+      markRecomputePending();
       // The renderer takes the whole set as one string, since the flips compose
       // into a single mirror rather than acting independently.
       const value = MIRROR_AXES.filter((a) => app.distanceDiffuseState.mirrorAxes[a]).join('') || 'none';


### PR DESCRIPTION
One line. [#214](https://github.com/mgth/Omniphony/pull/214) added the mirror-axis listener using `app.vbapRecomputing = true; renderVbapStatus();`; [#215](https://github.com/mgth/Omniphony/pull/215) replaced that pattern with `markRecomputePending()` at the 22 sites that existed when it was written. The two branched off the same commit, so neither could see the other and `git merge-tree` reported no conflict — the new listener simply arrived on `main` still using the old pattern.

Net effect: the diffuse mirror switches were the only control left without the unreachable-engine watchdog. Which is the control whose silent failure prompted the watchdog in the first place.

Verified in the browser preview on merged `main`: flipping a mirror switch now shows "computing…" and flips to the red "engine did not answer" after the timeout, instead of hanging.