### PR TITLE
perf(binaural): make the HRIR path throughput-bound, and cache the direction

### DIFF
--- a/omniphony-renderer/dsp_fixtures/src/scene.rs
+++ b/omniphony-renderer/dsp_fixtures/src/scene.rs
@@ -236,6 +236,36 @@ pub fn move_events(n_objects: usize, seed_round: u64) -> Vec<SpatialChannelEvent
         .collect()
 }
 
+/// One movement event per object on a *continuous* trajectory: each object
+/// circles the listener at its own angular rate, at its own fixed height.
+///
+/// This is the realistic counterpart to [`move_events`], which redraws every
+/// position at random each round. Random redraw is a legitimate worst case, but
+/// no stream produces it — it teleports every object across the dome every
+/// [`BLOCK_SAMPLES`] samples, which by construction defeats anything that
+/// exploits direction coherence between consecutive blocks, and so reports no
+/// gain for optimisations that real content would benefit from.
+///
+/// Rates span 12°/s to 96°/s; at 1200 blocks/s that is 0.01° to 0.08° of
+/// azimuth per block, the order of magnitude a panned object actually moves.
+pub fn drift_events(n_objects: usize, seed_round: u64) -> Vec<SpatialChannelEvent> {
+    (0..n_objects)
+        .map(|ch| {
+            let deg_per_block = (12.0 + (ch % 8) as f64 * 12.0) / 1200.0;
+            let az = (ch as f64 * 37.0 + seed_round as f64 * deg_per_block).to_radians();
+            SpatialChannelEvent {
+                channel_idx: ch,
+                is_bed: false,
+                gain_db: Some(0),
+                ramp_length: Some(BLOCK_SAMPLES as u32),
+                size: Some([0.0, 0.0, 0.0]),
+                position: Some([az.sin(), az.cos(), (ch % 5) as f64 * 0.25]),
+                sample_pos: Some(0),
+            }
+        })
+        .collect()
+}
+
 /// Build a renderer with `n_objects` already registered at initial positions,
 /// returns it plus a reusable PCM buffer. The first `render_frame` consumes the
 /// registration events so subsequent steady frames find populated channel state.

--- a/omniphony-renderer/renderer/benches/render_frame.rs
+++ b/omniphony-renderer/renderer/benches/render_frame.rs
@@ -25,8 +25,8 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use dsp_fixtures::scene::{
-    build_renderer, crossover_layout, make_pcm, move_events, prepared, prepared_binaural,
-    prepared_binaural_cascaded,
+    build_renderer, crossover_layout, drift_events, make_pcm, move_events, prepared,
+    prepared_binaural, prepared_binaural_cascaded,
 };
 use renderer::live_params::RampMode;
 
@@ -363,8 +363,13 @@ fn bench_polar_crossover(c: &mut Criterion) {
 /// cascade convolves its fixed virtual speakers whatever `n` is. `moving`
 /// re-arms a ramp every block, adding the per-block HRIR refresh (direct) vs
 /// the per-block virtual re-pan (cascaded) on top.
+///
+/// `drifting` is the one that reflects real content: `moving` redraws every
+/// position at random each block, which is not motion but teleportation, and
+/// it hides any benefit from direction coherence between blocks. Read
+/// `drifting` for the expected case and `moving` as the pathological bound.
 fn bench_binaural(c: &mut Criterion) {
-    for (scenario, moving) in [("static", false), ("moving", true)] {
+    for scenario in ["static", "moving", "drifting"] {
         let mut group = c.benchmark_group(format!("render_binaural_{scenario}"));
         for &n in &[1usize, 8, 16, 32, 64, 118] {
             for (label, cascaded) in [("direct", false), ("cascaded", true)] {
@@ -377,10 +382,10 @@ fn bench_binaural(c: &mut Criterion) {
                 let mut round = 1u64;
                 group.bench_function(BenchmarkId::new(label, n), |b| {
                     b.iter(|| {
-                        let events = if moving {
-                            move_events(n, round)
-                        } else {
-                            Vec::new()
+                        let events = match scenario {
+                            "moving" => move_events(n, round),
+                            "drifting" => drift_events(n, round),
+                            _ => Vec::new(),
                         };
                         round = round.wrapping_add(1);
                         let f = r

--- a/omniphony-renderer/renderer/src/binaural/convolver.rs
+++ b/omniphony-renderer/renderer/src/binaural/convolver.rs
@@ -1,8 +1,8 @@
 //! Direct-form FIR convolver for one ear of one object.
 //!
-//! Length is fixed at [`HRIR_LEN`]. The input-history ring buffer persists
-//! across coefficient swaps, so updating the HRIR between frames (as the object
-//! or head moves) keeps the *state* continuous — and a kernel change is
+//! Length is fixed at [`HRIR_LEN`]. The input history persists across
+//! coefficient swaps, so updating the HRIR between frames (as the object or
+//! head moves) keeps the *state* continuous — and a kernel change is
 //! additionally crossfaded over a caller-chosen ramp
 //! ([`set_coeffs_smooth`](EarConvolver::set_coeffs_smooth)): the old and new
 //! kernels run over the same history and blend linearly, which is exactly
@@ -10,18 +10,105 @@
 //! function moves without a block-boundary discontinuity (issue #155). The
 //! doubled dot product is paid only during fade samples of blocks whose kernel
 //! actually changed. Direct-form FIR is the simplest steady-state cost for
-//! short kernels; a partitioned-FFT path can replace this in M2/M3 if
-//! profiling on the object count demands it.
+//! short kernels; a partitioned-FFT path can replace this if profiling on the
+//! object count demands it.
+//!
+//! # Tap-loop layout
+//!
+//! The tap loop is the renderer's hottest inner loop — `HRIR_LEN` multiply-adds
+//! per sample *per ear per object* — so its shape is deliberate on two counts:
+//!
+//! * **The history is linear and double-written**, not a ring walked backwards.
+//!   Each input lands at both `pos` and `pos + HRIR_LEN`, which makes
+//!   `hist[pos + 1 ..= pos + HRIR_LEN]` the last `HRIR_LEN` inputs in
+//!   oldest→newest order, contiguous and ascending whatever `pos` is. The
+//!   kernel is stored reversed to match, so the loop is a plain forward dot
+//!   product over two contiguous slices — no wrap test and no descending index
+//!   in the way of the load/store units.
+//! * **The accumulation is split across [`ACC_LANES`] independent partial
+//!   sums** (see that constant).
+//!
+//! Neither is a micro-optimisation: together they take the loop from
+//! latency-bound scalar to throughput-bound. The change is a *reassociation* of
+//! `f32` additions, so outputs move at the ULP level — which is exactly the
+//! cross-host noise the golden gate is dimensioned for
+//! (`dsp_fixtures::golden::BINAURAL_RESIDUAL_GATE_DBFS`).
 
 use super::hrir::HRIR_LEN;
 
+/// Independent partial sums accumulated by the tap loop.
+///
+/// A single `acc += c * h` chain is bound by floating-point add/FMA *latency*
+/// (~4-7 cycles per tap on both x86 and Cortex-A), not by throughput: the taps
+/// serialise on one register. Splitting the accumulation into this many
+/// independent chains keeps several multiply-adds in flight at once.
+///
+/// It has to be written in the source rather than left to the optimiser:
+/// `f32` addition is not associative, so re-associating a plain reduction would
+/// change results, and no compiler will do it without fast-math — on *any*
+/// target. That matters for the embedded target in particular (issue #220): the
+/// CoreELEC images for its Amlogic SoC run a 32-bit ARM userspace, where Rust
+/// exposes no stable NEON intrinsics and AArch32's non-IEEE flush-to-zero
+/// makes LLVM more conservative still, so this is the only vectorisation-shaped
+/// win available there.
+///
+/// 8 covers the FMA latency on the in-order Cortex-A53 as well as on wide x86,
+/// maps onto 2 NEON or 1 AVX2 vector where those *are* reachable, and divides
+/// `HRIR_LEN`.
+const ACC_LANES: usize = 8;
+
+const _: () = assert!(
+    HRIR_LEN.is_multiple_of(ACC_LANES),
+    "the tap loop consumes the kernel in whole ACC_LANES chunks"
+);
+
+/// Forward dot product of a reversed kernel with the ascending history window.
+#[inline(always)]
+fn dot(coeffs: &[f32; HRIR_LEN], win: &[f32]) -> f32 {
+    let mut acc = [0.0f32; ACC_LANES];
+    for (c, h) in coeffs
+        .chunks_exact(ACC_LANES)
+        .zip(win.chunks_exact(ACC_LANES))
+    {
+        for l in 0..ACC_LANES {
+            acc[l] += c[l] * h[l];
+        }
+    }
+    acc.iter().sum()
+}
+
+/// Both kernels of a running crossfade over the same window, in one pass — the
+/// history loads are shared between them.
+#[inline(always)]
+fn dot2(new_c: &[f32; HRIR_LEN], old_c: &[f32; HRIR_LEN], win: &[f32]) -> (f32, f32) {
+    let mut acc_new = [0.0f32; ACC_LANES];
+    let mut acc_old = [0.0f32; ACC_LANES];
+    for ((cn, co), h) in new_c
+        .chunks_exact(ACC_LANES)
+        .zip(old_c.chunks_exact(ACC_LANES))
+        .zip(win.chunks_exact(ACC_LANES))
+    {
+        for l in 0..ACC_LANES {
+            let hv = h[l];
+            acc_new[l] += cn[l] * hv;
+            acc_old[l] += co[l] * hv;
+        }
+    }
+    (acc_new.iter().sum(), acc_old.iter().sum())
+}
+
 pub struct EarConvolver {
-    /// Past inputs; `pos` marks the slot just written (most recent sample).
-    hist: [f32; HRIR_LEN],
+    /// Past inputs, each written twice (`pos` and `pos + HRIR_LEN`) so the
+    /// live window is always a contiguous ascending slice. `pos` marks the
+    /// primary slot of the most recent sample.
+    hist: [f32; 2 * HRIR_LEN],
     pos: usize,
-    coeffs: [f32; HRIR_LEN],
-    /// Fade-out kernel of a running crossfade (valid while `fade_pos < fade_len`).
-    prev_coeffs: [f32; HRIR_LEN],
+    /// Current kernel, stored **reversed** (`rcoeffs[j] == coeffs[N - 1 - j]`)
+    /// to match the oldest→newest history window.
+    rcoeffs: [f32; HRIR_LEN],
+    /// Fade-out kernel of a running crossfade (valid while `fade_pos <
+    /// fade_len`), reversed the same way.
+    prev_rcoeffs: [f32; HRIR_LEN],
     fade_pos: u32,
     fade_len: u32,
 }
@@ -35,10 +122,10 @@ impl Default for EarConvolver {
 impl EarConvolver {
     pub fn new() -> Self {
         Self {
-            hist: [0.0; HRIR_LEN],
+            hist: [0.0; 2 * HRIR_LEN],
             pos: 0,
-            coeffs: [0.0; HRIR_LEN],
-            prev_coeffs: [0.0; HRIR_LEN],
+            rcoeffs: [0.0; HRIR_LEN],
+            prev_rcoeffs: [0.0; HRIR_LEN],
             fade_pos: 0,
             fade_len: 0,
         }
@@ -50,9 +137,18 @@ impl EarConvolver {
     /// on live update paths.
     #[inline]
     pub fn set_coeffs(&mut self, coeffs: &[f32; HRIR_LEN]) {
-        self.coeffs.copy_from_slice(coeffs);
+        for (dst, &c) in self.rcoeffs.iter_mut().zip(coeffs.iter().rev()) {
+            *dst = c;
+        }
         self.fade_pos = 0;
         self.fade_len = 0;
+    }
+
+    /// Whether `coeffs` is the kernel already loaded (compared in natural
+    /// order against the reversed store — no temporary).
+    #[inline]
+    fn kernel_is(&self, coeffs: &[f32; HRIR_LEN]) -> bool {
+        self.rcoeffs.iter().eq(coeffs.iter().rev())
     }
 
     /// Replace the FIR kernel, crossfading from the current one over the next
@@ -62,7 +158,7 @@ impl EarConvolver {
     /// from the currently *effective* (blended) kernel, so back-to-back
     /// changes stay click-free too.
     pub fn set_coeffs_smooth(&mut self, coeffs: &[f32; HRIR_LEN], fade_len: usize) {
-        if *coeffs == self.coeffs {
+        if self.kernel_is(coeffs) {
             return;
         }
         if fade_len == 0 {
@@ -73,12 +169,14 @@ impl EarConvolver {
             // Freeze the running blend as the new fade-out kernel.
             let w = self.fade_pos as f32 / self.fade_len as f32;
             for i in 0..HRIR_LEN {
-                self.prev_coeffs[i] += (self.coeffs[i] - self.prev_coeffs[i]) * w;
+                self.prev_rcoeffs[i] += (self.rcoeffs[i] - self.prev_rcoeffs[i]) * w;
             }
         } else {
-            self.prev_coeffs.copy_from_slice(&self.coeffs);
+            self.prev_rcoeffs.copy_from_slice(&self.rcoeffs);
         }
-        self.coeffs.copy_from_slice(coeffs);
+        for (dst, &c) in self.rcoeffs.iter_mut().zip(coeffs.iter().rev()) {
+            *dst = c;
+        }
         self.fade_pos = 0;
         self.fade_len = fade_len as u32;
     }
@@ -86,35 +184,26 @@ impl EarConvolver {
     /// Push one input sample and return the filtered output.
     #[inline]
     pub fn process(&mut self, x: f32) -> f32 {
-        self.hist[self.pos] = x;
-        let mut idx = self.pos;
-        let acc = if self.fade_pos < self.fade_len {
-            // Crossfade: both kernels over the shared history, linear blend.
-            self.fade_pos += 1;
-            let w = self.fade_pos as f32 / self.fade_len as f32;
-            let mut acc_new = 0.0f32;
-            let mut acc_old = 0.0f32;
-            for i in 0..HRIR_LEN {
-                let h = self.hist[idx];
-                acc_new += self.coeffs[i] * h;
-                acc_old += self.prev_coeffs[i] * h;
-                idx = if idx == 0 { HRIR_LEN - 1 } else { idx - 1 };
-            }
-            acc_old + (acc_new - acc_old) * w
-        } else {
-            let mut acc = 0.0f32;
-            for &c in self.coeffs.iter() {
-                acc += c * self.hist[idx];
-                idx = if idx == 0 { HRIR_LEN - 1 } else { idx - 1 };
-            }
-            acc
-        };
+        // Advance first, then write both copies: the window below is then the
+        // last HRIR_LEN inputs, oldest→newest, with `x` as its final element.
         self.pos = if self.pos + 1 == HRIR_LEN {
             0
         } else {
             self.pos + 1
         };
-        acc
+        self.hist[self.pos] = x;
+        self.hist[self.pos + HRIR_LEN] = x;
+        let win = &self.hist[self.pos + 1..self.pos + 1 + HRIR_LEN];
+
+        if self.fade_pos < self.fade_len {
+            // Crossfade: both kernels over the shared history, linear blend.
+            self.fade_pos += 1;
+            let w = self.fade_pos as f32 / self.fade_len as f32;
+            let (acc_new, acc_old) = dot2(&self.rcoeffs, &self.prev_rcoeffs, win);
+            acc_old + (acc_new - acc_old) * w
+        } else {
+            dot(&self.rcoeffs, win)
+        }
     }
 }
 
@@ -141,6 +230,48 @@ mod tests {
         let xs = [1.0, 0.0, 0.0, 0.0, 0.0];
         let ys: Vec<f32> = xs.iter().map(|&x| c.process(x)).collect();
         assert_eq!(ys, vec![0.0, 0.0, 0.0, 1.0, 0.0]);
+    }
+
+    /// The last tap is the one the doubled history has to reach across the
+    /// wrap, and `pos` visits every slot — so drive the impulse through a full
+    /// lap and a bit more. A window that mirrors the wrong copy shows up here
+    /// and nowhere else.
+    #[test]
+    fn last_tap_delays_by_full_kernel_length() {
+        let mut c = EarConvolver::new();
+        let mut k = [0.0; HRIR_LEN];
+        k[HRIR_LEN - 1] = 1.0;
+        c.set_coeffs(&k);
+        // Impulse at t=0, then silence: the echo must come back exactly once,
+        // at t = HRIR_LEN - 1, whatever lap of the buffer that lands on.
+        let mut hits = Vec::new();
+        for t in 0..(3 * HRIR_LEN) {
+            let y = c.process(if t == 0 { 1.0 } else { 0.0 });
+            if y != 0.0 {
+                hits.push((t, y));
+            }
+        }
+        assert_eq!(hits, vec![(HRIR_LEN - 1, 1.0)]);
+    }
+
+    /// Every tap index must map to its own delay — a full sweep catches an
+    /// off-by-one in the reversed kernel that a single probe tap would miss.
+    #[test]
+    fn every_tap_maps_to_its_own_delay() {
+        for tap in [0, 1, 2, 7, 8, 63, HRIR_LEN - 2, HRIR_LEN - 1] {
+            let mut c = EarConvolver::new();
+            let mut k = [0.0; HRIR_LEN];
+            k[tap] = 1.0;
+            c.set_coeffs(&k);
+            let mut hits = Vec::new();
+            for t in 0..(2 * HRIR_LEN) {
+                let y = c.process(if t == 0 { 1.0 } else { 0.0 });
+                if y != 0.0 {
+                    hits.push(t);
+                }
+            }
+            assert_eq!(hits, vec![tap], "tap {tap} landed at the wrong delay");
+        }
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/hrir.rs
+++ b/omniphony-renderer/renderer/src/binaural/hrir.rs
@@ -197,11 +197,56 @@ pub struct HrirSet {
     grid: Vec<HrirPair>,
 }
 
+/// A direction snapped to the HRIR update lattice — see
+/// [`HrirSet::quantize_direction`]. Equality is the whole point: two directions
+/// with the same key interpolate to the same kernel, bit for bit.
+///
+/// The angles are held as their bit patterns so the type can derive `Eq`, and
+/// because bitwise identity is exactly the property the render path needs —
+/// `f32` equality would additionally have to reason about `NaN` and `-0.0`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct DirectionKey {
+    az_bits: u32,
+    el_bits: u32,
+}
+
+impl DirectionKey {
+    fn new(az_deg: f32, el_deg: f32) -> Self {
+        Self {
+            az_bits: az_deg.to_bits(),
+            el_bits: el_deg.to_bits(),
+        }
+    }
+    fn az_deg(self) -> f32 {
+        f32::from_bits(self.az_bits)
+    }
+    fn el_deg(self) -> f32 {
+        f32::from_bits(self.el_bits)
+    }
+}
+
 impl HrirSet {
     const AZ_STEP_DEG: f32 = 10.0;
     const EL_STEP_DEG: f32 = 10.0;
     const EL_MIN_DEG: f32 = -40.0;
     const EL_MAX_DEG: f32 = 90.0;
+    /// Sub-steps per measured cell on the HRIR update lattice, or `None` to
+    /// update on any change of direction at all.
+    ///
+    /// This is a **quality/cost knob, not a free optimisation**. Measured on
+    /// the `drifting` bench at 16 objects, against the binaural golden:
+    ///
+    /// | value      | lattice | peak residual | direct/16 |
+    /// |------------|---------|---------------|-----------|
+    /// | `None`     | exact   | bit-exact     | 49.3 µs   |
+    /// | `Some(512)`| 0.020°  | −53.3 dBFS    | 47.5 µs   |
+    /// | `Some(128)`| 0.078°  | −43.9 dBFS    | 35.1 µs   |
+    /// | `Some(32)` | 0.313°  | −30.9 dBFS    | 20.8 µs   |
+    ///
+    /// `None` still pays off on *static* content (nothing moved ⇒ nothing
+    /// recomputed) and costs nothing at all in fidelity, which is why it is the
+    /// default until the lattice has been judged by ear rather than by residual.
+    const DIR_SUBDIV: Option<i32> = None;
 
     /// Precompute the grid from `provider` at `sample_rate`.
     pub fn new(provider: &dyn HrirProvider, sample_rate: u32) -> Self {
@@ -277,6 +322,52 @@ impl HrirSet {
         &self.grid[el_idx * self.az_count + az_idx]
     }
 
+    /// Snap a direction onto the HRIR *update lattice*.
+    ///
+    /// [`at`](Self::at) is the single most expensive per-block operation in the
+    /// binaural path — a bilinear blend of four 1 KB pairs gathered from a
+    /// ~700 KB table — and its result then has to be compared against the
+    /// convolvers' current kernels to find out whether anything moved at all.
+    /// Both costs are wasted whenever an object barely turned.
+    ///
+    /// The grid is measured every [`AZ_STEP_DEG`](Self::AZ_STEP_DEG) /
+    /// [`EL_STEP_DEG`](Self::EL_STEP_DEG) — 10° — but `fa`/`fe` below are
+    /// continuous, so today a 0.01° move yields a numerically different kernel
+    /// and arms a full crossfade. That is precision the measurements do not
+    /// contain: below the lattice we are only interpolating measurement noise.
+    ///
+    /// The key carries the very angles [`at_key`](Self::at_key) will feed to
+    /// [`at`](Self::at), so "same key ⇒ same kernel" holds by construction
+    /// rather than by argument — and [`DIR_SUBDIV`](Self::DIR_SUBDIV) `= None`
+    /// degenerates to an exact-direction cache that skips only when nothing
+    /// moved at all, which is bit-identical to never skipping.
+    pub fn quantize_direction(&self, az_deg: f32, el_deg: f32) -> DirectionKey {
+        self.key_at(az_deg, el_deg, Self::DIR_SUBDIV)
+    }
+
+    /// [`quantize_direction`](Self::quantize_direction) with the lattice passed
+    /// explicitly, so tests can exercise both settings of a compile-time knob.
+    fn key_at(&self, az_deg: f32, el_deg: f32, subdiv: Option<i32>) -> DirectionKey {
+        let az = az_deg.rem_euclid(360.0);
+        // Elevation is clamped here, exactly as `at` clamps it, so two
+        // directions past the pole share one key instead of missing the skip.
+        let el = el_deg.clamp(self.el_min_deg, self.el_max_deg);
+        let Some(subdiv) = subdiv else {
+            return DirectionKey::new(az, el);
+        };
+        let step_az = Self::AZ_STEP_DEG / subdiv as f32;
+        let step_el = Self::EL_STEP_DEG / subdiv as f32;
+        DirectionKey::new(
+            ((az / step_az).round() * step_az).rem_euclid(360.0),
+            (el / step_el).round() * step_el,
+        )
+    }
+
+    /// The interpolated pair for a key from [`quantize_direction`](Self::quantize_direction).
+    pub fn at_key(&self, key: DirectionKey, out: &mut HrirPair) {
+        self.at(key.az_deg(), key.el_deg(), out);
+    }
+
     /// Bilinearly-interpolated HRIR pair for an arbitrary direction.
     /// `az_deg`: 0 = front, positive = right. `el_deg`: 0 = horizontal.
     pub fn at(&self, az_deg: f32, el_deg: f32, out: &mut HrirPair) {
@@ -318,6 +409,98 @@ mod tests {
 
     fn energy(h: &[f32; HRIR_LEN]) -> f32 {
         h.iter().map(|&x| x * x).sum()
+    }
+
+    /// The contract the render path relies on to skip work: same key ⇒ the
+    /// *identical* kernel, bit for bit. If this ever weakens to "almost the
+    /// same", the skip silently freezes a stale kernel instead of updating it.
+    #[test]
+    fn same_key_yields_a_bit_identical_kernel() {
+        let set = HrirSet::synthetic(48_000);
+        let mut a = HrirPair::zeroed();
+        let mut b = HrirPair::zeroed();
+        // Two directions a hair apart — well inside one lattice step (0.31°).
+        let k1 = set.key_at(31.700, 12.400, Some(32));
+        let k2 = set.key_at(31.705, 12.402, Some(32));
+        assert_eq!(k1, k2, "directions within a lattice step must share a key");
+        set.at_key(k1, &mut a);
+        set.at_key(k2, &mut b);
+        assert_eq!(a.left, b.left);
+        assert_eq!(a.right, b.right);
+    }
+
+    /// Without a lattice the cache must be exact: it may only skip when the
+    /// direction did not move at all. That is what makes `DIR_SUBDIV = None`
+    /// bit-identical to never skipping.
+    #[test]
+    fn the_exact_lattice_only_matches_an_unmoved_direction() {
+        let set = HrirSet::synthetic(48_000);
+        let base = set.key_at(31.7, 12.4, None);
+        assert_eq!(base, set.key_at(31.7, 12.4, None), "same direction");
+        assert_ne!(base, set.key_at(31.700_01, 12.4, None), "a hair of azimuth");
+        assert_ne!(
+            base,
+            set.key_at(31.7, 12.400_01, None),
+            "a hair of elevation"
+        );
+    }
+
+    /// The lattice must still *track* — a move of a few degrees has to produce
+    /// a new key at any setting, or objects would freeze at their first
+    /// direction.
+    #[test]
+    fn a_real_move_changes_the_key() {
+        let set = HrirSet::synthetic(48_000);
+        for subdiv in [None, Some(512), Some(32)] {
+            let base = set.key_at(31.7, 12.4, subdiv);
+            assert_ne!(base, set.key_at(33.0, 12.4, subdiv), "azimuth {subdiv:?}");
+            assert_ne!(base, set.key_at(31.7, 14.0, subdiv), "elevation {subdiv:?}");
+        }
+    }
+
+    /// Azimuth wraps: 0° and 360° are the same direction, so they must not
+    /// produce two keys (which would cost a pointless kernel rebuild per lap).
+    #[test]
+    fn azimuth_wraps_to_a_single_key() {
+        let set = HrirSet::synthetic(48_000);
+        assert_eq!(
+            set.quantize_direction(0.0, 0.0),
+            set.quantize_direction(360.0, 0.0)
+        );
+        assert_eq!(
+            set.quantize_direction(-90.0, 0.0),
+            set.quantize_direction(270.0, 0.0)
+        );
+    }
+
+    /// Elevation clamps exactly where `at` clamps it, so directions past the
+    /// pole collapse onto one key instead of missing the skip.
+    #[test]
+    fn elevation_past_the_pole_shares_one_key() {
+        let set = HrirSet::synthetic(48_000);
+        assert_eq!(
+            set.quantize_direction(10.0, 95.0),
+            set.quantize_direction(10.0, 120.0)
+        );
+    }
+
+    /// Snapping must stay within half a lattice step of the true direction —
+    /// the bound that makes the approximation defensible against a 10° grid.
+    #[test]
+    fn snapping_error_stays_under_half_a_lattice_step() {
+        let set = HrirSet::synthetic(48_000);
+        for subdiv in [512, 128, 32] {
+            let step = HrirSet::AZ_STEP_DEG / subdiv as f32;
+            for &az in &[0.0f32, 7.3, 91.6, 179.9, 271.4, 359.8] {
+                let snapped = set.key_at(az, 0.0, Some(subdiv)).az_deg();
+                let raw = (snapped - az.rem_euclid(360.0)).abs();
+                let err = raw.min(360.0 - raw);
+                assert!(
+                    err <= step / 2.0 + 1e-4,
+                    "subdiv {subdiv}, az {az}: snapped to {snapped}, error {err}"
+                );
+            }
+        }
     }
 
     /// cos(el)-weighted mean per-ear grid energy — the shared reference level

--- a/omniphony-renderer/renderer/src/binaural/hrir.rs
+++ b/omniphony-renderer/renderer/src/binaural/hrir.rs
@@ -230,23 +230,6 @@ impl HrirSet {
     const EL_STEP_DEG: f32 = 10.0;
     const EL_MIN_DEG: f32 = -40.0;
     const EL_MAX_DEG: f32 = 90.0;
-    /// Sub-steps per measured cell on the HRIR update lattice, or `None` to
-    /// update on any change of direction at all.
-    ///
-    /// This is a **quality/cost knob, not a free optimisation**. Measured on
-    /// the `drifting` bench at 16 objects, against the binaural golden:
-    ///
-    /// | value      | lattice | peak residual | direct/16 |
-    /// |------------|---------|---------------|-----------|
-    /// | `None`     | exact   | bit-exact     | 49.3 µs   |
-    /// | `Some(512)`| 0.020°  | −53.3 dBFS    | 47.5 µs   |
-    /// | `Some(128)`| 0.078°  | −43.9 dBFS    | 35.1 µs   |
-    /// | `Some(32)` | 0.313°  | −30.9 dBFS    | 20.8 µs   |
-    ///
-    /// `None` still pays off on *static* content (nothing moved ⇒ nothing
-    /// recomputed) and costs nothing at all in fidelity, which is why it is the
-    /// default until the lattice has been judged by ear rather than by residual.
-    const DIR_SUBDIV: Option<i32> = None;
 
     /// Precompute the grid from `provider` at `sample_rate`.
     pub fn new(provider: &dyn HrirProvider, sample_rate: u32) -> Self {
@@ -338,15 +321,19 @@ impl HrirSet {
     ///
     /// The key carries the very angles [`at_key`](Self::at_key) will feed to
     /// [`at`](Self::at), so "same key ⇒ same kernel" holds by construction
-    /// rather than by argument — and [`DIR_SUBDIV`](Self::DIR_SUBDIV) `= None`
+    /// rather than by argument — and `subdiv = None`
+    /// ([`HrirUpdateLattice::Exact`](crate::live_params::HrirUpdateLattice::Exact))
     /// degenerates to an exact-direction cache that skips only when nothing
     /// moved at all, which is bit-identical to never skipping.
-    pub fn quantize_direction(&self, az_deg: f32, el_deg: f32) -> DirectionKey {
-        self.key_at(az_deg, el_deg, Self::DIR_SUBDIV)
+    pub fn quantize_direction(
+        &self,
+        az_deg: f32,
+        el_deg: f32,
+        subdiv: Option<i32>,
+    ) -> DirectionKey {
+        self.key_at(az_deg, el_deg, subdiv)
     }
 
-    /// [`quantize_direction`](Self::quantize_direction) with the lattice passed
-    /// explicitly, so tests can exercise both settings of a compile-time knob.
     fn key_at(&self, az_deg: f32, el_deg: f32, subdiv: Option<i32>) -> DirectionKey {
         let az = az_deg.rem_euclid(360.0);
         // Elevation is clamped here, exactly as `at` clamps it, so two
@@ -464,12 +451,12 @@ mod tests {
     fn azimuth_wraps_to_a_single_key() {
         let set = HrirSet::synthetic(48_000);
         assert_eq!(
-            set.quantize_direction(0.0, 0.0),
-            set.quantize_direction(360.0, 0.0)
+            set.key_at(0.0, 0.0, Some(32)),
+            set.key_at(360.0, 0.0, Some(32))
         );
         assert_eq!(
-            set.quantize_direction(-90.0, 0.0),
-            set.quantize_direction(270.0, 0.0)
+            set.key_at(-90.0, 0.0, Some(32)),
+            set.key_at(270.0, 0.0, Some(32))
         );
     }
 
@@ -479,8 +466,8 @@ mod tests {
     fn elevation_past_the_pole_shares_one_key() {
         let set = HrirSet::synthetic(48_000);
         assert_eq!(
-            set.quantize_direction(10.0, 95.0),
-            set.quantize_direction(10.0, 120.0)
+            set.key_at(10.0, 95.0, Some(32)),
+            set.key_at(10.0, 120.0, Some(32))
         );
     }
 

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -39,7 +39,7 @@ pub use tracking::{HeadTracking, HeadTrackingFormat};
 use crate::delay_line::DelayLine;
 use crate::live_params::{BinauralReflections, BinauralReverb};
 use convolver::EarConvolver;
-use hrir::{HRIR_LEN, HrirPair, HrirSet, ParametricPinnaHrir};
+use hrir::{DirectionKey, HRIR_LEN, HrirPair, HrirSet, ParametricPinnaHrir};
 use measured::MeasuredHrirData;
 use prtf::SpagnolPrtfHrir;
 use reflections::ReflectionBank;
@@ -201,6 +201,11 @@ struct ChannelDsp {
     /// Air-absorption smoothing coefficient for the current block
     /// (0 = bypass, →1 = heavy low-pass). Updated per block from distance.
     air_coeff: f32,
+    /// Lattice direction the loaded kernels were built from, tagged with the
+    /// HRIR grid generation they came out of — a live source switch replaces
+    /// the grid under us, and a key alone would then match across two
+    /// different datasets and freeze the stale kernels in place.
+    last_dir: Option<(u32, DirectionKey)>,
 }
 
 impl ChannelDsp {
@@ -214,6 +219,7 @@ impl ChannelDsp {
             refl: None,
             air_state: 0.0,
             air_coeff: 0.0,
+            last_dir: None,
         }
     }
 }
@@ -247,6 +253,9 @@ pub struct BinauralRenderer {
     channels: Vec<Option<ChannelDsp>>,
     /// Reusable HRIR scratch so `at()` writes in place (no per-channel alloc).
     hrir_scratch: HrirPair,
+    /// Bumped every time a rebuilt grid is swapped in, so the per-channel
+    /// direction cache cannot match across two different datasets.
+    hrir_generation: u32,
     /// Shared late-reverb tail; allocated lazily while enabled.
     fdn: Option<Fdn>,
     /// Mono reverb send bus, one sample per frame (reused).
@@ -291,6 +300,7 @@ impl BinauralRenderer {
                 left: [0.0; HRIR_LEN],
                 right: [0.0; HRIR_LEN],
             },
+            hrir_generation: 0,
             fdn: None,
             reverb_bus: Vec::new(),
         }
@@ -375,6 +385,9 @@ impl BinauralRenderer {
     pub fn ensure_source(&mut self, source: &HrirSource) {
         if let Some(set) = self.incoming.swap(None) {
             self.hrir = set;
+            // Invalidates every channel's cached lattice direction at once —
+            // the new grid answers differently for the same key.
+            self.hrir_generation = self.hrir_generation.wrapping_add(1);
         }
         if &self.source != source {
             self.source = source.clone();
@@ -486,21 +499,35 @@ impl BinauralRenderer {
             let dist_norm = ((pos[0] * pos[0] + pos[1] * pos[1] + pos[2] * pos[2]).sqrt()) as f32;
             let dist_m = (dist_norm * unit_scale_m).max(0.0);
 
-            // Per-frame HRIR + ITD update (continuous: delay/convolver state persists).
-            self.hrir.at(
-                az_rad.to_degrees(),
-                el_rad.to_degrees(),
-                &mut self.hrir_scratch,
-            );
+            // ITD stays continuous: it is the dominant lateralisation cue, and
+            // it is a closed-form formula feeding an interpolating delay line —
+            // cheap enough that quantizing it would buy nothing.
             let (itd_l, itd_r) = itd::ear_delays_seconds(az_rad, el_rad, head_radius_m);
 
+            // The HRIR is the expensive one, so it updates on a lattice
+            // instead. The kernel is a pure function of this key, so an
+            // unchanged key means `at()` would rebuild the very kernels the
+            // convolvers already hold: skip the four-pair gather *and* the
+            // kernel compare rather than paying both to learn nothing moved.
+            // Skipping also leaves no crossfade armed, which halves the tap
+            // loop for the block (one dot product instead of two).
+            let dir = (
+                self.hrir_generation,
+                self.hrir
+                    .quantize_direction(az_rad.to_degrees(), el_rad.to_degrees()),
+            );
             let dsp = self.channels[c].get_or_insert_with(|| ChannelDsp::new(self.sample_rate));
-            // Kernel changes (moving object / head) crossfade over the block
-            // — capped at HRIR_LEN samples for large offline blocks — so the
-            // transfer function never jumps at a block boundary (issue #155).
-            let fade = sample_length.min(HRIR_LEN);
-            dsp.conv_l.set_coeffs_smooth(&self.hrir_scratch.left, fade);
-            dsp.conv_r.set_coeffs_smooth(&self.hrir_scratch.right, fade);
+            if dsp.last_dir != Some(dir) {
+                dsp.last_dir = Some(dir);
+                self.hrir.at_key(dir.1, &mut self.hrir_scratch);
+                // Kernel changes (moving object / head) crossfade over the
+                // block — capped at HRIR_LEN samples for large offline blocks
+                // — so the transfer function never jumps at a block boundary
+                // (issue #155).
+                let fade = sample_length.min(HRIR_LEN);
+                dsp.conv_l.set_coeffs_smooth(&self.hrir_scratch.left, fade);
+                dsp.conv_r.set_coeffs_smooth(&self.hrir_scratch.right, fade);
+            }
             dsp.delay_l.set_target_ms(itd_l * 1000.0, self.sample_rate);
             dsp.delay_r.set_target_ms(itd_r * 1000.0, self.sample_rate);
 

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -233,6 +233,8 @@ pub struct BinauralFrameParams {
     pub reflections: BinauralReflections,
     pub reverb: BinauralReverb,
     pub air_absorption: bool,
+    /// How finely a direction must change before its HRIR is rebuilt.
+    pub hrir_update_lattice: crate::live_params::HrirUpdateLattice,
 }
 
 /// Owns the per-channel binaural DSP state and the HRIR set; renders all input
@@ -425,6 +427,7 @@ impl BinauralRenderer {
             ref reflections,
             ref reverb,
             air_absorption,
+            hrir_update_lattice,
         } = *params;
         debug_assert_eq!(out.len(), sample_length * 2);
         if input_channel_count == 0 || sample_length == 0 {
@@ -513,8 +516,11 @@ impl BinauralRenderer {
             // loop for the block (one dot product instead of two).
             let dir = (
                 self.hrir_generation,
-                self.hrir
-                    .quantize_direction(az_rad.to_degrees(), el_rad.to_degrees()),
+                self.hrir.quantize_direction(
+                    az_rad.to_degrees(),
+                    el_rad.to_degrees(),
+                    hrir_update_lattice.subdiv(),
+                ),
             );
             let dsp = self.channels[c].get_or_insert_with(|| ChannelDsp::new(self.sample_rate));
             if dsp.last_dir != Some(dir) {
@@ -648,6 +654,7 @@ mod tests {
                 ..Default::default()
             },
             air_absorption: false,
+            hrir_update_lattice: crate::live_params::HrirUpdateLattice::default(),
         }
     }
 

--- a/omniphony-renderer/renderer/src/config.rs
+++ b/omniphony-renderer/renderer/src/config.rs
@@ -387,6 +387,12 @@ pub struct BinauralConfig {
     /// Distance low-pass on the direct path (air absorption). Default true.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub air_absorption: Option<bool>,
+    /// How finely a direction must change before its HRIR is rebuilt:
+    /// `"exact"` (default, bit-exact) | `"fine"` | `"balanced"` | `"coarse"`.
+    /// Anything but `exact` trades fidelity for speed — see
+    /// [`crate::live_params::HrirUpdateLattice`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hrir_update_lattice: Option<String>,
     /// See `Config::extra` — preserve unknown keys through round-trips.
     #[serde(flatten, default, skip_serializing_if = "Mapping::is_empty")]
     pub extra: Mapping,

--- a/omniphony-renderer/renderer/src/config_fields.rs
+++ b/omniphony-renderer/renderer/src/config_fields.rs
@@ -405,9 +405,67 @@ pub mod presentation {
     }
 }
 
+/// HRIR update lattice (`render.binaural.hrir_update_lattice`). Bespoke: it
+/// lives in the nested `binaural` section rather than among the `render.*`
+/// scalars the generic macros cover, next to the other binaural settings.
+pub mod hrir_update_lattice {
+    use super::RenderConfig;
+    use crate::live_params::HrirUpdateLattice;
+
+    /// Canonical default — the single copy of this field's default.
+    pub const DEFAULT: HrirUpdateLattice = HrirUpdateLattice::Exact;
+
+    pub fn get(cfg: &RenderConfig) -> Option<HrirUpdateLattice> {
+        cfg.binaural
+            .as_ref()?
+            .hrir_update_lattice
+            .as_deref()
+            .and_then(HrirUpdateLattice::from_str)
+    }
+
+    /// Skip-if-default: the key stays out of the file at `exact`.
+    pub fn store(cfg: &mut RenderConfig, value: HrirUpdateLattice) {
+        let stored = (value != DEFAULT).then(|| value.as_str().to_string());
+        if stored.is_none() && cfg.binaural.is_none() {
+            return; // don't materialise the section just to omit a key
+        }
+        cfg.binaural
+            .get_or_insert_with(Default::default)
+            .hrir_update_lattice = stored;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::RenderConfig;
+    use crate::live_params::HrirUpdateLattice;
+
+    #[test]
+    fn hrir_lattice_round_trips_and_omits_the_default() {
+        let mut cfg = RenderConfig::default();
+        super::hrir_update_lattice::store(&mut cfg, HrirUpdateLattice::Coarse);
+        assert_eq!(
+            super::hrir_update_lattice::get(&cfg),
+            Some(HrirUpdateLattice::Coarse)
+        );
+        super::hrir_update_lattice::store(&mut cfg, HrirUpdateLattice::Exact);
+        assert_eq!(super::hrir_update_lattice::get(&cfg), None);
+        assert!(
+            cfg.binaural
+                .as_ref()
+                .is_none_or(|b| b.hrir_update_lattice.is_none()),
+            "the default must not be written to the file"
+        );
+    }
+
+    /// Storing the default into a config with no binaural section must not
+    /// create one — an empty `binaural: {}` block in every saved file.
+    #[test]
+    fn hrir_lattice_default_does_not_materialise_the_section() {
+        let mut cfg = RenderConfig::default();
+        super::hrir_update_lattice::store(&mut cfg, HrirUpdateLattice::Exact);
+        assert!(cfg.binaural.is_none());
+    }
 
     #[test]
     fn store_non_default_sets_some() {

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -336,6 +336,75 @@ impl BinauralMode {
     }
 }
 
+/// How finely an object has to turn before its HRIR is rebuilt.
+///
+/// Interpolating a fresh HRIR pair is the most expensive per-block operation of
+/// the binaural stage, and it is repeated for a move of a hundredth of a degree
+/// — precision the measured grid (10° steps) does not contain. Snapping
+/// directions onto a coarser lattice lets an object that barely turned keep its
+/// kernel, which also leaves no crossfade armed and so halves that block's tap
+/// loop.
+///
+/// This is a **quality/cost trade, not a free optimisation**: every setting
+/// other than [`Exact`](Self::Exact) changes the rendered output. Measured on
+/// the `drifting` bench at 16 objects, against the binaural golden:
+///
+/// | setting    | lattice | peak residual | direct/16 |
+/// |------------|---------|---------------|-----------|
+/// | `exact`    | —       | bit-exact     | 49.3 µs   |
+/// | `fine`     | 0.020°  | −53.3 dBFS    | 47.5 µs   |
+/// | `balanced` | 0.078°  | −43.9 dBFS    | 35.1 µs   |
+/// | `coarse`   | 0.313°  | −30.9 dBFS    | 20.8 µs   |
+///
+/// `exact` is the default: it still skips the rebuild whenever nothing moved
+/// (static objects, and every virtual speaker of the cascaded mode), which
+/// costs nothing in fidelity. The coarser rungs are worth their residual only
+/// once judged by ear, which has not been done.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HrirUpdateLattice {
+    /// Rebuild whenever the direction changes at all. Bit-identical output.
+    #[default]
+    Exact,
+    /// 1/512 of a measured cell.
+    Fine,
+    /// 1/128 of a measured cell.
+    Balanced,
+    /// 1/32 of a measured cell — the cheapest, and the one that makes object
+    /// motion nearly free on constrained hardware.
+    Coarse,
+}
+
+impl HrirUpdateLattice {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Fine => "fine",
+            Self::Balanced => "balanced",
+            Self::Coarse => "coarse",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "exact" | "off" | "none" => Some(Self::Exact),
+            "fine" => Some(Self::Fine),
+            "balanced" | "medium" => Some(Self::Balanced),
+            "coarse" => Some(Self::Coarse),
+            _ => None,
+        }
+    }
+
+    /// Sub-steps per measured grid cell, or `None` for exact matching.
+    pub fn subdiv(self) -> Option<i32> {
+        match self {
+            Self::Exact => None,
+            Self::Fine => Some(512),
+            Self::Balanced => Some(128),
+            Self::Coarse => Some(32),
+        }
+    }
+}
+
 /// Live-tunable parameters for one headphone ear channel of the binaural
 /// output. Dedicated storage: the ears used to ride the first two per-speaker
 /// slots, which collides now that the cascaded mode applies the per-speaker
@@ -443,6 +512,8 @@ pub struct BinauralLiveParams {
     pub tracking: crate::binaural::HeadTracking,
     /// HRIR data set to convolve with (synthetic / embedded KEMAR / SOFA).
     pub hrir_source: crate::binaural::HrirSource,
+    /// How finely a direction must change before its HRIR is rebuilt.
+    pub hrir_update_lattice: HrirUpdateLattice,
     /// Shoebox early-reflection settings (externalization).
     pub reflections: BinauralReflections,
     /// Late-reverb tail settings (distance / externalization).
@@ -463,6 +534,7 @@ impl Default for BinauralLiveParams {
             head_pose: crate::binaural::HeadPose::identity(),
             tracking: crate::binaural::HeadTracking::default(),
             hrir_source: crate::binaural::HrirSource::default(),
+            hrir_update_lattice: HrirUpdateLattice::default(),
             reflections: BinauralReflections::default(),
             reverb: BinauralReverb::default(),
             air_absorption: true,

--- a/omniphony-renderer/renderer/src/options.rs
+++ b/omniphony-renderer/renderer/src/options.rs
@@ -29,7 +29,9 @@
 //! missing a layer.
 
 use crate::config::RenderConfig;
-use crate::live_params::{LiveParams, OutputChannelMapping, PhantomExtractMode, SurroundPlacement};
+use crate::live_params::{
+    HrirUpdateLattice, LiveParams, OutputChannelMapping, PhantomExtractMode, SurroundPlacement,
+};
 
 /// What kind of value an option takes. Drives wire validation, the published
 /// schema, and (later) which Studio control the binder renders.
@@ -278,6 +280,37 @@ pub static LIVE_OPTIONS: &[OptionSpec] = &[
         config_seed: |live, render| {
             if let Some(mode) = crate::config_fields::phantom_extract_mode::get(render) {
                 live.phantom_extract_mode = mode;
+            }
+        },
+    },
+    OptionSpec {
+        key: "hrir_update_lattice",
+        kind: OptionKind::Enum(&["exact", "fine", "balanced", "coarse"]),
+        default: OptionDefault::Str("exact"),
+        // No REPLAN: the lattice only gates a per-block cache in the binaural
+        // stage, it does not change any synthesized-object topology.
+        flags: OptionFlags::PERSIST,
+        i18n_key: "binaural.hrirUpdateLatticeLabel",
+        help_i18n_key: Some("help.hrirUpdateLattice"),
+        legacy_control_addr: "/omniphony/control/binaural/hrir_update_lattice",
+        set: |live, raw| match raw {
+            RawOptionValue::Str(s) => {
+                let lattice = HrirUpdateLattice::from_str(s)?;
+                live.binaural.hrir_update_lattice = lattice;
+                Some(lattice.as_str().to_string())
+            }
+            _ => None,
+        },
+        get_json: |live| live.binaural.hrir_update_lattice.as_str().into(),
+        config_store: |render, live| {
+            crate::config_fields::hrir_update_lattice::store(
+                render,
+                live.binaural.hrir_update_lattice,
+            )
+        },
+        config_seed: |live, render| {
+            if let Some(lattice) = crate::config_fields::hrir_update_lattice::get(render) {
+                live.binaural.hrir_update_lattice = lattice;
             }
         },
     },

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -666,6 +666,7 @@ impl SpatialRenderer {
                         reflections: g.binaural.reflections.clone(),
                         reverb: g.binaural.reverb.clone(),
                         air_absorption: g.binaural.air_absorption,
+                        hrir_update_lattice: g.binaural.hrir_update_lattice,
                     },
                     g.binaural.ears,
                 )

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -153,6 +153,12 @@ pub const CONTROL_OUTPUT_CHANNEL_MAPPING: &str = "/omniphony/control/output_chan
 /// `SpeakerLayout` (one entry per channel label, `spatialize` = virtual/direct);
 /// an empty string resets to the built-in canonical poses (LFE direct).
 pub const CONTROL_VIRTUAL_BED: &str = "/omniphony/control/virtual_bed";
+/// How finely an object must turn before its HRIR is rebuilt: `exact`
+/// (default, bit-identical output), `fine`, `balanced` or `coarse`. Coarser
+/// lattices skip more HRIR interpolation — and the crossfade that goes with it
+/// — at a measurable cost in fidelity. Persisted to config.
+pub const CONTROL_BINAURAL_HRIR_UPDATE_LATTICE: &str =
+    "/omniphony/control/binaural/hrir_update_lattice";
 /// Generic setter for any declared live option (`renderer::options`):
 /// args `[key (string), value]`. The per-option addresses listed above
 /// (`synthetic_objects`, `object_generator`, `phantom_extract`,
@@ -287,6 +293,7 @@ pub const STATE_WRITE_TIME_MS: &str = "/omniphony/state/write_time_ms";
 
 pub const ALL_CONTROL: &[&str] = &[
     CONTROL_ADAPTIVE_RESAMPLING,
+    CONTROL_BINAURAL_HRIR_UPDATE_LATTICE,
     CONTROL_ADAPTIVE_RESAMPLING_ENABLE_FAR_MODE,
     CONTROL_ADAPTIVE_RESAMPLING_FAR_MODE_RETURN_FADE_IN_MS,
     CONTROL_ADAPTIVE_RESAMPLING_FORCE_SILENCE_IN_FAR_MODE,

--- a/omniphony-renderer/runtime_control/src/persist.rs
+++ b/omniphony-renderer/runtime_control/src/persist.rs
@@ -267,8 +267,13 @@ pub fn save_live_config_to_path(
             extra: Default::default(),
         }),
         air_absorption: Some(live.binaural.air_absorption),
+        // Written just below through its descriptor, so the skip-if-default
+        // rule lives in one place — this wholesale rebuild of the section runs
+        // *after* `store_live_to_config` and would otherwise clobber it.
+        hrir_update_lattice: None,
         extra: Default::default(),
     });
+    renderer::config_fields::hrir_update_lattice::store(render, live.binaural.hrir_update_lattice);
     // barycenter / experimental_distance params now live in the generic param bag
     // (`render.backend_params`, written below), so drop the legacy dedicated keys
     // on save. Reading an old config still migrates them into the bag on load.

--- a/omniphony-renderer/runtime_control/tests/live_options_conformance.rs
+++ b/omniphony-renderer/runtime_control/tests/live_options_conformance.rs
@@ -268,6 +268,7 @@ mod registry {
             ("synthetic_objects_enabled", RawOptionValue::Bool(true)),
             ("object_generator_id", RawOptionValue::Str("copy_up")),
             ("phantom_extract_mode", RawOptionValue::Str("spectral")),
+            ("hrir_update_lattice", RawOptionValue::Str("coarse")),
         ]
     }
 

--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "Senkrechte Projektion",
   "log.mpvOrenderEnabled": "orender in {path} aktiviert",
   "log.mpvOrenderDisabled": "orender in {path} auskommentiert",
-  "log.mpvOrenderFailed": "Änderung der mpv-Konfiguration fehlgeschlagen: {error}"
+  "log.mpvOrenderFailed": "Änderung der mpv-Konfiguration fehlgeschlagen: {error}",
+  "binaural.hrirUpdateLatticeLabel": "HRIR-Aktualisierung",
+  "binaural.hrirLattice.exact": "Exakt",
+  "binaural.hrirLattice.fine": "Fein",
+  "binaural.hrirLattice.balanced": "Ausgewogen",
+  "binaural.hrirLattice.coarse": "Grob",
+  "help.hrirUpdateLattice": "Wie weit sich ein Objekt drehen muss, bevor sein HRTF-Filter neu berechnet wird. „Exakt“ rechnet bei jeder Bewegung neu und ist bitgenau identisch mit „keine Optimierung“; gröbere Stufen lassen ein kaum bewegtes Objekt sein Filter behalten, was auf schwacher Hardware deutlich CPU spart, aber das Ergebnis verändert. Bleiben Sie bei „Exakt“, sofern Sie die Reserve nicht brauchen."
 }

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "Perpendicular projection",
   "log.mpvOrenderEnabled": "orender enabled in {path}",
   "log.mpvOrenderDisabled": "orender commented out in {path}",
-  "log.mpvOrenderFailed": "mpv config change failed: {error}"
+  "log.mpvOrenderFailed": "mpv config change failed: {error}",
+  "binaural.hrirUpdateLatticeLabel": "HRIR update",
+  "binaural.hrirLattice.exact": "Exact",
+  "binaural.hrirLattice.fine": "Fine",
+  "binaural.hrirLattice.balanced": "Balanced",
+  "binaural.hrirLattice.coarse": "Coarse",
+  "help.hrirUpdateLattice": "How far an object must turn before its HRTF filter is rebuilt. Exact rebuilds on any movement and is bit-identical to no optimisation; the coarser steps let a barely-moving object keep its filter, which costs noticeably less CPU on weak hardware but does alter the output. Leave on Exact unless you need the headroom."
 }

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "Proyección perpendicular",
   "log.mpvOrenderEnabled": "orender activado en {path}",
   "log.mpvOrenderDisabled": "orender comentado en {path}",
-  "log.mpvOrenderFailed": "Error al modificar la configuración de mpv: {error}"
+  "log.mpvOrenderFailed": "Error al modificar la configuración de mpv: {error}",
+  "binaural.hrirUpdateLatticeLabel": "Actualización HRIR",
+  "binaural.hrirLattice.exact": "Exacta",
+  "binaural.hrirLattice.fine": "Fina",
+  "binaural.hrirLattice.balanced": "Equilibrada",
+  "binaural.hrirLattice.coarse": "Gruesa",
+  "help.hrirUpdateLattice": "Cuánto debe girar un objeto antes de recalcular su filtro HRTF. «Exacta» recalcula con cualquier movimiento y es idéntica bit a bit a no optimizar; los pasos más gruesos permiten que un objeto casi inmóvil conserve su filtro, lo que ahorra bastante CPU en hardware modesto pero altera la salida. Mantén «Exacta» salvo que necesites el margen."
 }

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "Projection perpendiculaire",
   "log.mpvOrenderEnabled": "orender activé dans {path}",
   "log.mpvOrenderDisabled": "orender commenté dans {path}",
-  "log.mpvOrenderFailed": "Échec de la modification de la config mpv : {error}"
+  "log.mpvOrenderFailed": "Échec de la modification de la config mpv : {error}",
+  "binaural.hrirUpdateLatticeLabel": "Mise à jour HRIR",
+  "binaural.hrirLattice.exact": "Exacte",
+  "binaural.hrirLattice.fine": "Fine",
+  "binaural.hrirLattice.balanced": "Équilibrée",
+  "binaural.hrirLattice.coarse": "Grossière",
+  "help.hrirUpdateLattice": "De combien un objet doit tourner avant que son filtre HRTF soit recalculé. « Exacte » recalcule au moindre mouvement et donne un résultat strictement identique à l'absence d'optimisation ; les pas plus grossiers laissent un objet quasi immobile conserver son filtre, ce qui coûte nettement moins de CPU sur matériel modeste mais modifie la sortie. Restez sur « Exacte » sauf si vous manquez de marge."
 }

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "Proiezione perpendicolare",
   "log.mpvOrenderEnabled": "orender attivato in {path}",
   "log.mpvOrenderDisabled": "orender commentato in {path}",
-  "log.mpvOrenderFailed": "Modifica della configurazione di mpv non riuscita: {error}"
+  "log.mpvOrenderFailed": "Modifica della configurazione di mpv non riuscita: {error}",
+  "binaural.hrirUpdateLatticeLabel": "Aggiornamento HRIR",
+  "binaural.hrirLattice.exact": "Esatto",
+  "binaural.hrirLattice.fine": "Fine",
+  "binaural.hrirLattice.balanced": "Bilanciato",
+  "binaural.hrirLattice.coarse": "Grossolano",
+  "help.hrirUpdateLattice": "Di quanto deve ruotare un oggetto prima che il suo filtro HRTF venga ricalcolato. «Esatto» ricalcola a ogni movimento ed è identico bit per bit all'assenza di ottimizzazione; i passi più grossolani lasciano che un oggetto quasi fermo mantenga il filtro, con un risparmio di CPU notevole su hardware modesto ma alterando l'uscita. Lascia «Esatto» se non ti serve il margine."
 }

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "垂直投影",
   "log.mpvOrenderEnabled": "{path} で orender を有効化しました",
   "log.mpvOrenderDisabled": "{path} で orender をコメントアウトしました",
-  "log.mpvOrenderFailed": "mpv 設定の変更に失敗しました: {error}"
+  "log.mpvOrenderFailed": "mpv 設定の変更に失敗しました: {error}",
+  "binaural.hrirUpdateLatticeLabel": "HRIR の更新",
+  "binaural.hrirLattice.exact": "厳密",
+  "binaural.hrirLattice.fine": "細かい",
+  "binaural.hrirLattice.balanced": "標準",
+  "binaural.hrirLattice.coarse": "粗い",
+  "help.hrirUpdateLattice": "オブジェクトがどれだけ向きを変えたら HRTF フィルターを再計算するかを決めます。「厳密」はわずかな動きでも再計算し、最適化なしとビット単位で同一の結果になります。粗い段階ではほとんど動いていないオブジェクトがフィルターを保持するため、非力なハードウェアで CPU を大きく節約できますが、出力は変化します。余裕が必要でなければ「厳密」のままにしてください。"
 }

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "Projeção perpendicular",
   "log.mpvOrenderEnabled": "orender ativado em {path}",
   "log.mpvOrenderDisabled": "orender comentado em {path}",
-  "log.mpvOrenderFailed": "Falha ao alterar a configuração do mpv: {error}"
+  "log.mpvOrenderFailed": "Falha ao alterar a configuração do mpv: {error}",
+  "binaural.hrirUpdateLatticeLabel": "Atualização de HRIR",
+  "binaural.hrirLattice.exact": "Exata",
+  "binaural.hrirLattice.fine": "Fina",
+  "binaural.hrirLattice.balanced": "Equilibrada",
+  "binaural.hrirLattice.coarse": "Grossa",
+  "help.hrirUpdateLattice": "Quanto um objeto precisa girar antes de seu filtro HRTF ser recalculado. «Exata» recalcula a qualquer movimento e é idêntica bit a bit a não otimizar; os passos mais grossos deixam um objeto quase parado manter seu filtro, o que economiza bastante CPU em hardware modesto mas altera a saída. Mantenha «Exata» a menos que precise da folga."
 }

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -829,5 +829,11 @@
   "backendParamOption.size_to_spread_mode.projection_perpendicular": "垂直投影",
   "log.mpvOrenderEnabled": "已在 {path} 中启用 orender",
   "log.mpvOrenderDisabled": "已在 {path} 中注释掉 orender",
-  "log.mpvOrenderFailed": "修改 mpv 配置失败：{error}"
+  "log.mpvOrenderFailed": "修改 mpv 配置失败：{error}",
+  "binaural.hrirUpdateLatticeLabel": "HRIR 更新",
+  "binaural.hrirLattice.exact": "精确",
+  "binaural.hrirLattice.fine": "精细",
+  "binaural.hrirLattice.balanced": "均衡",
+  "binaural.hrirLattice.coarse": "粗略",
+  "help.hrirUpdateLattice": "对象需要转动多少角度才重新计算其 HRTF 滤波器。“精确”在任何移动时都重算，与不做优化的结果逐位一致；较粗的档位让几乎未移动的对象保留原滤波器，在性能较弱的硬件上可显著节省 CPU，但会改变输出。除非需要余量，否则请保持“精确”。"
 }

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -81,6 +81,15 @@ export function rendererPanelMarkup() {
                 </div>
                 <input id="binauralHeadRadius" type="range" min="5" max="15" step="0.1" value="8.75" style="width:100%;" />
               </div>
+              <div class="binaural-help-row" style="display:flex;align-items:center;justify-content:space-between;gap:0.4rem;">
+                <span style="font-size:0.65rem;color:#888;" data-i18n="binaural.hrirUpdateLatticeLabel" data-help-i18n="help.hrirUpdateLattice" data-help-anchor=".binaural-help-row">HRIR update</span>
+                <select id="binauralHrirUpdateLattice" class="form-select" data-option="hrir_update_lattice" style="font-size:0.7rem;padding:0.1rem 0.2rem;width:auto;">
+                  <option value="exact" data-i18n="binaural.hrirLattice.exact">Exact</option>
+                  <option value="fine" data-i18n="binaural.hrirLattice.fine">Fine</option>
+                  <option value="balanced" data-i18n="binaural.hrirLattice.balanced">Balanced</option>
+                  <option value="coarse" data-i18n="binaural.hrirLattice.coarse">Coarse</option>
+                </select>
+              </div>
               <div id="binauralPinnaControls" style="display:none;gap:0.3rem;">
                 <div class="binaural-help-row" style="display:flex;align-items:center;justify-content:space-between;gap:0.4rem;">
                   <span style="font-size:0.65rem;color:#888;" data-i18n="binaural.pinnaPreset" data-help-i18n="help.binaural.pinnaPreset" data-help-anchor=".binaural-help-row">Pinna preset (D)</span>


### PR DESCRIPTION
The binaural stage spent most of its time on work the arithmetic does not
require. Three commits, deliberately separated because they do not carry the
same risk: the first two change no output at all, the third offers a trade and
does not take it.

Numbers below are from the existing criterion benches on a Ryzen 9 9950X, at
**16 objects** — the operating point that matters, since a consumer immersive
stream carries at most 15 objects plus LFE. The block budget is 833 µs.

### 1. `3a13213` — the tap loop was latency-bound

The per-ear FIR walked its history *backwards* through a ring buffer, one wrap
test per tap, accumulating onto a single register. That binds the loop to FP
add/FMA latency (~4-7 cycles/tap) rather than throughput, and no vectoriser can
touch it.

The history is now linear and double-written (each input at `pos` and
`pos + HRIR_LEN`), so the live window is always a contiguous ascending slice;
the kernel is stored reversed to match, and the accumulation is split across 8
explicit partial sums.

The split has to be written in the source: `f32` addition is not associative,
so no compiler will re-associate a reduction without fast-math, on any target.
That matters most for the embedded target of #220 — the CoreELEC images for its
Amlogic SoC run a 32-bit ARM userspace, where Rust exposes no stable NEON
intrinsics and AArch32's non-IEEE flush-to-zero makes LLVM more conservative
still, so this is the only vectorisation-shaped win reachable there at all.

| | before | after |
|---|---|---|
| static direct | 62.6 µs | **17.2 µs** (−72 %) |
| static cascaded | 49.1 µs | 17.5 µs (−64 %) |
| moving direct | 71.9 µs | 49.9 µs (−31 %) |

At 118 objects, 462 → 127 µs static. The `moving` case gains least because the
old crossfade path already had two accumulators, so it was accidentally
enjoying the parallelism this commit makes explicit.

**Output moves only by re-association**: the binaural golden reads a peak
residual of −118.5 dBFS (rms −133.3) — below the −109.8 dBFS of cross-host FP
noise the gate was dimensioned for, and ~100 dB under any behavioural change.
The goldens are unchanged.

### 2. `fcbaa6c` — the HRIR was rebuilt for a move of a hundredth of a degree

Per block and per object the path interpolated a fresh HRIR pair (a bilinear
blend of four 1 KB pairs gathered from a ~700 KB table), then compared the
result against the convolvers' kernels to discover whether anything had moved.
When nothing had, both costs were waste — and since the tap loop got faster,
that waste is what is left.

The direction each channel's kernels were built from is now cached. The key
carries the very angles fed to `at()`, so "same key ⇒ same kernel" holds by
construction, and it is tagged with a grid generation because a live HRIR
source switch replaces the dataset underneath and a bare direction would
otherwise match across two different sets and freeze stale kernels in place.

static direct 18.2 → **15.5 µs**, static cascaded 18.0 → 16.7 µs. Bit-exact;
goldens untouched.

### 3. `57fcf76` — the update lattice, offered but not chosen

Snapping directions onto a lattice lets a barely-moving object keep its kernel,
which also leaves no crossfade armed and halves that block's tap loop. This is
a **quality/cost trade, not a free optimisation**, so it ships as a live option
(`render.binaural.hrir_update_lattice`) defaulting to the exact behaviour:

| setting | lattice | peak residual | drifting/16 |
|---|---|---|---|
| `exact` *(default)* | — | bit-exact | 49.3 µs |
| `fine` | 0.020° | −53.3 dBFS | 47.5 µs |
| `balanced` | 0.078° | −43.9 dBFS | 35.1 µs |
| `coarse` | 0.313° | −30.9 dBFS | 20.8 µs |

No useful setting comes near the −100 dBFS gate: once an approximate kernel is
tolerated, the residual lands between −30 and −53 dBFS. The argument for
`coarse` is that the measured grid is sampled every 10°, so a 0.31° lattice is
still 32× finer than the data it draws from — below it we interpolate
measurement noise. But that is an argument, not a listening test, and the
residual is 88 dB above the one commit 1 produced. **Nobody has listened to any
of this yet.**

One registry row carries the option: OSC, persistence, CLI/FFI seeding, the
snapshot block and the published schema all derive from it, and the Studio
control is markup with `data-option` and no JavaScript. The conformance net
drove the work — it flagged the missing OSC catalogue entry and the missing
round-trip sample.

### A bench that was measuring the wrong thing

`move_events` redraws every object position at random each block. That is not
motion, it is teleportation, and no stream produces it — but it makes direction
coherence structurally unmeasurable, so it reports no gain for work real
content benefits from.

`drift_events` and a `render_binaural_drifting` group sweep objects at
12-96 °/s instead. It shows the problem plainly: **before these commits,
drifting 0.01° per block cost 49.3 µs — exactly the price of crossing the
room.** Read `drifting` for the expected case and `moving` as the pathological
bound.

### Verification

Full workspace test suite green, `fmt --check` clean, clippy clean on the
touched files, live-options conformance net 10/10, options-schema gate OK, i18n
parity unchanged (8 locales populated). The Studio control was exercised in the
dev server: it renders, resolves its i18n, and emits
`control_option { key: "hrir_update_lattice", value: "coarse" }`.

Not verified: **anything by ear**, and anything on the embedded target — no
measurement has ever been taken on the AM6B+, so the case for these changes
there rests on extrapolation from x86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)