### PR TITLE
perf(renderer): stop paying for the speaker output stage per sample

### DIFF
--- a/omniphony-renderer/renderer/src/delay_line.rs
+++ b/omniphony-renderer/renderer/src/delay_line.rs
@@ -59,6 +59,25 @@ impl DelayLine {
         self.target == 0.0 && self.current == 0.0
     }
 
+    /// Keep the ring warm without doing the fractional read.
+    ///
+    /// While [`is_bypass`](Self::is_bypass) holds, `process` reduces to the
+    /// identity: the read pointer sits exactly on the write position with a
+    /// zero fractional part, so the interpolation returns `input` unchanged.
+    /// A caller that has already checked `is_bypass` can skip to the write —
+    /// but it must still *do* the write, or the history is missing when a
+    /// non-zero delay is set later and the ramp starts reading behind the
+    /// write pointer.
+    #[inline]
+    pub fn push_history(&mut self, input: f32) {
+        debug_assert!(
+            self.is_bypass(),
+            "push_history is only the identity while bypassed",
+        );
+        self.buf[self.write_pos] = input;
+        self.write_pos = (self.write_pos + 1) % self.buf.len();
+    }
+
     /// Process one sample through the delay line.
     ///
     /// Write `input` into the buffer, ramp the read pointer one step toward the

--- a/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
@@ -92,6 +92,18 @@ pub(super) struct SpeakerStageDiagnostics {
     pub(super) crossover_elapsed: std::time::Duration,
 }
 
+/// Scale-accumulate one band's speaker gains onto a single output frame.
+///
+/// Kept as a slice-to-slice loop rather than index arithmetic: it is the one
+/// shape in this loop nest that carries no bounds check and no reduction, so a
+/// compiler is free to widen it. Every ramp arm funnels through here.
+#[inline(always)]
+fn accumulate_band(out_frame: &mut [f32], gains: &[f32], sample: f32) {
+    for (out, &gain) in out_frame.iter_mut().zip(gains.iter()) {
+        *out += sample * gain;
+    }
+}
+
 impl SpeakerRenderStage {
     /// Fill `out` with one full-size `Gains` per render band at `position`. Uses
     /// the unified multi-band table (one cell localisation for all bands) when
@@ -344,11 +356,13 @@ impl SpeakerRenderStage {
                             crossover_elapsed += started_at.elapsed();
                             for sample_idx in 0..sample_length {
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = self.crossover_band_scratch[b][sample_idx];
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(
+                                        out_frame,
+                                        gains,
+                                        self.crossover_band_scratch[b][sample_idx],
+                                    );
                                 }
                             }
                         } else {
@@ -362,11 +376,9 @@ impl SpeakerRenderStage {
                                     fst.as_mut().map(|v| v.as_mut_slice()),
                                 );
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = split.get(b);
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(out_frame, gains, split.get(b));
                                 }
                             }
                         }
@@ -405,11 +417,13 @@ impl SpeakerRenderStage {
                             crossover_elapsed += started_at.elapsed();
                             for sample_idx in 0..sample_length {
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = self.crossover_band_scratch[b][sample_idx];
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(
+                                        out_frame,
+                                        gains,
+                                        self.crossover_band_scratch[b][sample_idx],
+                                    );
                                 }
                             }
                         } else {
@@ -423,11 +437,9 @@ impl SpeakerRenderStage {
                                     fst.as_mut().map(|v| v.as_mut_slice()),
                                 );
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = split.get(b);
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(out_frame, gains, split.get(b));
                                 }
                             }
                         }
@@ -481,11 +493,13 @@ impl SpeakerRenderStage {
                                     last_size = size;
                                 }
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = self.crossover_band_scratch[b][sample_idx];
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(
+                                        out_frame,
+                                        gains,
+                                        self.crossover_band_scratch[b][sample_idx],
+                                    );
                                 }
                                 state.ramp.commit_output_position();
                                 state.ramp.advance_ramp(1);
@@ -529,11 +543,9 @@ impl SpeakerRenderStage {
                                     fst.as_mut().map(|v| v.as_mut_slice()),
                                 );
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = split.get(b);
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(out_frame, gains, split.get(b));
                                 }
                                 state.ramp.commit_output_position();
                                 state.ramp.advance_ramp(1);
@@ -600,11 +612,13 @@ impl SpeakerRenderStage {
                                     }
                                 }
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = self.crossover_band_scratch[b][sample_idx];
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(
+                                        out_frame,
+                                        gains,
+                                        self.crossover_band_scratch[b][sample_idx],
+                                    );
                                 }
                             }
                         } else {
@@ -627,11 +641,9 @@ impl SpeakerRenderStage {
                                     fst.as_mut().map(|v| v.as_mut_slice()),
                                 );
                                 let out_base = sample_idx * self.num_speakers;
+                                let out_frame = &mut output[out_base..out_base + self.num_speakers];
                                 for (b, gains) in band_gains.iter().enumerate() {
-                                    let s = split.get(b);
-                                    for (spk, &g) in gains.iter().enumerate() {
-                                        output[out_base + spk] += s * g;
-                                    }
+                                    accumulate_band(out_frame, gains, split.get(b));
                                 }
                             }
                         }
@@ -789,19 +801,40 @@ impl SpeakerRenderStage {
 
         // Apply per-speaker gains and delay lines, and detect peak (tracking which
         // speaker channel held the peak, for clip reporting).
-        let sample_length = output.len() / self.num_speakers.max(1);
+        //
+        // Speaker-major, not sample-major: a sample-major walk touches all N
+        // delay rings once per sample, so N × 100 ms of ring buffer is cycled
+        // through the cache every block. One speaker at a time keeps a single
+        // ring hot, and lifts both the bypass test and the peak comparison out
+        // of the per-sample loop.
+        let num_speakers = self.num_speakers;
+        let sample_length = output.len() / num_speakers.max(1);
         let mut peak_sample: f32 = 0.0;
         let mut peak_speaker_idx: usize = 0;
-        for sample_idx in 0..sample_length {
-            for speaker_idx in 0..self.num_speakers {
-                let s = &mut output[sample_idx * self.num_speakers + speaker_idx];
-                *s *= speaker_total_gains[speaker_idx];
-                *s = self.delay_lines[speaker_idx].process(*s);
-                let a = s.abs();
-                if a > peak_sample {
-                    peak_sample = a;
-                    peak_speaker_idx = speaker_idx;
+        for (speaker_idx, delay_line) in self.delay_lines.iter_mut().enumerate().take(num_speakers)
+        {
+            let gain = speaker_total_gains[speaker_idx];
+            let mut peak: f32 = 0.0;
+            // Zero delay is the common case (no per-speaker delay configured),
+            // and there `process` is the identity — but it still pays for a
+            // float remainder and an interpolated read per sample.
+            if delay_line.is_bypass() {
+                for sample_idx in 0..sample_length {
+                    let s = &mut output[sample_idx * num_speakers + speaker_idx];
+                    *s *= gain;
+                    delay_line.push_history(*s);
+                    peak = peak.max(s.abs());
                 }
+            } else {
+                for sample_idx in 0..sample_length {
+                    let s = &mut output[sample_idx * num_speakers + speaker_idx];
+                    *s = delay_line.process(*s * gain);
+                    peak = peak.max(s.abs());
+                }
+            }
+            if peak > peak_sample {
+                peak_sample = peak;
+                peak_speaker_idx = speaker_idx;
             }
         }
         (peak_sample, peak_speaker_idx)


### PR DESCRIPTION
Follow-up to the profiling reported in #220.

## `finalize_output`

It walked the interleaved buffer sample-major, so every sample touched all N delay rings in turn and cycled N × 100 ms of ring buffer through the cache each block. It also re-tested the peak and re-entered `DelayLine::process` per sample per speaker — and `process` costs a float remainder plus an interpolated read even when the delay is zero, which is the default, and is the one case `is_bypass` was written for and never wired to.

Walking speaker-major keeps one ring hot for a whole block and lifts both the bypass test and the peak comparison out of the inner loop. A bypassed line only has to keep its history warm (new `DelayLine::push_history`), which is what `process` reduces to there anyway.

## `mix_channels`

The eight copies of the band accumulation indexed `output[out_base + spk]` through a bounds check per speaker. They now share one `accumulate_band` helper over a frame subslice: no bounds check, no reduction, and a shape a compiler is free to widen.

## Measured

`render_steady`, Ryzen 9 9950X, 7.1.4, 40-sample blocks:

| objects | before | after | delta |
|---|---|---|---|
| 1 | 2.360 µs | 0.697 µs | **-70.5%** |
| 8 | 3.813 µs | 1.866 µs | **-51.1%** |
| 16 | 5.555 µs | 3.206 µs | **-42.3%** |
| 32 | 8.927 µs | 5.869 µs | **-34.3%** |
| 64 | 15.690 µs | 11.303 µs | **-28.0%** |
| 118 | 26.991 µs | 20.678 µs | **-23.4%** |

The output stage cost is fixed per block, so the saving is roughly constant and matters most where the object count is low — which is where Atmos actually sits.

## Exactness

Neither change touches per-element arithmetic, and the reordering is a max reduction. The `speaker_714_32obj`, `crossover_bands` and `partial_metadata` goldens all come back at **-inf dBFS residual** — bit identical, not merely under the gate. (The binaural golden sits at its existing -118.5 dBFS from #226, untouched here.)

One behavioural note: `peak_speaker_idx` now breaks exact ties toward the lower speaker index rather than the earlier sample. It only feeds clip reporting, and an exact cross-speaker tie needs identical channels.

## Why this matters for #220

The reporter concluded that the renderer half of the armv7/aarch64 gap was not ours to fix, on the reading that `mix_channels`, `finalize_output` and `vbap3d` are float code that vectorises on aarch64 and cannot on armv7. That reading does not hold: `vbap3d` is not in the per-block path at all (it runs during gain-table generation), and the other two do not vectorise on **any** architecture — a per-sample call into a fractional delay line and a per-sample crossover dispatch block it everywhere. Which is good news: the win above is structural and portable, so it lands on armv7 as fully as on x86.

Unrelated, found while validating: `binaural::validation::itd_magnitude_tracks_the_model` and `itd_magnitude_grows_toward_the_interaural_axis` fail roughly one full-suite run in three and never in isolation. Reproduced on pristine `main` at cb1239f, so it predates this branch.