### PR TITLE
Studio UI polish: select styling, button row heights, gauge alignment, band-coloured speakers

### DIFF
--- a/omniphony-studio/src/controls/diag-plot.js
+++ b/omniphony-studio/src/controls/diag-plot.js
@@ -313,7 +313,7 @@ function buildWindowSelector() {
   lbl.style.fontSize = '10px';
   wrap.appendChild(lbl);
   const sel = document.createElement('select');
-  sel.style.cssText = 'font-size:10px;background:rgba(255,255,255,0.06);color:#d9ecff;border:1px solid rgba(255,255,255,0.15);border-radius:4px;padding:0.1rem 0.25rem;';
+  sel.className = 'micro-select';
   for (const ms of WINDOW_OPTIONS_MS) {
     const opt = document.createElement('option');
     opt.value = String(ms);
@@ -347,7 +347,7 @@ function buildDiagRateSelector() {
   wrap.appendChild(lbl);
   const sel = document.createElement('select');
   sel.title = 'Diag publish rate (Hz) — independent from the audio meter rate. Higher = more plot resolution, more network/CPU.';
-  sel.style.cssText = 'font-size:10px;background:rgba(255,255,255,0.06);color:#d9ecff;border:1px solid rgba(255,255,255,0.15);border-radius:4px;padding:0.1rem 0.25rem;';
+  sel.className = 'micro-select';
   for (const hz of DIAG_RATE_OPTIONS_HZ) {
     const opt = document.createElement('option');
     opt.value = String(hz);

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -50,7 +50,7 @@
            scroll. The overlay is position:fixed over the canvas, so this row
            never changes the 3D viewport geometry. -->
       <div id="profileRow">
-        <select id="profileSelect" class="form-select" style="font-size:0.75rem;padding:0.1rem 0.2rem;flex:1 1 auto;min-width:0" data-i18n-title="profiles.selectTitle" title="Config profile"></select>
+        <select id="profileSelect" class="form-select" style="flex:1 1 auto;min-width:0" data-i18n-title="profiles.selectTitle" title="Config profile"></select>
         <button id="profileCreateBtn" type="button" class="panel-toggle-btn" data-i18n-title="profiles.create" title="New profile"><span>+</span></button>
         <button id="profileRenameBtn" type="button" class="panel-toggle-btn" data-i18n-title="profiles.rename" title="Rename profile"><span>✎</span></button>
         <button id="profileDeleteBtn" type="button" class="panel-toggle-btn" data-i18n-title="profiles.delete" title="Delete profile"><span>✕</span></button>
@@ -518,7 +518,7 @@
           <div style="margin-top:0.25rem;padding:0.4rem 0.5rem;border:1px solid rgba(255,255,255,0.08);border-radius:8px;background:rgba(255,255,255,0.03);display:grid;gap:0.35rem">
             <div class="inline-toggle" id="drcControlRow" style="margin-top:0; display:none;">
               <div data-i18n="input.drc" data-help-i18n="help.drc.mode">DRC</div>
-              <select id="drcModeSelect" class="form-select" style="font-size:0.75rem; padding:0.1rem 0.2rem; width:auto; min-width:80px;"></select>
+              <select id="drcModeSelect" class="form-select" style="width:auto; min-width:80px;"></select>
             </div>
             <div id="drcWeightRow" style="display:none;">
               <div style="font-size: 0.65rem; color: #888; margin-bottom: 0.15rem; display: flex; justify-content: space-between;">
@@ -560,7 +560,7 @@
           <select
             id="oscMeteringRateSelect"
             title="Audio meter publish rate (Hz) — drives the level meters only. Diag publication has its own rate in the diag plot controls."
-            style="font-size:11px;background:rgba(255,255,255,0.06);color:#d9ecff;border:1px solid rgba(255,255,255,0.18);border-radius:4px;padding:0.1rem 0.25rem;margin-left:auto"
+            style="margin-left:auto"
           >
             <option value="10">10 Hz</option>
             <option value="20">20 Hz</option>

--- a/omniphony-studio/src/scene/speaker-band-bars.js
+++ b/omniphony-studio/src/scene/speaker-band-bars.js
@@ -45,7 +45,8 @@ export function bandColor(index, count) {
 // Index of the band a speaker belongs to within `edges` (= [0, ...cutoffs,
 // Infinity]). A band starts at the speaker's lower cutoff (freqLow, or 0 for a
 // full-/low-pass), which uniquely identifies the band in a crossover layout.
-function speakerBandIndex(speaker, edges) {
+// Exported so the speaker cubes can take the same band colour as this gauge.
+export function speakerBandIndex(speaker, edges) {
   if (!Array.isArray(edges) || edges.length < 2) return 0;
   const lo = Number(speaker?.freqLow) > 0 ? Number(speaker.freqLow) : 0;
   for (let i = 0; i < edges.length - 1; i += 1) {

--- a/omniphony-studio/src/sources.js
+++ b/omniphony-studio/src/sources.js
@@ -895,7 +895,12 @@ export function updateSpeakerColorsFromSelection() {
 
   speakerMeshes.forEach((mesh, index) => {
     const mix = gainToMix(gains?.[index]);
-    mesh.material.color.copy(speakerBaseColor).lerp(speakerHotColor, mix);
+    // Per-speaker base colour when the layout has a crossover split (set by
+    // applySpeakerBandBaseColor, so the cube matches its band gauge); the
+    // shared blue otherwise, which is also what a single-band layout resolves
+    // to. Hot blending and the selection override still apply on top.
+    const base = mesh.userData.baseColor ?? speakerBaseColor;
+    mesh.material.color.copy(base).lerp(speakerHotColor, mix);
     if (app.selectedSpeakerIndex !== null && index === app.selectedSpeakerIndex) {
       mesh.material.color.copy(speakerSelectedColor);
     }

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -97,7 +97,12 @@ import {
 import { updateHeadphoneControlsUI } from './controls/headphone-meter.js';
 
 import { createLabelSprite, setLabelSpriteText, updateSpeakerLabelsFromSelection } from './scene/labels.js';
-import { createSpeakerBandBar, updateSpeakerBandBar, bandColor } from './scene/speaker-band-bars.js';
+import {
+  createSpeakerBandBar,
+  updateSpeakerBandBar,
+  bandColor,
+  speakerBandIndex
+} from './scene/speaker-band-bars.js';
 import { syncCrossoverBandSelects } from './scene/speaker-band-select.js';
 import { refreshGaintableSubscription } from './scene/speaker-gaintable.js';
 
@@ -1043,6 +1048,31 @@ export function setSpeakerSpatializeLocal(index, spatialize) {
   renderSpeakerEditor();
 }
 
+// Give the speaker cube the colour of its crossover band, so a multi-band
+// layout reads in the 3D view the same way the band gauges already do. Stored
+// as the mesh's base colour rather than written to the material directly:
+// updateSpeakerColorsFromSelection() blends from it towards the hot colour and
+// overrides it entirely on selection, so writing the material here would be
+// undone on the next meter tick.
+//
+// With a single band bandColor() returns the full-band blue, which is exactly
+// speakerMaterial's own default — so a layout with no crossover split keeps
+// looking as it did, without needing a branch here.
+//
+// The colour object is reused: this runs for every speaker on every crossover
+// edit, and the palette lookup is a string, so re-parsing into a fresh
+// THREE.Color each time would churn for nothing.
+function applySpeakerBandBaseColor(mesh, speaker, edges) {
+  if (!mesh) return;
+  const bandCount = Array.isArray(edges) ? edges.length - 1 : 1;
+  const style = bandColor(speakerBandIndex(speaker, edges), bandCount);
+  if (mesh.userData.baseColor) {
+    mesh.userData.baseColor.setStyle(style);
+  } else {
+    mesh.userData.baseColor = new THREE.Color().setStyle(style);
+  }
+}
+
 export function updateSpeakerVisualsFromState(index) {
   const currentLayoutSpeakers = get_currentLayoutSpeakers();
   const selectedSpeakerIndex = get_selectedSpeakerIndex();
@@ -1565,6 +1595,10 @@ export function renderSpeakersList() {
     if (bandBar) {
       updateSpeakerBandBar(bandBar, speaker, bandEdges);
     }
+    // Same dependency as the gauge, so the cube follows the same edits. A
+    // cutoff change reaches us here: bindSpeakerFrequencyInput re-renders this
+    // list precisely so the crossover readouts refresh.
+    applySpeakerBandBaseColor(speakerMeshes[index], speaker, bandEdges);
     speakersListEl.appendChild(entry.root);
   });
   speakerItems.forEach((entry, id) => {
@@ -1573,6 +1607,9 @@ export function renderSpeakersList() {
       speakerItems.delete(id);
     }
   });
+  // Push the base colours just set onto the materials; on its own
+  // applySpeakerBandBaseColor only records them.
+  updateSpeakerColorsFromSelection();
   updateSectionProportions();
 }
 
@@ -2337,6 +2374,9 @@ export function renderLayout(key) {
     scene.add(bandBar);
     speakerBandBars.push(bandBar);
 
+    // Seed the cube's band colour; the updateSpeakerColorsFromSelection() after
+    // this loop is what writes it to the materials.
+    applySpeakerBandBaseColor(mesh, speaker, bandEdges);
     applySpeakerLevel(mesh, speakerLevels.get(String(index)));
   });
 

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -1455,8 +1455,14 @@
         gap: 0.18rem;
       }
 
-      #objectsList,
-      #speakersList {
+      /* #speakersList used to share this gutter, from when these lists scrolled
+         themselves. It no longer does: #speakersOverlayScroll is the scroll
+         container and already reserves the bar (its own padding, plus the width
+         a thin scrollbar takes out of layout). The leftover padding stopped the
+         speaker rows 9.6px short of the right edge while the headphone rows in
+         the very same container reached it, so the two gauge blocks failed to
+         line up in virtual-room mode, where both are shown. */
+      #objectsList {
         padding-right: 0.6rem;
         box-sizing: border-box;
       }

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -4,6 +4,10 @@
         --panel-open-max-height-large: min(52vh, 520px);
         --panel-width-left: min(440px, 92vw);
         --panel-width-right: min(440px, 92vw);
+        /* Select chevron, held in one place because several field classes set
+           the `background` shorthand — which resets background-image — and so
+           have to restore it explicitly. */
+        --select-chevron: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6" viewBox="0 0 10 6" fill="none"><path d="M1 1l4 4 4-4" stroke="%23d9ecff" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>');
       }
 
       body {
@@ -635,13 +639,10 @@
       }
 
       .log-panel-level select {
+        /* Shell comes from the shared `select` rule; only the width is local.
+           It used to hand-roll a pill variant, which left no room for the
+           chevron and made this the one select with a different radius. */
         min-width: 6.8rem;
-        background: rgba(255, 255, 255, 0.08);
-        border: 1px solid rgba(255, 255, 255, 0.18);
-        color: #d9ecff;
-        border-radius: 999px;
-        padding: 0.2rem 0.55rem;
-        font-size: 12px;
       }
 
       .log-panel-filter {
@@ -1702,6 +1703,92 @@
       .delay-input:focus {
         outline: none;
         border-color: rgba(255, 255, 255, 0.45);
+      }
+
+      /* Selects were left native: the platform default is a 13.3px font on an
+         opaque grey chrome with a platform chevron, which reads taller and
+         heavier than the 12px translucent text fields sitting next to it.
+         Give them the same shell as .delay-input and the OSC inputs, and draw
+         our own chevron so the control keeps one predictable height across
+         WebKitGTK, WebView2 and WKWebView instead of three different ones. */
+      select {
+        box-sizing: border-box;
+        appearance: none;
+        -webkit-appearance: none;
+        font-family: inherit;
+        font-size: 12px;
+        /* An explicit ratio, not `normal`: a select resolves `normal` taller
+           than an input does, so the two would not line up on the same row.
+           1.2 + the padding below lands the box on the inputs' 20px. */
+        line-height: 1.2;
+        color: #d9ecff;
+        background-color: rgba(255, 255, 255, 0.08);
+        /* Chevron drawn as a background image, so it never becomes a separate
+           hit target that could swallow the click that opens the popup. */
+        background-image: var(--select-chevron);
+        background-repeat: no-repeat;
+        background-position: right 0.45rem center;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 6px;
+        /* Right padding reserves the chevron lane so long option labels stop
+           before it instead of running underneath. */
+        padding: 0.125rem 1.35rem 0.125rem 0.4rem;
+        cursor: pointer;
+        /* Same WebKitGTK first-click guard as the buttons: a drag on the label
+           text must not start a text selection instead of opening the popup. */
+        -webkit-user-select: none;
+        user-select: none;
+      }
+
+      select:hover:not(:disabled) {
+        background-color: rgba(255, 255, 255, 0.12);
+        border-color: rgba(255, 255, 255, 0.32);
+      }
+
+      select:focus-visible {
+        outline: none;
+        border-color: rgba(255, 255, 255, 0.45);
+      }
+
+      select:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      /* The popup list is drawn by the platform, which does not inherit the
+         control's colours — without this it falls back to grey-on-grey. */
+      select option {
+        background-color: #12141c;
+        color: #d9ecff;
+      }
+
+      /* Compact variant: the renderer and input panels pair selects with
+         .delay-input text fields on the same row, at 11px. Those inputs come
+         out at 16.8px, so this trims the vertical padding to land there too —
+         the default padding above is tuned for the 12px/20px pairing. */
+      select.delay-input {
+        padding-top: 1px;
+        padding-bottom: 1px;
+        /* .delay-input sets the `background` shorthand, which wipes the chevron
+           set above — and since a class outranks the bare `select` selector,
+           these would end up with no dropdown affordance at all. */
+        background-image: var(--select-chevron);
+        background-repeat: no-repeat;
+        background-position: right 0.4rem center;
+        /* Same reason: .delay-input is a 52px right-aligned numeric field. A
+           select shows a word, and its width comes from the panel rules. */
+        text-align: left;
+      }
+
+      /* Densest variant: the diag-plot strip sets 10px selects beside 10px
+         labels inside a bordered pill, so the chevron lane tightens to match.
+         These used to carry an inline `background:` shorthand, which reset the
+         chevron image while `appearance: none` still removed the native one —
+         leaving a select with no affordance at all. */
+      select.micro-select {
+        font-size: 10px;
+        padding: 1px 1.05rem 1px 0.3rem;
+        background-position: right 0.32rem center;
       }
 
       .input-panel-shell {

--- a/omniphony-studio/src/styles/app.css
+++ b/omniphony-studio/src/styles/app.css
@@ -433,6 +433,28 @@
         cursor: pointer;
       }
 
+      /* Buttons sharing a row must agree on height. A label that wraps to two
+         lines grows its own button, and with the row on `align-items: center`
+         the others stayed at their one-line height — e.g. the layout row came
+         out 20 / 33.6 / 33.6 / 28.8px.
+
+         `align-self` fixes that from the button rather than the row: it
+         overrides the container's align-items, so none of the four affected
+         rows (three are anonymous divs carrying inline styles) has to change.
+         It is inert outside flex and grid, and it does not inflate anything on
+         its own — a row where no label wraps keeps the compact height, because
+         every button then measures the same. The inline-flex centring is what
+         keeps a one-line label vertically centred inside a stretched button
+         instead of riding at the top. */
+      .ui-btn,
+      .toggle-btn {
+        align-self: stretch;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+
       .ui-btn-primary {
         background: rgba(255,255,255,0.1);
         border-color: rgba(255,255,255,0.25);

--- a/omniphony-studio/src/ui/audio-panel.js
+++ b/omniphony-studio/src/ui/audio-panel.js
@@ -255,7 +255,7 @@ export function audioPanelMarkup() {
               </div>
               <div id="adaptiveControlSmoothingOrderRow" class="control-row" style="margin-top:0.2rem">
                 <label for="adaptiveControlSmoothingOrderSelect" style="font-size:12px;white-space:nowrap" data-i18n="adaptive.controlSmoothingOrder" data-help-i18n="help.adaptive.controlSmoothingOrder">IIR order</label>
-                <select id="adaptiveControlSmoothingOrderSelect" style="font-size:11px;background:rgba(255,255,255,0.06);color:#d9ecff;border:1px solid rgba(255,255,255,0.18);border-radius:4px;padding:0.1rem 0.25rem">
+                <select id="adaptiveControlSmoothingOrderSelect">
                   <option value="1" data-i18n="adaptive.controlSmoothingOrder.opt1">1 (single pole, 6 dB/oct)</option>
                   <option value="2" data-i18n="adaptive.controlSmoothingOrder.opt2">2 (Butterworth, 12 dB/oct)</option>
                 </select>

--- a/omniphony-studio/src/ui/renderer-panel.js
+++ b/omniphony-studio/src/ui/renderer-panel.js
@@ -9,7 +9,7 @@ export function rendererPanelMarkup() {
             <div class="panel-header-main">
             <div class="info-title panel-title" data-i18n="section.renderer">Renderer</div>
             <div style="display:flex;gap:0.25rem;flex:0 0 auto;margin-left:auto">
-              <select id="outputModeSelect" class="form-select" style="font-size:0.75rem;padding:0.1rem 0.2rem;width:auto;" data-i18n-title="outputMode.selectTitle" title="Output mode">
+              <select id="outputModeSelect" class="form-select" style="width:auto;" data-i18n-title="outputMode.selectTitle" title="Output mode">
                 <option value="speaker" data-i18n="outputMode.speakers">Speakers</option>
                 <option value="binaural-direct" data-i18n="outputMode.headphones">Headphones</option>
                 <option value="binaural-cascaded" data-i18n="outputMode.headphonesVirtual">Headphones (virtual room)</option>


### PR DESCRIPTION
Four independent Studio fixes found while going over the interface. Frontend only — no Rust touched.

## 1. Selects had no styling at all

They were left native everywhere: the platform default is a 13.3px font on an opaque grey chrome (`rgb(107,107,107)`, grey text) with a platform chevron, next to 12px translucent text fields with a 6px radius. That is what made the combos read as both taller and older than the rest of the panel.

One shared `select` rule now models them on `.delay-input` and the OSC inputs, with the chevron drawn as a background image so it never becomes a separate hit target. Two size variants follow the fields they sit beside: `.delay-input` for the 11px renderer/input panels, `.micro-select` for the 10px diag strip.

Measured in the running frontend, selects now land exactly on the inputs:

| Family | Selects | Text inputs |
|---|---|---|
| 11px | 16.8px × 14 | 16.8px × 37 |
| 12px | 20.0px × 11 | 20.0px × 3 |

Two traps, both the same shape — a `background` shorthand resetting `background-image` while `appearance: none` had already removed the native arrow, leaving a select with **no affordance at all**:

- `.delay-input` sets that shorthand and, being a class, outranks the bare `select` selector; 18 selects lost their chevron until the variant restored it. The chevron now lives in a `--select-chevron` custom property so there is one copy to restore.
- `diag-plot.js` set the same shorthand through `style.cssText`.

Five call sites hand-rolled a near-identical look inline (profile, DRC, metering rate, output mode, IIR order); those declarations are redundant now and were removed, keeping only their layout parts.

## 2. Button rows split heights when a label wrapped

A button whose label wrapped to two lines grew on its own while its neighbours stayed at their one-line height. The speaker layout row came out 20 / 33.6 / 33.6 / 28.8px.

`align-self: stretch` on `.ui-btn` and `.toggle-btn` fixes it from the button rather than the row, so none of the four affected rows has to change — three are anonymous divs carrying inline styles. It equalises without inflating: a row where no label wraps keeps the compact height, since every button then measures the same.

Verified both ways: short labels → 20px across; real labels → 33.6px across.

Deliberately scoped to the text buttons. Two rows still pair an `.info-icon-btn` with a `.panel-toggle-btn` (17 vs 19.2px, 18 vs 20.8px) — two icon-button sizes, not a wrapping artefact.

## 3. Speaker gauges did not line up with the headphone gauges

In virtual-room mode both groups are stacked in one section, and the speaker rows stopped 9.6px short of the right edge while the headphone rows reached it.

`#speakersList` shared a `padding-right: 0.6rem` with `#objectsList`, left over from when these lists scrolled themselves. They no longer do — `#speakersOverlayScroll` is the scroll container and already reserves the bar. `#hpChannelsList` sits in that same container with no such padding, which is what made the mismatch visible. `#objectsList` keeps the rule.

Before: speaker row right edge 1095.2px against the headphone rows' 1104.8px. After: both rows and both M/S columns land on the same edge.

## 4. 3D speakers are now coloured by their crossover band

With a multi-band layout every cube was the same blue, though the frequency-extent gauge floating beside it was already colour coded. The cube now takes its own band colour, from the same palette.

Recorded as the mesh's base colour rather than written to the material: `updateSpeakerColorsFromSelection()` blends from that base towards the hot colour and overrides it for the selected speaker, so a direct write would be undone on the next pass.

No branch on band count is needed — `bandColor()` already returns the full-band blue for a single band, and that is exactly `speakerMaterial`'s default. Verified in the browser that `setStyle('#8ec8ff')` and `new THREE.Color(0x8ec8ff)` resolve identically under three's colour management, so a layout with no crossover split is untouched.

Verified end to end with a three-band probe layout: cubes come out `db5743` / `43db61` / `6b43db`, matching `bandColor(0..2, 3)`; a flat layout stays `8ec8ff` everywhere; selecting still overrides to `4dff88` and deselecting restores the band colour.

## Verification

`vite build` clean and i18n parity green (8 locales) on each commit. Measurements above were taken against the running dev frontend.

Two things this could not cover, both worth a pass in the real shell:

- **WebKitGTK popup rendering** for the restyled selects — the Chrome preview does not reproduce its behaviour, and that is exactly where first-click problems hide.
- The band-colour and gauge-alignment checks used layouts **injected through the app's own modules**, since no renderer is connected to the dev frontend. The wiring is exercised, but not the path from a real engine-sent layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)