### PR TITLE
fix(build): stop the version stamp freezing at a stale commit

### DIFF
--- a/omniphony-renderer/build.rs
+++ b/omniphony-renderer/build.rs
@@ -1,9 +1,75 @@
 use anyhow::Result;
 use chrono::TimeZone;
 use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 use vergen_gitcl::{Emitter, GitclBuilder};
 
+// Resolve a path inside the git directory, if it exists.
+//
+// `git rev-parse --git-path` handles the layouts we actually build in: a plain
+// checkout, and a linked worktree (where `.git` is a file and per-worktree refs
+// live under `.git/worktrees/<name>/`). Returns None outside a repository — a
+// source tarball still builds, it just falls back to Cargo's default staleness
+// rule.
+fn git_path(arg: &str) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--git-path", arg])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = PathBuf::from(String::from_utf8(out.stdout).ok()?.trim());
+    // Only declare paths that exist: cargo treats a missing `rerun-if-changed`
+    // target as perpetually dirty, which would rebuild on every invocation.
+    path.exists().then_some(path)
+}
+
+// Declare the git HEAD as an input of this build script.
+//
+// Without this, a build script that emits no `rerun-if-changed` is re-run only
+// when a file in *its own package* changes. The version stamp does not depend
+// on this package's sources at all — it depends on HEAD — so it used to freeze
+// at whatever commit was checked out the last time some unrelated edit landed
+// in the package. Observed in practice: `liborender` reporting a commit three
+// days stale, and the `orender` binary one nearly three months stale, both on a
+// clean tree. A wrong commit in `--version` is worse than no commit at all,
+// since it silently misidentifies which build is running.
+//
+// Kept in sync with runtime_control/build.rs, which stamps the same pair of
+// values for the embedded host.
+fn emit_git_rerun_triggers() {
+    // Covers a detached HEAD, where the file holds the commit id directly, and
+    // any branch switch, which rewrites it.
+    if let Some(path) = git_path("HEAD") {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    // On a branch, HEAD only names the ref; the commit id lives in the ref
+    // file, and that is what a new commit rewrites.
+    if let Ok(out) = Command::new("git")
+        .args(["symbolic-ref", "--quiet", "HEAD"])
+        .output()
+    {
+        if out.status.success() {
+            if let Ok(reference) = String::from_utf8(out.stdout) {
+                if let Some(path) = git_path(reference.trim()) {
+                    println!("cargo:rerun-if-changed={}", path.display());
+                }
+            }
+        }
+    }
+
+    // After `git gc` the loose ref above is gone and the id lives here instead.
+    if let Some(path) = git_path("packed-refs") {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
 fn main() -> Result<()> {
+    emit_git_rerun_triggers();
+
     // Generate git information
     let gitcl = GitclBuilder::default()
         .describe(true, true, Some("[0-9]*"))

--- a/omniphony-renderer/runtime_control/build.rs
+++ b/omniphony-renderer/runtime_control/build.rs
@@ -1,7 +1,58 @@
 use anyhow::Result;
 use chrono::TimeZone;
 use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 use vergen_gitcl::{Emitter, GitclBuilder};
+
+// Resolve a path inside the git directory, if it exists. See the twin in the
+// root build.rs for why this exists; both are kept in sync.
+fn git_path(arg: &str) -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--git-path", arg])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = PathBuf::from(String::from_utf8(out.stdout).ok()?.trim());
+    // A missing `rerun-if-changed` target is perpetually dirty to cargo.
+    path.exists().then_some(path)
+}
+
+// Declare the git HEAD as an input of this build script.
+//
+// A build script emitting no `rerun-if-changed` is re-run only when a file in
+// its own package changes. This stamp depends on HEAD, not on this package's
+// sources, so it used to freeze at whatever commit was checked out the last
+// time `runtime_control/` happened to be edited — which is exactly how
+// liborender came to report a commit three days older than the tree it was
+// built from, while claiming to be a fresh build.
+fn emit_git_rerun_triggers() {
+    // Detached HEAD holds the commit id directly; a branch switch rewrites it.
+    if let Some(path) = git_path("HEAD") {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    // On a branch the id lives in the ref file, which is what a commit updates.
+    if let Ok(out) = Command::new("git")
+        .args(["symbolic-ref", "--quiet", "HEAD"])
+        .output()
+    {
+        if out.status.success() {
+            if let Ok(reference) = String::from_utf8(out.stdout) {
+                if let Some(path) = git_path(reference.trim()) {
+                    println!("cargo:rerun-if-changed={}", path.display());
+                }
+            }
+        }
+    }
+
+    // After `git gc` the loose ref is packed away and the id lives here.
+    if let Some(path) = git_path("packed-refs") {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
 
 // Stamp this crate with a git-describe + build timestamp, exactly like the
 // `orender` binary crate's root build.rs. `runtime_control` is linked by BOTH
@@ -10,6 +61,8 @@ use vergen_gitcl::{Emitter, GitclBuilder};
 // connected renderer's real build in About — making a liborender-vs-orender
 // version skew immediately visible.
 fn main() -> Result<()> {
+    emit_git_rerun_triggers();
+
     let gitcl = GitclBuilder::default()
         .describe(true, true, Some("[0-9]*"))
         .build()?;


### PR DESCRIPTION
Both stamped binaries reported a commit they were not built from. On a clean tree at `152fa2c`:

| Binary | Reported | Reality |
|---|---|---|
| `orender --version` | `c142082` built 2026-05-27 | 152fa2c, built today |
| `liborender` (via the mpv loader) | `0cbd74a` built 2026-08-11 | 152fa2c, built today |

Nearly three months and three days stale respectively. The build date was equally wrong, so nothing in the banner flagged it.

## Cause

Cargo re-runs a build script that declares no `rerun-if-changed` only when a file in its **own package** changes. These two scripts derive their output from git HEAD, not from their package's sources, so the stamp froze at whichever commit happened to be checked out the last time an unrelated edit landed in that package.

`runtime_control/` had not been touched since `0cbd74a`, and the root package not since `c142082` — exactly the two dates observed. It is not a worktree artefact: this checkout holds a real `.git` directory.

## Fix

Declare the git HEAD as an input of both scripts:

- the **HEAD file** — covers a detached checkout, where it holds the id directly, and every branch switch, which rewrites it;
- the **ref it resolves to** — on a branch, HEAD only names the ref; the id lives in the ref file, and that is what a new commit rewrites;
- **packed-refs** — where the id ends up after a `git gc` retires the loose ref.

Paths come from `git rev-parse --git-path`, so a linked worktree resolves to its own per-worktree HEAD rather than the shared one — which matters here, since feature work happens in worktrees under `workflows/`.

Only paths that **exist** are declared: cargo treats a missing `rerun-if-changed` target as perpetually dirty, which would rebuild on every invocation. Outside a git repository every lookup returns `None` and no trigger is emitted, so a source tarball keeps building under cargo's default rule.

The helper is duplicated across the two scripts rather than shared. They are separate crates and already duplicate the whole vergen block; a shared build-helper crate for ~30 lines seemed worse than following the existing shape.

## Why it matters

A wrong commit is worse than no commit: it silently misidentifies which build is running, which is the one thing this banner exists to answer.

It also made the mpv loader's `loaded liborender ... 0cbd74a` line useless for its stated purpose. That line is how you tell a stale Studio-deployed library apart from a fresh local build — and both were printing the same stamp, so the two were indistinguishable except by path.

Worth noting for release builds: CI caches `omniphony-renderer/target`, so a cache hit could carry a stale stamp into a published artifact too. `release.yml` already checks out with `fetch-depth: 0`, so `git describe` has its tags.

## Verification

- Both targets now report `152fa2c` on a `152fa2c` tree, where they previously reported `c142082` and `0cbd74a`.
- **Trigger proven directly**: an empty commit — touching no package file at all — moved HEAD to `8582999`, and a plain rebuild took both stamps to `8582999`. Before this change that rebuild was a no-op. The probe commit was then removed.
- **No perpetual rebuild**: a second consecutive `cargo build --release` finishes in 0.05s.
- `cargo fmt --all -- --check` clean, `cargo test --workspace --release` green (538 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)