### PR TITLE
fix(studio): stop flagging the mpv-embedded renderer as foreign

### DIFF
--- a/omniphony-studio/src/controls/config.js
+++ b/omniphony-studio/src/controls/config.js
@@ -2,7 +2,7 @@
  * Config saved indicator.
  */
 
-import { app, dirty } from '../state.js';
+import { app, dirty, isEmbeddedProducer } from '../state.js';
 import { scheduleUIFlush, flushCallbacks } from '../flush.js';
 import { inAudioPanel, inSaveFooter } from '../ui/panel-roots.js';
 import { t } from '../i18n.js';
@@ -115,8 +115,16 @@ function withExecutablePath(text) {
  * connection then looks healthy while every control the other build does not
  * implement is silently dropped. `null` while either path is still unknown, so
  * the check cannot cry wolf before the first snapshot lands.
+ *
+ * An embedded producer is exempt. liborender hosted by mpv is never the binary
+ * Studio would launch, so the path comparison flags every single mpv session —
+ * and it asks the wrong question there: a different path is the expected
+ * topology, not a symptom. The premise does not hold either, because the
+ * capability handshake (`variant`/`host`, `realtime`) already tells Studio what
+ * this producer implements, so controls are gated rather than silently dropped.
  */
 export function rendererIsForeign() {
+  if (isEmbeddedProducer()) return false;
   const running = typeof app.renderExecutable === 'string' ? app.renderExecutable.trim() : '';
   const expected = typeof app.expectedOrenderPath === 'string' ? app.expectedOrenderPath.trim() : '';
   if (!running || !expected) return null;


### PR DESCRIPTION
Every mpv session raised **"Connected to a renderer this Studio did not start"**.

## Why

The ownership check is a plain path comparison — the executable the renderer broadcasts over OSC against the binary Studio would launch itself ([config.js:119](omniphony-studio/src/controls/config.js:119)):

```js
return running !== expected;
```

liborender hosted by mpv is never that binary, so the banner fired **by construction** on a topology that is entirely normal. Studio does not track ownership by PID or child-process handle at all; the path is the whole signal.

The banner's premise does not hold there either. Its detail text warns that *"controls it does not implement are dropped silently"* — a version-skew argument aimed at a foreign **standalone** build. For an embedded producer Studio already has the capability handshake (`variant`/`host`, plus the `realtime` list) and gates its controls on it, so nothing is dropped silently.

Studio even consumes that same handshake a few lines away: `isEmbeddedProducer()` is what hides the launch and service buttons behind the `cap-embedded` class. One code path already knew the situation was legitimate while the other called it an anomaly — the two notions simply never met.

## What changed

Exempt embedded producers from the check, and say why in the doc comment.

Kept deliberately narrow. A **standalone** renderer on a different path still raises the banner, which is the case it was written for: an instance left running by another workflow answering on the shared OSC port. I considered rebasing the warning on the broadcast ABI/version instead of the path, since that is closer to what it actually wants to detect — but that changes behaviour for the standalone case too, and I could not validate it here, so it stays a follow-up.

## Verification

Exercised in the running frontend, checking both the predicate and the banner element's computed display:

| Case | `rendererIsForeign()` | Banner |
|---|---|---|
| embedded, host mpv | `false` | hidden |
| standalone, different path | `true` | **visible** |
| standalone, our own path | `false` | hidden |
| path not yet known | `null` | hidden |

The last row matters: the check still returns `null` rather than `false` before the first snapshot lands, so it cannot cry wolf early.

`vite build` clean, i18n parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)