### PR TITLE
fix(standby): make the CLI⇄mpv handoff symmetric

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -364,6 +364,11 @@ pub struct OscSender {
     /// (port re-acquired) from one that failed because the port is still held, so
     /// it can re-arm standby instead of running portless (which strands Studio).
     listener_bound: bool,
+    /// Set by `resume` so the listener it starts adopts the live state the
+    /// departing host handed off in the sidecar. Only a resume takes over from
+    /// another instance; the first `start_listener` of a process follows the
+    /// engine's own startup load, which already consumed any sidecar.
+    adopt_live_on_listen: bool,
 }
 
 impl OscSender {
@@ -397,6 +402,7 @@ impl OscSender {
             standby_stop: Arc::new(AtomicBool::new(false)),
             standby_thread: Mutex::new(None),
             listener_bound: false,
+            adopt_live_on_listen: false,
         })
     }
 
@@ -459,6 +465,11 @@ impl OscSender {
         *LOCAL_RX_RELEASE.lock().unwrap() = Some(Arc::clone(&stop));
         log::info!("OSC listener ready on port {}", rx_port);
 
+        // Taken only once the bind above succeeded: a resume that could not
+        // re-acquire the port re-arms standby, and the next attempt must still
+        // adopt the handoff.
+        let adopt_live = std::mem::take(&mut self.adopt_live_on_listen);
+
         let handle = std::thread::Builder::new()
             .name("osc-listener".into())
             .spawn(move || {
@@ -479,6 +490,23 @@ impl OscSender {
                 // mpv shim flips them through the FFI toggles, so a client that
                 // only ever hears its own OSC pushes would drift.
                 let mut last_overlay_generation: Option<u64> = None;
+
+                // Resuming from standby: take over the live state the departing
+                // host left in the sidecar. Deliberately *after* the generation
+                // snapshots above — the adoption bumps the live-state generation
+                // so the poll below sees it move and broadcasts the adopted
+                // values. Sampling the generation after the mutation instead
+                // would leave Studio showing the state we just replaced.
+                if adopt_live {
+                    if let Some(ref ctrl) = control {
+                        profiles::adopt_handoff_live_state(
+                            ctrl,
+                            &socket,
+                            &clients,
+                            &gaintable_cache,
+                        );
+                    }
+                }
 
                 let mut buf = [0u8; 4096];
                 loop {
@@ -761,6 +789,11 @@ impl OscSender {
         }
         self.standby_stop.store(false, Ordering::Relaxed);
         *RESUME_SOCKET.lock().unwrap() = None;
+        // The host that just handed the port back wrote its unsaved live state
+        // to the sidecar as it went; the listener we are about to start picks
+        // it up. Without this we would come back on our pre-yield state and
+        // silently discard everything done while the other host held the port.
+        self.adopt_live_on_listen = true;
         let rx_port = self.rx_port;
         self.start_listener(rx_port, true)
     }
@@ -1013,6 +1046,63 @@ mod yield_tests {
 
         *LOCAL_RX_RELEASE.lock().unwrap() = None;
         h.join().unwrap();
+    }
+
+    fn test_sender() -> OscSender {
+        OscSender::new(SocketAddrV4::new(std::net::Ipv4Addr::LOCALHOST, 1)).unwrap()
+    }
+
+    /// A resume that re-acquires the port must arm the handoff adoption and then
+    /// consume the flag, so the listener adopts exactly once. `control` is unset
+    /// here, so the adoption itself no-ops — what is pinned is the arming.
+    #[test]
+    fn resume_arms_then_consumes_the_handoff_adoption() {
+        let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let mut sender = test_sender();
+        sender.rx_port = free_port();
+        assert!(
+            !sender.adopt_live_on_listen,
+            "nothing to adopt before a resume"
+        );
+
+        sender.resume().expect("re-acquires a free port");
+        assert!(sender.is_listening());
+        assert!(
+            !sender.adopt_live_on_listen,
+            "the started listener must consume the flag, so a later plain \
+             start_listener does not adopt a second time"
+        );
+
+        sender.listener_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = sender.listener_thread.lock().unwrap().take() {
+            let _ = handle.join();
+        }
+        *LOCAL_RX_RELEASE.lock().unwrap() = None;
+    }
+
+    /// A resume that cannot re-acquire the port re-arms standby and tries again
+    /// later. The adoption flag must survive that failure — dropping it there
+    /// would strand the departing host's live state in a sidecar nobody reads.
+    #[test]
+    fn failed_resume_keeps_the_handoff_adoption_armed() {
+        let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let port = free_port();
+        // A squatter that never answers the yield: bind_rx_socket exhausts its
+        // budget and start_listener returns without a listener.
+        let _squatter = UdpSocket::bind(("0.0.0.0", port)).unwrap();
+        *LOCAL_RX_RELEASE.lock().unwrap() = None;
+
+        let mut sender = test_sender();
+        sender.rx_port = port;
+        sender
+            .resume()
+            .expect("a busy port is not an error, just no listener");
+
+        assert!(!sender.is_listening(), "the port was held throughout");
+        assert!(
+            sender.adopt_live_on_listen,
+            "the adoption must stay armed for the retry that follows re-arming standby"
+        );
     }
 
     /// A standby holder that replies to a `yield_port` with a dynamic resume

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -369,10 +369,6 @@ pub struct OscSender {
     /// another instance; the first `start_listener` of a process follows the
     /// engine's own startup load, which already consumed any sidecar.
     adopt_live_on_listen: bool,
-    /// `config.yaml`'s mtime when this instance entered standby, so the resume
-    /// can tell whether the departing host *saved* over it — which writes no
-    /// sidecar, having cleared the dirty flag — while we were standing by.
-    standby_config_mtime: Option<std::time::SystemTime>,
 }
 
 impl OscSender {
@@ -407,7 +403,6 @@ impl OscSender {
             standby_thread: Mutex::new(None),
             listener_bound: false,
             adopt_live_on_listen: false,
-            standby_config_mtime: None,
         })
     }
 
@@ -474,7 +469,6 @@ impl OscSender {
         // re-acquire the port re-arms standby, and the next attempt must still
         // adopt the handoff.
         let adopt_live = std::mem::take(&mut self.adopt_live_on_listen);
-        let standby_config_mtime = self.standby_config_mtime.take();
 
         let handle = std::thread::Builder::new()
             .name("osc-listener".into())
@@ -510,7 +504,6 @@ impl OscSender {
                             &socket,
                             &clients,
                             &gaintable_cache,
-                            standby_config_mtime,
                         );
                     }
                 }
@@ -734,16 +727,6 @@ impl OscSender {
         // mpv came up on the stale on-disk config. Mirrors the `Drop` handoff,
         // except we stay alive and keep our in-memory state for a later resume.
         self.write_live_handoff_sidecar();
-
-        // Baseline for the resume: if the successor *saves* rather than leaving
-        // unsaved edits, it clears the dirty flag and hands over no sidecar at
-        // all — a newer mtime here is then the only trace that the truth moved.
-        self.standby_config_mtime = self
-            .control
-            .as_ref()
-            .and_then(|control| control.config_path.lock().as_ref().cloned())
-            .and_then(|path| std::fs::metadata(path).ok())
-            .and_then(|meta| meta.modified().ok());
 
         // Release the RX port: stop + join the listener thread.
         self.listener_stop.store(true, Ordering::Relaxed);

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -369,6 +369,10 @@ pub struct OscSender {
     /// another instance; the first `start_listener` of a process follows the
     /// engine's own startup load, which already consumed any sidecar.
     adopt_live_on_listen: bool,
+    /// `config.yaml`'s mtime when this instance entered standby, so the resume
+    /// can tell whether the departing host *saved* over it — which writes no
+    /// sidecar, having cleared the dirty flag — while we were standing by.
+    standby_config_mtime: Option<std::time::SystemTime>,
 }
 
 impl OscSender {
@@ -403,6 +407,7 @@ impl OscSender {
             standby_thread: Mutex::new(None),
             listener_bound: false,
             adopt_live_on_listen: false,
+            standby_config_mtime: None,
         })
     }
 
@@ -469,6 +474,7 @@ impl OscSender {
         // re-acquire the port re-arms standby, and the next attempt must still
         // adopt the handoff.
         let adopt_live = std::mem::take(&mut self.adopt_live_on_listen);
+        let standby_config_mtime = self.standby_config_mtime.take();
 
         let handle = std::thread::Builder::new()
             .name("osc-listener".into())
@@ -504,6 +510,7 @@ impl OscSender {
                             &socket,
                             &clients,
                             &gaintable_cache,
+                            standby_config_mtime,
                         );
                     }
                 }
@@ -727,6 +734,16 @@ impl OscSender {
         // mpv came up on the stale on-disk config. Mirrors the `Drop` handoff,
         // except we stay alive and keep our in-memory state for a later resume.
         self.write_live_handoff_sidecar();
+
+        // Baseline for the resume: if the successor *saves* rather than leaving
+        // unsaved edits, it clears the dirty flag and hands over no sidecar at
+        // all — a newer mtime here is then the only trace that the truth moved.
+        self.standby_config_mtime = self
+            .control
+            .as_ref()
+            .and_then(|control| control.config_path.lock().as_ref().cloned())
+            .and_then(|path| std::fs::metadata(path).ok())
+            .and_then(|meta| meta.modified().ok());
 
         // Release the RX port: stop + join the listener thread.
         self.listener_stop.store(true, Ordering::Relaxed);

--- a/omniphony-renderer/orender_engine/src/osc/profiles.rs
+++ b/omniphony-renderer/orender_engine/src/osc/profiles.rs
@@ -196,44 +196,38 @@ fn resolve_profile_layout(
 /// the moment we took the port back — and, worse, silently overwritten by our
 /// stale pre-yield state on the next save.
 ///
-/// The handoff is now symmetric: whichever side departs writes the sidecar, and
-/// whichever side takes the port over consumes it. `load_or_default_with_live`
-/// is consume-once, so this both reads and clears it.
+/// The handoff is symmetric: whichever side departs leaves its state behind,
+/// and whichever side takes the port over reads it.
 ///
-/// Two ways the truth can have moved while we stood by, and both must be picked
-/// up for the switchover to be invisible:
+/// The read is unconditional — the saved config every time, plus the sidecar if
+/// one is there. The departing host may have left unsaved edits (sidecar) or
+/// saved over `config.yaml`, which clears the dirty flag and so writes no
+/// sidecar at all; and it may have done neither. Rather than detect which, this
+/// simply re-reads: after standing by, the file is authoritative and our
+/// in-memory state is not evidence of anything.
 ///
-/// * a **sidecar** — the departing host had unsaved changes and handed them over;
-/// * a **newer config.yaml** — the departing host *saved* instead, which cleared
-///   its dirty flag and so wrote no sidecar at all.
+/// An earlier revision gated the config leg on the file's mtime having moved.
+/// That worked, but it made correctness depend on filesystem timestamp
+/// granularity and on nothing else writing within the same tick — a whole class
+/// of "did we notice?" bugs, for the sake of skipping a rebuild at the one
+/// moment the instance is already re-acquiring its audio output. Not worth the
+/// ambiguity.
 ///
-/// Neither means our in-memory state is still valid. Only when both are absent
-/// is it left alone.
-///
-/// Reuses the profile-switch application path: a config arriving from outside
-/// the process is the same problem as a profile being switched in — re-seed the
-/// live params, stage the layout, rebuild the topology in the background while
-/// audio keeps playing on the previous one.
+/// `load_or_default_with_live` is consume-once, so this both reads and clears
+/// the sidecar. Reuses the profile-switch application path: a config arriving
+/// from outside the process is the same problem as a profile being switched in
+/// — re-seed the live params, stage the layout, rebuild the topology in the
+/// background while audio keeps playing on the previous one.
 pub(crate) fn adopt_handoff_live_state(
     control: &Arc<RendererControl>,
     socket: &Arc<UdpSocket>,
     clients: &Arc<OscClientRegistry>,
     gaintable_cache: &Arc<GaintableCache>,
-    config_mtime_at_standby: Option<std::time::SystemTime>,
 ) {
     let Some(path) = control.config_path.lock().as_ref().cloned() else {
         return;
     };
     let (config, restored) = renderer::config::Config::load_or_default_with_live(&path);
-    // The sidecar only carries *unsaved* state. If the departing host saved
-    // instead, it cleared the dirty flag, so it wrote no sidecar at all — and
-    // the truth moved to config.yaml while we stood by. Adopting only on a
-    // restored sidecar would leave us running our pre-yield state against a
-    // config file that now says something else, and reporting it as saved.
-    // That is the case where the user was most explicit about the change.
-    if !restored && !config_changed_since(&path, config_mtime_at_standby) {
-        return;
-    }
     apply_switched_profile(&config, control, socket, clients, gaintable_cache);
     if restored {
         // Sidecar state only ever lived in that file, so it is unsaved by
@@ -255,19 +249,6 @@ pub(crate) fn adopt_handoff_live_state(
         "standby resume: adopted the live state handed off by the previous host ({})",
         if restored { "sidecar" } else { "saved config" }
     );
-}
-
-/// Whether `path` was modified after we entered standby. Conservative: an
-/// unreadable mtime, or no recorded baseline, reports no change — a spurious
-/// adopt would rebuild the topology on every mpv quit for nothing.
-fn config_changed_since(path: &std::path::Path, since: Option<std::time::SystemTime>) -> bool {
-    let Some(since) = since else {
-        return false;
-    };
-    std::fs::metadata(path)
-        .and_then(|meta| meta.modified())
-        .map(|modified| modified > since)
-        .unwrap_or(false)
 }
 
 /// Apply the freshly switched-in `render:` section to the running engine:
@@ -317,50 +298,4 @@ fn apply_switched_profile(
     control.bump_options_epoch();
     control.bump_geometry_generation();
     trigger_layout_recompute(control, socket, clients, gaintable_cache);
-}
-
-#[cfg(test)]
-mod handoff_tests {
-    use super::config_changed_since;
-    use std::time::{Duration, SystemTime};
-
-    fn temp_config(name: &str) -> std::path::PathBuf {
-        let path = std::env::temp_dir().join(format!("omniphony-handoff-{name}.yaml"));
-        std::fs::write(&path, "render: {}\n").unwrap();
-        path
-    }
-
-    /// The second trigger of the adoption: the departing host saved over
-    /// config.yaml, which writes no sidecar because saving clears the dirty
-    /// flag. A newer mtime is then the only evidence the truth moved.
-    #[test]
-    fn a_config_saved_during_standby_is_detected() {
-        let path = temp_config("saved");
-        let before_save = SystemTime::now() - Duration::from_secs(60);
-        assert!(
-            config_changed_since(&path, Some(before_save)),
-            "a config written after we stood by must trigger the adoption"
-        );
-        let _ = std::fs::remove_file(&path);
-    }
-
-    /// An untouched config must NOT trigger it: a spurious adopt would rebuild
-    /// the topology on every single mpv quit for no reason.
-    #[test]
-    fn an_untouched_config_does_not_trigger_adoption() {
-        let path = temp_config("untouched");
-        let after_write = SystemTime::now() + Duration::from_secs(60);
-        assert!(!config_changed_since(&path, Some(after_write)));
-        let _ = std::fs::remove_file(&path);
-    }
-
-    /// No baseline (never stood by) and an unreadable path both stay quiet,
-    /// rather than adopting on a guess.
-    #[test]
-    fn missing_baseline_or_file_stays_quiet() {
-        let path = temp_config("baseline");
-        assert!(!config_changed_since(&path, None));
-        let _ = std::fs::remove_file(&path);
-        assert!(!config_changed_since(&path, Some(SystemTime::UNIX_EPOCH)));
-    }
 }

--- a/omniphony-renderer/orender_engine/src/osc/profiles.rs
+++ b/omniphony-renderer/orender_engine/src/osc/profiles.rs
@@ -186,6 +186,52 @@ fn resolve_profile_layout(
     }
 }
 
+/// Adopt the live state a departing host handed off, when resuming from standby.
+///
+/// `enter_standby` writes this instance's unsaved live state to the sidecar so
+/// the successor (the mpv-embedded renderer taking the RX port) starts from it.
+/// The return leg had no counterpart: this process stays alive across the yield,
+/// so nothing ever re-read the config, and `resume` only re-bound the listener.
+/// Everything changed in Studio while mpv held the port was therefore dropped
+/// the moment we took the port back — and, worse, silently overwritten by our
+/// stale pre-yield state on the next save.
+///
+/// The handoff is now symmetric: whichever side departs writes the sidecar, and
+/// whichever side takes the port over consumes it. `load_or_default_with_live`
+/// is consume-once, so this both reads and clears it; `restored == false` means
+/// there was nothing unsaved to hand over (or it aged past the sidecar TTL), in
+/// which case our in-memory state is still the truth and is left alone.
+///
+/// Reuses the profile-switch application path: a config arriving from outside
+/// the process is the same problem as a profile being switched in — re-seed the
+/// live params, stage the layout, rebuild the topology in the background while
+/// audio keeps playing on the previous one.
+pub(crate) fn adopt_handoff_live_state(
+    control: &Arc<RendererControl>,
+    socket: &Arc<UdpSocket>,
+    clients: &Arc<OscClientRegistry>,
+    gaintable_cache: &Arc<GaintableCache>,
+) {
+    let Some(path) = control.config_path.lock().as_ref().cloned() else {
+        return;
+    };
+    let (config, restored) = renderer::config::Config::load_or_default_with_live(&path);
+    if !restored {
+        return;
+    }
+    apply_switched_profile(&config, control, socket, clients, gaintable_cache);
+    // The adopted state is by definition unsaved — it only ever lived in the
+    // sidecar — so the save indicator must show it as pending, exactly as the
+    // engine does when it restores a sidecar at startup.
+    control.mark_dirty();
+    // `mark_dirty` only flips the saved flag; the state bundle is re-broadcast
+    // off the live-state generation. Without this the adoption would be applied
+    // to the audio but never reach Studio, which would keep displaying — and
+    // then save — the values we just replaced.
+    control.bump_live_state();
+    log::info!("standby resume: adopted the live state handed off by the previous host");
+}
+
 /// Apply the freshly switched-in `render:` section to the running engine:
 /// stage the profile's layout, re-seed the live params through the shared
 /// construction seeds, and kick the background topology rebuild. Audio keeps

--- a/omniphony-renderer/orender_engine/src/osc/profiles.rs
+++ b/omniphony-renderer/orender_engine/src/osc/profiles.rs
@@ -198,9 +198,17 @@ fn resolve_profile_layout(
 ///
 /// The handoff is now symmetric: whichever side departs writes the sidecar, and
 /// whichever side takes the port over consumes it. `load_or_default_with_live`
-/// is consume-once, so this both reads and clears it; `restored == false` means
-/// there was nothing unsaved to hand over (or it aged past the sidecar TTL), in
-/// which case our in-memory state is still the truth and is left alone.
+/// is consume-once, so this both reads and clears it.
+///
+/// Two ways the truth can have moved while we stood by, and both must be picked
+/// up for the switchover to be invisible:
+///
+/// * a **sidecar** — the departing host had unsaved changes and handed them over;
+/// * a **newer config.yaml** — the departing host *saved* instead, which cleared
+///   its dirty flag and so wrote no sidecar at all.
+///
+/// Neither means our in-memory state is still valid. Only when both are absent
+/// is it left alone.
 ///
 /// Reuses the profile-switch application path: a config arriving from outside
 /// the process is the same problem as a profile being switched in — re-seed the
@@ -211,25 +219,55 @@ pub(crate) fn adopt_handoff_live_state(
     socket: &Arc<UdpSocket>,
     clients: &Arc<OscClientRegistry>,
     gaintable_cache: &Arc<GaintableCache>,
+    config_mtime_at_standby: Option<std::time::SystemTime>,
 ) {
     let Some(path) = control.config_path.lock().as_ref().cloned() else {
         return;
     };
     let (config, restored) = renderer::config::Config::load_or_default_with_live(&path);
-    if !restored {
+    // The sidecar only carries *unsaved* state. If the departing host saved
+    // instead, it cleared the dirty flag, so it wrote no sidecar at all — and
+    // the truth moved to config.yaml while we stood by. Adopting only on a
+    // restored sidecar would leave us running our pre-yield state against a
+    // config file that now says something else, and reporting it as saved.
+    // That is the case where the user was most explicit about the change.
+    if !restored && !config_changed_since(&path, config_mtime_at_standby) {
         return;
     }
     apply_switched_profile(&config, control, socket, clients, gaintable_cache);
-    // The adopted state is by definition unsaved — it only ever lived in the
-    // sidecar — so the save indicator must show it as pending, exactly as the
-    // engine does when it restores a sidecar at startup.
-    control.mark_dirty();
-    // `mark_dirty` only flips the saved flag; the state bundle is re-broadcast
-    // off the live-state generation. Without this the adoption would be applied
-    // to the audio but never reach Studio, which would keep displaying — and
-    // then save — the values we just replaced.
+    if restored {
+        // Sidecar state only ever lived in that file, so it is unsaved by
+        // definition — the save indicator must show it as pending, exactly as
+        // the engine does when it restores a sidecar at startup.
+        control.mark_dirty();
+    } else {
+        // Adopted straight from config.yaml, which the departing host saved.
+        // Marking it dirty here would invent a phantom unsaved diff against the
+        // very file it came from.
+        control.mark_clean();
+    }
+    // The save flag alone changes nothing on the wire: the state bundle is
+    // re-broadcast off the live-state generation. Without this the adoption
+    // would be applied to the audio but never reach Studio, which would keep
+    // displaying — and then save — the values we just replaced.
     control.bump_live_state();
-    log::info!("standby resume: adopted the live state handed off by the previous host");
+    log::info!(
+        "standby resume: adopted the live state handed off by the previous host ({})",
+        if restored { "sidecar" } else { "saved config" }
+    );
+}
+
+/// Whether `path` was modified after we entered standby. Conservative: an
+/// unreadable mtime, or no recorded baseline, reports no change — a spurious
+/// adopt would rebuild the topology on every mpv quit for nothing.
+fn config_changed_since(path: &std::path::Path, since: Option<std::time::SystemTime>) -> bool {
+    let Some(since) = since else {
+        return false;
+    };
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .map(|modified| modified > since)
+        .unwrap_or(false)
 }
 
 /// Apply the freshly switched-in `render:` section to the running engine:
@@ -279,4 +317,50 @@ fn apply_switched_profile(
     control.bump_options_epoch();
     control.bump_geometry_generation();
     trigger_layout_recompute(control, socket, clients, gaintable_cache);
+}
+
+#[cfg(test)]
+mod handoff_tests {
+    use super::config_changed_since;
+    use std::time::{Duration, SystemTime};
+
+    fn temp_config(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("omniphony-handoff-{name}.yaml"));
+        std::fs::write(&path, "render: {}\n").unwrap();
+        path
+    }
+
+    /// The second trigger of the adoption: the departing host saved over
+    /// config.yaml, which writes no sidecar because saving clears the dirty
+    /// flag. A newer mtime is then the only evidence the truth moved.
+    #[test]
+    fn a_config_saved_during_standby_is_detected() {
+        let path = temp_config("saved");
+        let before_save = SystemTime::now() - Duration::from_secs(60);
+        assert!(
+            config_changed_since(&path, Some(before_save)),
+            "a config written after we stood by must trigger the adoption"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// An untouched config must NOT trigger it: a spurious adopt would rebuild
+    /// the topology on every single mpv quit for no reason.
+    #[test]
+    fn an_untouched_config_does_not_trigger_adoption() {
+        let path = temp_config("untouched");
+        let after_write = SystemTime::now() + Duration::from_secs(60);
+        assert!(!config_changed_since(&path, Some(after_write)));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// No baseline (never stood by) and an unreadable path both stay quiet,
+    /// rather than adopting on a guess.
+    #[test]
+    fn missing_baseline_or_file_stays_quiet() {
+        let path = temp_config("baseline");
+        assert!(!config_changed_since(&path, None));
+        let _ = std::fs::remove_file(&path);
+        assert!(!config_changed_since(&path, Some(SystemTime::UNIX_EPOCH)));
+    }
 }


### PR DESCRIPTION
The CLI⇄mpv handoff was one-way. The goal is that the switchover be invisible: whatever the departing host leaves behind, the one taking the port over picks up.

`enter_standby` already writes this instance's unsaved live state to the sidecar **before** releasing the RX port — precisely so the mpv-embedded renderer does not come up on a stale on-disk config. The return leg had no counterpart. The standby process stays alive across the yield, so nothing ever re-read the config, and `resume` only re-bound the listener:

```rust
pub fn resume(&mut self) -> Result<()> {
    …
    self.start_listener(rx_port, true)
}
```

Everything changed in Studio while mpv held the port was dropped the moment the standby took the port back — and then silently overwritten by its stale pre-yield state on the next save. mpv *does* write a sidecar on the way out; nobody consumed it, so it sat on disk until some later startup picked it up out of order, or the TTL deleted it unread.

## What changed

`resume` arms the listener it starts to re-read the config: **the saved `config.yaml` every time, plus the sidecar when one is there.**

The unconditional read is deliberate. There are two ways the truth can move while standing by — unsaved edits handed over in a sidecar, or a plain **save**, which clears the dirty flag and therefore writes no sidecar at all. The saved case is the one where the user was most explicit, and it is the one a sidecar-only check misses:

1. standby holds state A, clean, `config.yaml` = A
2. mpv takes the port, loads A
3. user changes to B in Studio — mpv is now dirty
4. user **saves**: `config.yaml` = B, mpv clean again
5. mpv quits: nothing dirty, so no sidecar
6. standby resumes, finds no sidecar, keeps its in-memory A
7. it runs A while the file says B — and reports A as **saved**

An intermediate revision detected that case by comparing `config.yaml`'s mtime against a baseline recorded at `enter_standby`. It worked, but it made correctness depend on filesystem timestamp granularity and on nothing else writing within the same tick, to save one topology rebuild at the exact moment the instance is already re-acquiring its audio output. That was dropped in favour of simply always re-reading: after standing by, the file is authoritative and the in-memory state is not evidence of anything, so there is nothing to detect.

`restored` still decides the saved flag — sidecar state is unsaved by definition and stays dirty, state read straight from `config.yaml` is marked clean, since flagging it dirty would invent a phantom diff against the file it came from — but it no longer decides *whether* to apply.

## Details that matter

**The application reuses the profile-switch path.** A config arriving from outside the process is the same problem as a profile being switched in: re-seed the live params, stage the layout, rebuild the topology in the background while audio keeps playing on the previous one.

**The flag is taken only after the bind succeeded.** A resume that cannot re-acquire the port re-arms standby and retries later; dropping it there would strand the handoff.

**The adoption runs *after* the listener thread snapshots the generation counters it polls.** It bumps the live-state generation so the poll sees it move and broadcasts. Sampling that counter after the mutation instead would apply the state to the audio but never send it — leaving Studio displaying, and then saving, the values just replaced. `mark_dirty` alone does not do this: it only flips the saved flag, which is why `bump_live_state` is explicit. I had this ordering wrong at first.

## Verification

- `cargo test --workspace --release` green — **540 passed, 0 failed** (+2 new).
- `cargo fmt --all -- --check` clean.

The two new tests pin the arming logic: the flag is consumed on a successful bind and retained on a failed one. The application path itself is the already-exercised profile switch.

**Not verified: a real CLI⇄mpv⇄Studio session.** Both legs are worth walking before this ships — change a parameter in Studio while mpv plays then quit mpv (sidecar leg), and save it before quitting (config leg) — confirming the standby comes back holding those values in each case.

## Known limit

If mpv **crashes**, no `Drop` runs, so no sidecar is written and `config.yaml` never moved: the standby resumes on its pre-yield state and that session's unsaved changes are gone. Inherent to writing state on the way out; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)