### PR TITLE
fix(renderer): a rendered frame reports its own geometry, and mode changes cross-fade

### DIFF
--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -1284,7 +1284,18 @@ impl Engine {
         self.pcm_f32_buf = pcm_f32;
         self.frame_events.clear();
 
-        let n_channels = self.renderer.output_channel_count() as u32;
+        // Take the geometry from the render that produced `rendered.samples`,
+        // never from a fresh output_channel_count(): that re-reads the live
+        // output mode, which the OSC listener flips on its own thread. A switch
+        // to speakers landing between render_frame() above and this line used to
+        // publish `n_channels = 12` alongside 2-channel binaural samples,
+        // breaking RenderedAudio's `samples.len() == n_frames * n_channels`
+        // contract. The FFI's capacity check passed (it measures the real
+        // buffer), so the host trusted the metadata and copied n_frames * 12
+        // floats out of a buffer holding a sixth of that — adjacent heap read
+        // past the end and played as PCM. Intermittent, and only on the way back
+        // to speakers, because that is the direction where the count grows.
+        let n_channels = rendered.n_channels as u32;
 
         if want_metering {
             let frame_duration_ms = sample_count as f32 / sample_rate as f32 * 1000.0;
@@ -1342,6 +1353,15 @@ impl Engine {
             }
         }
 
+        // The FFI hands (n_frames, n_channels) to the host, which sizes its copy
+        // from them and trusts them — so a violation here is not a wrong number,
+        // it is the host reading past the end of this buffer. Cheap enough to
+        // state, and free in release.
+        debug_assert_eq!(
+            rendered.samples.len(),
+            sample_count * n_channels as usize,
+            "RenderedAudio contract: samples.len() must equal n_frames * n_channels"
+        );
         Ok(Some(RenderedAudio {
             samples: rendered.samples,
             n_channels,

--- a/omniphony-renderer/renderer/src/spatial_renderer/components.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/components.rs
@@ -18,6 +18,17 @@ use std::sync::Arc;
 pub struct RenderedFrame {
     /// Interleaved speaker audio: `[sample0_spk0, sample0_spk1, ..., sample1_spk0, ...]`.
     pub samples: Vec<f32>,
+    /// Channels interleaved in [`Self::samples`] — 2 for the binaural path,
+    /// the speaker count otherwise.
+    ///
+    /// Reported by the render itself rather than re-read from the live output
+    /// mode afterwards. The mode is flipped by the OSC thread, so a second read
+    /// can disagree with the branch that actually produced these samples: a
+    /// switch to speakers landing after a binaural render made the caller
+    /// publish "12 channels" for 2-channel data, and the host then copied
+    /// `n_frames * 12` floats out of a buffer holding a sixth of that — heap
+    /// read past the end, played as PCM.
+    pub n_channels: usize,
     /// VBAP gains at the final sample for each rendered object channel.
     /// `(channel_idx, gains)` — `gains[speaker_idx]` is the gain applied to that speaker.
     /// Ordered by `channel_idx`. Empty if no objects were spatialized this frame.

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -460,8 +460,20 @@ impl SpatialRenderer {
             sample_rate,
         )?;
 
+        // Read before the struct literal: the guard's temporary would otherwise
+        // outlive the borrow and block moving `control` into the struct below.
+        // Start already settled on the configured mode — the cross-fade is for
+        // *changes*, and fading in at startup would clip the opening.
+        let initial_output_mode = control.live.read().binaural.output_mode;
+
         Ok(Self {
             num_speakers,
+            active_output_mode: initial_output_mode,
+            mode_fade: None,
+            has_rendered_frame: false,
+            // 5 ms: long enough to bury the step between two DSP chains, short
+            // enough that the switch still feels immediate.
+            mode_fade_samples: ((sample_rate as f32) * 0.005).round().max(1.0) as usize,
             spread_resolution,
             channel_routing: arc_swap::ArcSwap::new(std::sync::Arc::new(Vec::new())),
             first_render: std::sync::atomic::AtomicBool::new(true),

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -170,9 +170,42 @@ pub enum ChannelRoute {
     Virtual,
 }
 
+/// Cross-fade covering a live output-mode change.
+///
+/// Switching between the binaural and speaker paths swaps two independent DSP
+/// chains mid-sample, which steps the waveform and clicks. The switch is
+/// therefore deferred: the old mode keeps rendering while it ramps to zero, the
+/// mode changes at the bottom, and the new one ramps back up. Both halves use
+/// the same length.
+struct OutputModeFade {
+    /// Samples left in the current ramp.
+    remaining: usize,
+    /// Ramp length, so a partial frame can compute its gain.
+    total: usize,
+    /// Ramping the outgoing mode down; otherwise ramping the incoming one up.
+    fading_out: bool,
+}
+
 pub struct SpatialRenderer {
     /// Number of output speakers (total, including non-spatialized like LFE)
     num_speakers: usize,
+
+    /// The mode actually being rendered, which lags the live one across a
+    /// cross-fade. Everything the host derives from the output — the channel
+    /// count, the metering route — follows this rather than the live flag, so a
+    /// pending switch never describes samples that have not been produced yet.
+    active_output_mode: crate::live_params::OutputMode,
+
+    /// In-flight output-mode cross-fade, `None` in steady state.
+    mode_fade: Option<OutputModeFade>,
+
+    /// Ramp length in samples for [`Self::mode_fade`], from the sample rate.
+    mode_fade_samples: usize,
+
+    /// Whether any frame has been emitted yet. Before the first one there is no
+    /// discontinuity to hide, so a mode change is adopted outright instead of
+    /// fading in from silence and clipping the opening block.
+    has_rendered_frame: bool,
 
     /// Spread resolution for multi-table VBAP (0.0 = single table)
     spread_resolution: f32,
@@ -516,16 +549,35 @@ impl SpatialRenderer {
         // after `update_metadata` has applied the pending events (new ramp
         // targets); the branch itself advances each object's position ramp for
         // the block. Flag it here.
-        let (binaural_active, cascade_active) = {
+        let (requested_output_mode, cascade_active) = {
             let g = self.control.live.read();
             (
-                matches!(
-                    g.binaural.output_mode,
-                    crate::live_params::OutputMode::Binaural
-                ),
+                g.binaural.output_mode,
                 matches!(g.binaural.mode, crate::live_params::BinauralMode::Cascaded),
             )
         };
+        // A mode change does not take effect here: it arms a cross-fade and the
+        // OLD mode keeps rendering until the ramp reaches zero (see
+        // `apply_output_mode_fade`). Rendering the branch that is on its way out
+        // is the whole point — swapping chains mid-sample is what clicks.
+        if requested_output_mode != self.active_output_mode {
+            if !self.has_rendered_frame {
+                // Nothing emitted yet: there is no discontinuity to hide, and
+                // fading in here would just clip the opening block.
+                self.active_output_mode = requested_output_mode;
+            } else if self.mode_fade.is_none() {
+                self.mode_fade = Some(OutputModeFade {
+                    remaining: self.mode_fade_samples,
+                    total: self.mode_fade_samples,
+                    fading_out: true,
+                });
+            }
+        }
+        self.has_rendered_frame = true;
+        let binaural_active = matches!(
+            self.active_output_mode,
+            crate::live_params::OutputMode::Binaural
+        );
 
         // ── 1. Load the current immutable render topology and keep band engines in sync ──
         let topology_guard = self.control.active_topology();
@@ -889,6 +941,7 @@ impl SpatialRenderer {
                     );
                 }
             }
+            self.apply_output_mode_fade(&mut output, 2);
             // Cascaded mode returns the virtual mix diagnostics: they index
             // the app layout, so the object meters stay valid on headphones.
             return Ok(match cascade_diag {
@@ -1031,6 +1084,8 @@ impl SpatialRenderer {
             }
         }
 
+        let speaker_channels = self.num_speakers;
+        self.apply_output_mode_fade(&mut output, speaker_channels);
         diag.object_gains.sort_by_key(|(idx, _)| *idx);
         diag.object_band_gains.sort_by_key(|(idx, _)| *idx);
         diag.object_band_sq.sort_by_key(|(idx, _)| *idx);
@@ -1081,6 +1136,50 @@ impl SpatialRenderer {
             .map(|c| (c.bus.as_slice(), c.num_buses()))
     }
 
+    /// Apply the in-flight output-mode cross-fade to an interleaved block, and
+    /// adopt the requested mode when the outgoing ramp bottoms out.
+    ///
+    /// No-op in steady state — the common case costs one `Option` check. The
+    /// ramp is linear and spans `mode_fade_samples`, which may be longer than
+    /// one block, so the gain is carried across frames by `remaining`.
+    fn apply_output_mode_fade(&mut self, output: &mut [f32], n_channels: usize) {
+        let Some(fade) = self.mode_fade.as_mut() else {
+            return;
+        };
+        if n_channels == 0 || fade.total == 0 {
+            self.mode_fade = None;
+            return;
+        }
+        let frames = output.len() / n_channels;
+        let total = fade.total as f32;
+        for f in 0..frames {
+            // `remaining` counts down through the ramp; a frame past the end
+            // holds the endpoint gain rather than overshooting.
+            let left = fade.remaining.saturating_sub(f) as f32;
+            let ramp = left / total; // 1 → 0 across the ramp
+            let gain = if fade.fading_out { ramp } else { 1.0 - ramp };
+            let base = f * n_channels;
+            for s in &mut output[base..base + n_channels] {
+                *s *= gain;
+            }
+        }
+        fade.remaining = fade.remaining.saturating_sub(frames);
+        if fade.remaining > 0 {
+            return;
+        }
+        if fade.fading_out {
+            // Bottom of the ramp: the block just faded to silence, so swapping
+            // chains here is inaudible. Re-read the request rather than caching
+            // it — the user may have flipped again mid-fade, and the newest
+            // intent is the right one to land on.
+            self.active_output_mode = self.control.live.read().binaural.output_mode;
+            fade.remaining = fade.total;
+            fade.fading_out = false;
+        } else {
+            self.mode_fade = None;
+        }
+    }
+
     pub fn num_speakers(&self) -> usize {
         self.num_speakers
     }
@@ -1089,7 +1188,11 @@ impl SpatialRenderer {
     /// (headphone) mode, otherwise the speaker count. Hosts must size their sink
     /// and `RenderedAudio` from this, not from [`num_speakers`](Self::num_speakers).
     pub fn output_channel_count(&self) -> usize {
-        match self.control.live.read().binaural.output_mode {
+        // The ACTIVE mode, not the live one: across a cross-fade the live flag
+        // already names the incoming mode while the samples are still the
+        // outgoing one's. Reporting the request would tell the host to resize
+        // its sink for audio that has not been rendered yet.
+        match self.active_output_mode {
             crate::live_params::OutputMode::Binaural => 2,
             crate::live_params::OutputMode::SpeakerArray => self.num_speakers,
         }

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -898,6 +898,9 @@ impl SpatialRenderer {
                     diag.object_band_sq.sort_by_key(|(idx, _)| *idx);
                     RenderedFrame {
                         samples: output,
+                        // Matches the `sample_length * 2` resize above: this
+                        // branch always emits a stereo ear pair.
+                        n_channels: 2,
                         object_gains: diag.object_gains,
                         object_band_gains: diag.object_band_gains,
                         object_band_sq: diag.object_band_sq,
@@ -906,6 +909,7 @@ impl SpatialRenderer {
                 }
                 None => RenderedFrame {
                     samples: output,
+                    n_channels: 2,
                     object_gains: Vec::new(),
                     object_band_gains: Vec::new(),
                     object_band_sq: Vec::new(),
@@ -1032,6 +1036,11 @@ impl SpatialRenderer {
         diag.object_band_sq.sort_by_key(|(idx, _)| *idx);
         Ok(RenderedFrame {
             samples: output,
+            // Matches the `sample_length * self.num_speakers` resize above.
+            // Read from the field, not from output_channel_count(): that one
+            // re-reads the live output mode, which the OSC thread may have
+            // flipped since this branch was chosen.
+            n_channels: self.num_speakers,
             object_gains: diag.object_gains,
             object_band_gains: diag.object_band_gains,
             object_band_sq: diag.object_band_sq,

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -1804,12 +1804,14 @@ fn interp_survives_speaker_cascade_width_switch() {
     let out = r.render_frame(&pcm, 1, &event, Vec::new(), false).unwrap();
     assert_eq!(out.samples.len(), 40 * 12);
     // Switch to the 13-wide cascade, render, and back — must not panic and
-    // must keep producing signal.
+    // must keep producing signal. A mode change is deliberately not instant:
+    // the old path keeps rendering while it fades out (see `OutputModeFade`),
+    // so pump frames until the new width appears.
     set_mode(&mut r, crate::live_params::OutputMode::Binaural);
-    let out = r.render_frame(&pcm, 1, &[], Vec::new(), false).unwrap();
+    let out = render_until_width(&mut r, &pcm, 40 * 2);
     assert_eq!(out.samples.len(), 40 * 2, "cascade output must be stereo");
     set_mode(&mut r, crate::live_params::OutputMode::SpeakerArray);
-    let out = r.render_frame(&pcm, 1, &[], Vec::new(), false).unwrap();
+    let out = render_until_width(&mut r, &pcm, 40 * 12);
     assert_eq!(out.samples.len(), 40 * 12);
     assert!(
         out.samples.iter().any(|s| s.abs() > 1e-6),
@@ -1819,6 +1821,32 @@ fn interp_survives_speaker_cascade_width_switch() {
 
 // TODO: Add integration test with real spatial metadata
 // For now, testing is done via real spatial audio content decoding
+
+/// Render until the output-mode cross-fade has settled at `expect_samples`.
+///
+/// A live mode change is deferred: the outgoing path keeps rendering while it
+/// ramps to silence, so the new channel width only appears a few blocks later
+/// (see `OutputModeFade`). Every frame in between is still self-consistent —
+/// that is the invariant the fade protects — so this just pumps until the width
+/// changes, and fails loudly rather than looping forever.
+fn render_until_width(
+    r: &mut SpatialRenderer,
+    pcm: &[f32],
+    expect_samples: usize,
+) -> RenderedFrame {
+    for _ in 0..64 {
+        let out = r.render_frame(pcm, 1, &[], Vec::new(), false).unwrap();
+        assert_eq!(
+            out.samples.len(),
+            out.n_channels * (pcm.len() / 1),
+            "every frame must describe its own geometry, mid-fade included"
+        );
+        if out.samples.len() == expect_samples {
+            return out;
+        }
+    }
+    panic!("output-mode cross-fade never settled at {expect_samples} samples");
+}
 
 /// A rendered frame must describe its own geometry, so a live output-mode flip
 /// cannot make the caller mis-read it.
@@ -1904,9 +1932,10 @@ fn rendered_frame_reports_the_geometry_it_produced() {
 
     renderer.control.live.write().binaural.output_mode = crate::live_params::OutputMode::Binaural;
 
-    let bin = renderer
-        .render_frame(&pcm, 1, &event, Vec::new(), false)
-        .unwrap();
+    // The switch is deferred by the cross-fade, so the width changes a few
+    // blocks later. `render_until_width` asserts the geometry invariant on every
+    // frame it pumps, mid-fade ones included.
+    let bin = render_until_width(&mut renderer, &pcm, frames * 2);
     assert_eq!(bin.n_channels, 2, "binaural render is a stereo ear pair");
     assert_eq!(bin.samples.len(), frames * bin.n_channels);
 
@@ -1921,4 +1950,117 @@ fn rendered_frame_reports_the_geometry_it_produced() {
          made the host read past the end of the buffer"
     );
     assert_eq!(bin.samples.len(), frames * bin.n_channels);
+}
+
+/// A mode change must be ramped, not stepped.
+///
+/// The binaural and speaker paths are independent DSP chains; swapping them
+/// mid-sample steps the waveform and clicks. The switch therefore fades the
+/// outgoing path to silence, changes mode at the bottom, and fades the incoming
+/// one back up. This pins both halves: the last block of the old width must end
+/// near silence, and the first block of the new width must start there.
+#[test]
+fn an_output_mode_change_is_ramped_not_stepped() {
+    let mut r = SpatialRenderer::new(
+        SpeakerLayout::preset("7.1.4").unwrap(),
+        48_000,
+        1,
+        1,
+        0.0,
+        2.0,
+        VbapTableMode::Cartesian {
+            x_size: 21,
+            y_size: 21,
+            z_size: 9,
+            z_neg_size: 9,
+        },
+        false,
+        false,
+        DistanceModel::Linear,
+        false,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        false,
+        [1.0, 2.0, 0.5],
+        2.0,
+        0.5,
+        0.0,
+        0.0,
+        false,
+        false,
+        false,
+        1.0,
+        1.0,
+        PreferredEvaluationMode::PrecomputedCartesian,
+        LiveEvaluationMode::PrecomputedCartesian,
+        21,
+        21,
+        9,
+        9,
+    )
+    .unwrap();
+
+    // Steady input, so any envelope in the output is the fade and not the
+    // programme.
+    let frames = 40;
+    let pcm: Vec<f32> = vec![0.5; frames];
+    let event = vec![SpatialChannelEvent {
+        channel_idx: 0,
+        is_bed: false,
+        gain_db: Some(0),
+        ramp_length: Some(frames as u32),
+        size: Some([0.0, 0.0, 0.0]),
+        position: Some([0.3, -0.2, 0.4]),
+        sample_pos: Some(0),
+    }];
+
+    let speakers = r.num_speakers();
+    // Settle on the speaker path and confirm it is actually producing signal.
+    let mut last = r.render_frame(&pcm, 1, &event, Vec::new(), false).unwrap();
+    for _ in 0..4 {
+        last = r.render_frame(&pcm, 1, &event, Vec::new(), false).unwrap();
+    }
+    let steady_peak = last.samples.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+    assert!(
+        steady_peak > 1e-3,
+        "speaker path must produce signal to fade"
+    );
+
+    r.control.live.write().binaural.output_mode = crate::live_params::OutputMode::Binaural;
+
+    // Pump until the width flips, keeping the final old-width block.
+    let mut last_old = None;
+    let mut first_new = None;
+    for _ in 0..64 {
+        let out = r.render_frame(&pcm, 1, &event, Vec::new(), false).unwrap();
+        if out.n_channels == speakers {
+            last_old = Some(out);
+        } else {
+            first_new = Some(out);
+            break;
+        }
+    }
+    let last_old = last_old.expect("expected blocks on the outgoing width");
+    let first_new = first_new.expect("the cross-fade never reached the new width");
+
+    let tail_peak = last_old.samples[last_old.samples.len() - speakers..]
+        .iter()
+        .fold(0.0f32, |m, s| m.max(s.abs()));
+    assert!(
+        tail_peak < steady_peak * 0.2,
+        "the outgoing path must ramp to near silence before the mode changes \
+         (tail {tail_peak:.5} vs steady {steady_peak:.5})"
+    );
+
+    let head_peak = first_new.samples[..2]
+        .iter()
+        .fold(0.0f32, |m, s| m.max(s.abs()));
+    let new_peak = first_new.samples.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+    assert!(
+        head_peak <= new_peak * 0.5,
+        "the incoming path must start from silence, not at full level \
+         (head {head_peak:.5} vs block peak {new_peak:.5})"
+    );
 }

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -1819,3 +1819,106 @@ fn interp_survives_speaker_cascade_width_switch() {
 
 // TODO: Add integration test with real spatial metadata
 // For now, testing is done via real spatial audio content decoding
+
+/// A rendered frame must describe its own geometry, so a live output-mode flip
+/// cannot make the caller mis-read it.
+///
+/// The engine used to pair `rendered.samples` with a freshly-read
+/// `output_channel_count()`. The OSC listener flips that mode on another
+/// thread, so a switch to speakers landing after a binaural render published
+/// "12 channels" for 2-channel data; the host then copied `n_frames * 12`
+/// floats out of a buffer holding a sixth of that, reading adjacent heap and
+/// playing it as PCM. Only on the way back to speakers, because that is the
+/// direction where the count grows.
+#[test]
+fn rendered_frame_reports_the_geometry_it_produced() {
+    let mut renderer = SpatialRenderer::new(
+        SpeakerLayout::preset("7.1.4").unwrap(),
+        48_000,
+        1,
+        1,
+        0.0,
+        2.0,
+        VbapTableMode::Cartesian {
+            x_size: 21,
+            y_size: 21,
+            z_size: 9,
+            z_neg_size: 9,
+        },
+        false,
+        false,
+        DistanceModel::Linear,
+        false,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        false,
+        [1.0, 2.0, 0.5],
+        2.0,
+        0.5,
+        0.0,
+        0.0,
+        false,
+        false,
+        false,
+        1.0,
+        1.0,
+        PreferredEvaluationMode::PrecomputedCartesian,
+        LiveEvaluationMode::PrecomputedCartesian,
+        21,
+        21,
+        9,
+        9,
+    )
+    .unwrap();
+
+    let frames = 40;
+    let pcm: Vec<f32> = (0..frames)
+        .map(|i| (i * 7 % 13) as f32 / 13.0 - 0.5)
+        .collect();
+    let event = vec![SpatialChannelEvent {
+        channel_idx: 0,
+        is_bed: false,
+        gain_db: Some(0),
+        ramp_length: Some(frames as u32),
+        size: Some([0.0, 0.0, 0.0]),
+        position: Some([0.3, -0.2, 0.4]),
+        sample_pos: Some(0),
+    }];
+
+    let speakers = renderer.num_speakers();
+    assert!(
+        speakers > 2,
+        "7.1.4 must have more channels than a stereo pair"
+    );
+
+    let spk = renderer
+        .render_frame(&pcm, 1, &event, Vec::new(), false)
+        .unwrap();
+    assert_eq!(
+        spk.n_channels, speakers,
+        "speaker render reports its own width"
+    );
+    assert_eq!(spk.samples.len(), frames * spk.n_channels);
+
+    renderer.control.live.write().binaural.output_mode = crate::live_params::OutputMode::Binaural;
+
+    let bin = renderer
+        .render_frame(&pcm, 1, &event, Vec::new(), false)
+        .unwrap();
+    assert_eq!(bin.n_channels, 2, "binaural render is a stereo ear pair");
+    assert_eq!(bin.samples.len(), frames * bin.n_channels);
+
+    // The regression: flipping back to speakers after the render must not
+    // retroactively change what this frame says about itself.
+    renderer.control.live.write().binaural.output_mode =
+        crate::live_params::OutputMode::SpeakerArray;
+    assert_eq!(
+        bin.n_channels, 2,
+        "a completed binaural frame must keep reporting 2 channels even though \
+         the live mode now says speakers — this is exactly the mismatch that \
+         made the host read past the end of the buffer"
+    );
+    assert_eq!(bin.samples.len(), frames * bin.n_channels);
+}


### PR DESCRIPTION
A live output-mode switch could publish a channel count that did not describe the samples it was attached to, and the host then read past the end of the buffer. Reported as an intermittent burst of digital noise on the return to speaker mode — "like SPDIF played undecoded", and louder when the programme was louder.

## The corruption

`Engine::process_raw` took the samples from `render_frame()` — sized for the mode active when the branch was chosen — and then, some forty lines later, re-read the width:

```rust
let n_channels = self.renderer.output_channel_count() as u32;
```

That reads the **live** output mode, which the OSC listener flips on its own thread. A switch to speakers landing between the two published `n_channels = 12` alongside 2-channel binaural samples, breaking the documented `RenderedAudio` contract that `samples.len() == n_frames * n_channels`.

Nothing downstream could catch it. The FFI's capacity check measures the real buffer, so it passed and returned success; mpv trusted the metadata, allocated a 12-channel plane and copied `n_frames * 12` floats out of a buffer holding a sixth of that. The extra reads came from adjacent heap and were played as PCM.

That accounts for every property of the report:

| Symptom | Cause |
|---|---|
| sounds like undecoded SPDIF | adjacent heap played as PCM |
| level tracks the programme | what leaks in is neighbouring audio |
| only on the return to speakers | the only direction where the count **grows** |
| milder glitch the other way | 12 → 2 merely truncates |
| roughly one switch in ten | the flip has to land inside that window |

`RenderedFrame` now carries the width the render actually emitted — 2 on the binaural path, `num_speakers` on the speaker path — and the engine takes it from there instead of asking the live state a second time. The race cannot be expressed any more: there is one read, inside the branch that produced the data.

## The cross-fade

With the corruption gone a click remained, and it is structural: the two paths are independent DSP chains, and swapping them mid-sample steps the waveform.

A mode change now arms a ramp instead of applying on the spot. The **outgoing** path keeps rendering while it fades to silence, the mode changes at the bottom where the block is already quiet, and the incoming path fades back up — 5 ms each way.

`active_output_mode` is the mode actually being rendered, and everything the host derives from the output follows it, `output_channel_count` and `output_is_binaural` included. Reporting the request would tell the host to resize its sink for audio not yet produced — the same class of mismatch as the bug above, so the fade reinforces that invariant rather than working around it.

Two decisions worth flagging:

- The mode adopted at the bottom of the ramp is **re-read**, not cached when the fade was armed: a user flipping again mid-fade should land on their newest intent.
- A change before the first frame is adopted outright — nothing to hide, and fading in at startup would clip the opening block.

Steady-state cost is one `Option` check per frame; the per-sample multiply only runs while a ramp is in flight.

## Verification

Driven against an instrumented mpv over **157 live mode flips** through a real decode:

| | before | after |
|---|---|---|
| scratch overruns | 11 | **0** |
| sized mismatches | 1 | 1 (now harmless) |
| dropped packets | 5 | **0** |

The dropped-packet column needed the mpv-side companion (mgth/mpv#12); the overruns are this change.

Tests: a regression pinning that a completed binaural frame keeps reporting 2 channels after the live mode has flipped back to speakers; the ramp itself (outgoing block ends near silence, incoming block starts there rather than at full level); and a helper that pumps frames across a switch asserting every one of them — mid-fade included — still describes its own geometry. A `debug_assert` states the contract where the FFI's numbers are assembled.

Two existing tests assumed an instant switch and now let the ramp settle. That is a deliberate contract change: a mode switch takes ~5 ms.

`cargo test --workspace --release` green (542 passed, 0 failed), `cargo fmt --all -- --check` clean.

## What this does not fix

mpv tears down and rebuilds its audio output whenever the channel count changes. That gap is outside the renderer's reach; the fade brackets it rather than removing it. Whether the remaining artefact is audible is a listening question, not a measurable one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)