### PR TITLE
Speaker test from idle: feed silence through the input path

### DIFF
--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -813,6 +813,15 @@ pub struct LiveParams {
     /// a saved session can never come up making noise.
     pub speaker_test: Option<SpeakerTest>,
 
+    /// Idle-feed arm generation for the speaker-test pane: 0 = off, and every
+    /// arm message bumps it, so the decode loop can refresh its keepalive
+    /// deadline on each re-arm even though the armed state itself does not
+    /// change. While armed (and while a test runs), the decode loop fabricates
+    /// silence input frames when no real input is flowing, keeping the whole
+    /// output chain warm so a test is audible immediately. Transient like
+    /// `speaker_test`: never persisted, cleared on a fresh start.
+    pub speaker_test_idle_feed_gen: u64,
+
     /// Room proportions `[width, length, height]` used to scale ADM coordinates
     /// before VBAP panning.  Updated live via `/omniphony/control/room_ratio`.
     pub room_ratio: [f32; 3],

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -364,6 +364,7 @@ impl SpatialRenderer {
             // Never restored from config: a session must not come up making
             // noise because a test was running when it was last saved.
             speaker_test: None,
+            speaker_test_idle_feed_gen: 0,
             objects: std::collections::HashMap::new(),
             spread_min,
             spread_max,

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -835,6 +835,31 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
+    if addr == crate::osc_contract::CONTROL_SPEAKER_TEST_IDLE_FEED {
+        // Arm/disarm the idle feed that keeps the output chain warm while the
+        // client's test pane is open. Arming always bumps the generation (even
+        // when already armed) so the decode loop refreshes its keepalive
+        // deadline on every re-arm.
+        let Some(on) = parse_bool_arg(msg.args.first()) else {
+            log::warn!("OSC {addr}: expected [on]");
+            return Some(effects);
+        };
+        // Deliberately NOT mark_dirty: transient like speaker_test. Log only
+        // the arm/disarm edges, not the periodic re-arms.
+        let mut live = ctx.renderer.live.write();
+        if on {
+            if live.speaker_test_idle_feed_gen == 0 {
+                effects.log_message = Some("OSC: speaker_test idle feed -> armed".to_string());
+            }
+            live.speaker_test_idle_feed_gen =
+                live.speaker_test_idle_feed_gen.wrapping_add(1).max(1);
+        } else if live.speaker_test_idle_feed_gen != 0 {
+            live.speaker_test_idle_feed_gen = 0;
+            effects.log_message = Some("OSC: speaker_test idle feed -> off".to_string());
+        }
+        return Some(effects);
+    }
+
     if addr == "/omniphony/control/binaural_mode" {
         // Switch the binaural stage between per-object HRTF ("direct") and the
         // virtual-speaker cascade ("cascaded"). No topology recompute: the

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -192,6 +192,16 @@ pub const CONTROL_RELOAD_CONFIG: &str = "/omniphony/control/reload_config";
 /// toggle) is the client's, so the renderer only ever hears "start this" or
 /// "stop". Transient: never persisted, and cleared on a fresh start.
 pub const CONTROL_SPEAKER_TEST: &str = "/omniphony/control/speaker_test";
+/// Arm/disarm the speaker-test idle feed.
+///
+/// Args: `[on: Int]` (non-zero arms). While armed, the decode loop fabricates
+/// silence input frames whenever no real input is flowing, so the output chain
+/// is already warm when a speaker test starts and the noise is heard
+/// immediately instead of after the writer/latency-controller settling time.
+/// The arm expires after a keepalive window; clients re-send it periodically
+/// while their test pane is open, so a dead client cannot leave the feed
+/// running forever. Transient: never persisted, cleared on a fresh start.
+pub const CONTROL_SPEAKER_TEST_IDLE_FEED: &str = "/omniphony/control/speaker_test/idle_feed";
 pub const CONTROL_RENDER_BACKEND: &str = "/omniphony/control/render_backend";
 pub const CONTROL_RENDER_BACKEND_RESTORE: &str = "/omniphony/control/render_backend/restore";
 pub const CONTROL_RENDER_BRIDGE_PATH: &str = "/omniphony/control/render/bridge_path";
@@ -403,6 +413,7 @@ pub const ALL_CONTROL: &[&str] = &[
     CONTROL_REALTIME_SPEAKER_GAIN,
     CONTROL_RELOAD_CONFIG,
     CONTROL_SPEAKER_TEST,
+    CONTROL_SPEAKER_TEST_IDLE_FEED,
     CONTROL_RENDER_BACKEND,
     CONTROL_RENDER_BACKEND_RESTORE,
     CONTROL_RENDER_BRIDGE_PATH,

--- a/omniphony-renderer/src/cli/decode/idle_feed.rs
+++ b/omniphony-renderer/src/cli/decode/idle_feed.rs
@@ -1,0 +1,274 @@
+//! Idle silence feed for the speaker test.
+//!
+//! A speaker test only makes sound while the render loop runs, and the render
+//! loop only runs when decoded frames arrive. With no input stream nothing
+//! flows, so a test started from idle stayed silent (or, with the reverted
+//! render-pump approach, starved the adaptive latency controller by writing
+//! output the input path never saw — converge, hard-recover, cut).
+//!
+//! The fix mirrors what PipeWire live input mode does naturally: keep the
+//! *input* flowing. While a client's test pane is armed (or a test is
+//! running), the decode loop fabricates silence frames and pushes them through
+//! `handle_audio_message` — the exact path real frames take — so the writer,
+//! the latency controller and the metering all see an ordinary stream. The
+//! feed stops the moment real input shows up again.
+//!
+//! This module owns only the *decision and pacing*; the frame fabrication and
+//! the actual handler call stay in `session_run`, next to the decode loop.
+
+use std::time::{Duration, Instant};
+
+/// Arm keepalive: an arm message is honoured this long, and every re-arm
+/// refreshes the window. Studio re-arms on a much shorter period while its
+/// test pane is open, so an expiry means the client is gone — the feed must
+/// not outlive it forever.
+const KEEPALIVE: Duration = Duration::from_secs(600);
+
+/// A real frame this recent means input is flowing: do not feed. Above the
+/// 50 ms decode-loop receive timeout so ordinary inter-frame gaps never
+/// trigger the feed, below anything a human would notice as warm-up.
+const REAL_FRAME_HOLDOFF: Duration = Duration::from_millis(250);
+
+/// Cap on a single fabricated chunk. Bounds the burst after a stall (standby,
+/// a debugger pause) — the excess wall time is dropped, not queued as audio.
+const MAX_CHUNK: Duration = Duration::from_millis(250);
+
+/// Live-param + session inputs the pacing decision needs, decoupled from the
+/// handler so the logic is unit-testable.
+pub struct IdleFeedInputs {
+    /// `LiveParams::speaker_test_idle_feed_gen` (0 = disarmed).
+    pub arm_gen: u64,
+    /// A speaker test is currently requested (`LiveParams::speaker_test`).
+    pub test_active: bool,
+    /// The applied input mode delivers frames continuously on its own when
+    /// idle (PipeWire live capture) — feeding would double-drive the chain.
+    pub input_self_feeding: bool,
+    /// Sample rate for fabricated frames (last stream's, or the default).
+    pub sample_rate: u32,
+}
+
+/// One fabricated chunk of silence to push through the input path.
+pub struct IdleFeedChunk {
+    pub sample_count: u32,
+    pub sample_rate: u32,
+}
+
+pub struct IdleFeeder {
+    last_arm_gen: u64,
+    armed_until: Option<Instant>,
+    last_real_frame_at: Option<Instant>,
+    feeding: bool,
+    last_pump_at: Option<Instant>,
+    frac_samples: f64,
+}
+
+impl Default for IdleFeeder {
+    fn default() -> Self {
+        Self {
+            last_arm_gen: 0,
+            armed_until: None,
+            last_real_frame_at: None,
+            feeding: false,
+            last_pump_at: None,
+            frac_samples: 0.0,
+        }
+    }
+}
+
+impl IdleFeeder {
+    /// A real (channel-delivered, accepted-source) frame arrived.
+    pub fn note_real_frame(&mut self, now: Instant) {
+        self.last_real_frame_at = Some(now);
+        self.stop_feeding();
+    }
+
+    fn stop_feeding(&mut self) {
+        if self.feeding {
+            log::info!("Speaker-test idle feed: stopping (real input or disarm)");
+        }
+        self.feeding = false;
+        self.last_pump_at = None;
+        self.frac_samples = 0.0;
+    }
+
+    /// Called from the decode loop's receive-timeout branch. Returns a chunk
+    /// of silence to fabricate, or `None` when the feed should stay quiet.
+    pub fn poll(&mut self, now: Instant, inputs: &IdleFeedInputs) -> Option<IdleFeedChunk> {
+        if inputs.arm_gen != self.last_arm_gen {
+            self.last_arm_gen = inputs.arm_gen;
+            self.armed_until = (inputs.arm_gen != 0).then(|| now + KEEPALIVE);
+        }
+        let armed = inputs.test_active || self.armed_until.is_some_and(|deadline| now < deadline);
+        if !armed || inputs.input_self_feeding {
+            self.stop_feeding();
+            return None;
+        }
+        if self
+            .last_real_frame_at
+            .is_some_and(|at| now.saturating_duration_since(at) < REAL_FRAME_HOLDOFF)
+        {
+            self.stop_feeding();
+            return None;
+        }
+
+        let Some(last_pump_at) = self.last_pump_at else {
+            // First armed tick: start the clock, emit from the next one, so a
+            // stale wall-time gap never turns into a burst of audio.
+            log::info!("Speaker-test idle feed: starting silence injection");
+            self.feeding = true;
+            self.last_pump_at = Some(now);
+            self.frac_samples = 0.0;
+            return None;
+        };
+
+        let elapsed = now.saturating_duration_since(last_pump_at).min(MAX_CHUNK);
+        self.last_pump_at = Some(now);
+        let sample_rate = inputs.sample_rate.max(1);
+        let exact = elapsed.as_secs_f64() * sample_rate as f64 + self.frac_samples;
+        let sample_count = exact.floor();
+        self.frac_samples = exact - sample_count;
+        if sample_count < 1.0 {
+            return None;
+        }
+        Some(IdleFeedChunk {
+            sample_count: sample_count as u32,
+            sample_rate,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(arm_gen: u64) -> IdleFeedInputs {
+        IdleFeedInputs {
+            arm_gen,
+            test_active: false,
+            input_self_feeding: false,
+            sample_rate: 48_000,
+        }
+    }
+
+    #[test]
+    fn disarmed_never_feeds() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        assert!(feeder.poll(t0, &inputs(0)).is_none());
+        assert!(
+            feeder
+                .poll(t0 + Duration::from_millis(50), &inputs(0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn armed_feeds_wall_clock_samples_after_priming_tick() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        // Priming tick starts the clock without emitting.
+        assert!(feeder.poll(t0, &inputs(1)).is_none());
+        let chunk = feeder
+            .poll(t0 + Duration::from_millis(50), &inputs(1))
+            .expect("second tick emits");
+        assert_eq!(chunk.sample_count, 2400);
+        assert_eq!(chunk.sample_rate, 48_000);
+    }
+
+    #[test]
+    fn fractional_samples_carry_across_ticks() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        let mut inputs = inputs(1);
+        inputs.sample_rate = 44_100;
+        assert!(feeder.poll(t0, &inputs).is_none());
+        let mut total = 0u64;
+        for tick in 1..=10 {
+            if let Some(chunk) = feeder.poll(t0 + Duration::from_millis(50 * tick), &inputs) {
+                total += chunk.sample_count as u64;
+            }
+        }
+        // 500 ms at 44.1 kHz = 22050 samples; per-tick floor must not lose any.
+        assert_eq!(total, 22_050);
+    }
+
+    #[test]
+    fn stall_is_capped_not_queued() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        assert!(feeder.poll(t0, &inputs(1)).is_none());
+        let chunk = feeder
+            .poll(t0 + Duration::from_secs(30), &inputs(1))
+            .expect("emits after stall");
+        assert_eq!(chunk.sample_count as u128, MAX_CHUNK.as_millis() * 48);
+    }
+
+    #[test]
+    fn real_frame_holds_the_feed_off() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        assert!(feeder.poll(t0, &inputs(1)).is_none());
+        feeder.note_real_frame(t0 + Duration::from_millis(60));
+        // Within the holdoff: quiet, and the pacing clock was reset.
+        assert!(
+            feeder
+                .poll(t0 + Duration::from_millis(100), &inputs(1))
+                .is_none()
+        );
+        // Past the holdoff: primes again, then emits.
+        assert!(
+            feeder
+                .poll(t0 + Duration::from_millis(400), &inputs(1))
+                .is_none()
+        );
+        assert!(
+            feeder
+                .poll(t0 + Duration::from_millis(450), &inputs(1))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn keepalive_expires_without_rearm_but_refreshes_on_gen_bump() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        assert!(feeder.poll(t0, &inputs(1)).is_none());
+        let expired = t0 + KEEPALIVE + Duration::from_secs(1);
+        assert!(feeder.poll(expired, &inputs(1)).is_none());
+        // A re-arm (gen bump) opens a fresh window: prime, then emit.
+        assert!(feeder.poll(expired, &inputs(2)).is_none());
+        assert!(
+            feeder
+                .poll(expired + Duration::from_millis(50), &inputs(2))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn active_test_feeds_even_without_arm() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        let mut inputs = inputs(0);
+        inputs.test_active = true;
+        assert!(feeder.poll(t0, &inputs).is_none());
+        assert!(
+            feeder
+                .poll(t0 + Duration::from_millis(50), &inputs)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn self_feeding_input_disables_the_feed() {
+        let mut feeder = IdleFeeder::default();
+        let t0 = Instant::now();
+        let mut inputs = inputs(1);
+        inputs.input_self_feeding = true;
+        assert!(feeder.poll(t0, &inputs).is_none());
+        assert!(
+            feeder
+                .poll(t0 + Duration::from_millis(50), &inputs)
+                .is_none()
+        );
+    }
+}

--- a/omniphony-renderer/src/cli/decode/mod.rs
+++ b/omniphony-renderer/src/cli/decode/mod.rs
@@ -2,6 +2,7 @@ mod bootstrap;
 mod config_resolution;
 pub mod decoder_thread;
 pub mod handler;
+mod idle_feed;
 mod live_input;
 pub mod output;
 mod output_runtime_sync;

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -1,10 +1,11 @@
 use super::bootstrap::init_render_handler;
 use super::config_resolution::{effective_to_config, merge_render_config};
 use super::decoder_thread::{
-    DecodedAudioData, DecoderCommand, DecoderMessage, DecoderThreadConfig, PipeInputDiag,
-    spawn_decoder_thread,
+    DecodedAudioData, DecodedSource, DecoderCommand, DecoderMessage, DecoderThreadConfig,
+    PipeInputDiag, spawn_decoder_thread,
 };
 use super::handler::DecodeHandler;
+use super::idle_feed::{IdleFeedInputs, IdleFeeder};
 use super::live_input::{LiveBridgeRuntimeConfig, spawn_live_input_manager};
 use super::state::FrameHandlerContext;
 use crate::cli::command::{Cli, EvaluationModeArg, OutputBackend, RenderArgSources, RenderArgs};
@@ -40,6 +41,11 @@ struct PreparedDecodeRun {
     /// Receives per-packet emitted audio duration (microseconds) from the
     /// decoder thread; consumed by the pure pipe-bridge pacer drain thread.
     drain_rx: Option<mpsc::Receiver<u64>>,
+    /// Sender side of the pacer drain clock, kept so the speaker-test idle
+    /// feed can post tokens for its fabricated frames — in pure pipe-bridge
+    /// mode nothing else drains the output FIFO, so silence fed without a
+    /// matching token would fill the pacer and never reach the device.
+    drain_tx: mpsc::Sender<u64>,
     pipe_input_diag: PipeInputDiag,
     pacer_bridge_diag: PacerBridgeDiag,
     _shutdown: sys::ShutdownHandle,
@@ -269,7 +275,7 @@ fn prepare_render_run(args: &RenderArgs) -> Result<PreparedDecodeRun> {
         drain_pipe: !args.no_drain_pipe,
         tx: tx.clone(),
         cmd_rx,
-        drain_tx: Some(drain_tx),
+        drain_tx: Some(drain_tx.clone()),
         pipe_input_diag: Some(pipe_input_diag.clone()),
         bridge,
         shutdown_signal,
@@ -281,6 +287,7 @@ fn prepare_render_run(args: &RenderArgs) -> Result<PreparedDecodeRun> {
         cmd_tx,
         decode_thread,
         drain_rx: Some(drain_rx),
+        drain_tx,
         pipe_input_diag,
         pacer_bridge_diag,
         _shutdown: shutdown,
@@ -535,11 +542,81 @@ fn standby_idle_until_resume(handler: &mut DecodeHandler, mut drain: impl FnMut(
     }
 }
 
+/// While the speaker-test idle feed is armed and no real input flows,
+/// fabricate a chunk of decoded silence and push it through the exact same
+/// path a real frame takes (`handle_audio_message`), so the writer, the
+/// adaptive latency controller and the metering all see an ordinary stream.
+/// Rendering silence still runs `inject_speaker_test`, which is what makes a
+/// test audible — and immediate — with no programme playing.
+fn pump_idle_feed(
+    feeder: &mut IdleFeeder,
+    handler: &mut DecodeHandler,
+    ctx: &DecodeRunContext<'_>,
+    drain_tx: &mpsc::Sender<u64>,
+) -> Result<()> {
+    // No spatial renderer means no speaker test to keep warm.
+    let Some(renderer) = handler.spatial_renderer.as_ref() else {
+        return Ok(());
+    };
+    let (arm_gen, test_active) = {
+        let control = renderer.renderer_control();
+        let live = control.live.read();
+        (live.speaker_test_idle_feed_gen, live.speaker_test.is_some())
+    };
+    // PipeWire live capture delivers silence frames on the graph clock all by
+    // itself when idle — that mode never needs (or wants) a second driver.
+    let input_self_feeding = handler
+        .input_control
+        .as_ref()
+        .map(|control| control.applied_snapshot().active_mode == audio_input::InputMode::Live)
+        .unwrap_or(false);
+    let inputs = IdleFeedInputs {
+        arm_gen,
+        test_active,
+        input_self_feeding,
+        sample_rate: handler.session.final_sample_rate,
+    };
+    let Some(chunk) = feeder.poll(std::time::Instant::now(), &inputs) else {
+        return Ok(());
+    };
+
+    let channel_count = 2u32;
+    let frame = bridge_api::RDecodedFrame {
+        sampling_frequency: chunk.sample_rate,
+        sample_count: chunk.sample_count,
+        channel_count,
+        pcm: vec![0i32; (chunk.sample_count * channel_count) as usize].into(),
+        channel_labels: vec![bridge_api::RChannelLabel::L, bridge_api::RChannelLabel::R].into(),
+        metadata: abi_stable::std_types::RVec::new(),
+        drc_gain: 1.0,
+        drc_ramp_duration: 0,
+        dialogue_level: abi_stable::std_types::ROption::RNone,
+        is_new_segment: false,
+    };
+    // Post the pacer drain token first, exactly like the decoder thread does
+    // for a real packet. Ignored (by the drain thread) outside pure
+    // pipe-bridge mode; a closed channel just means the run is winding down.
+    let emitted_us = chunk.sample_count as u64 * 1_000_000 / chunk.sample_rate.max(1) as u64;
+    let _ = drain_tx.send(emitted_us);
+    handle_audio_message(
+        handler,
+        DecodedAudioData {
+            source: DecodedSource::Bridge,
+            frame,
+            decode_time_ms: 0.0,
+            sent_at: std::time::Instant::now(),
+        },
+        ctx,
+    )
+}
+
 fn process_decoder_messages(
     rx: &mpsc::Receiver<Result<DecoderMessage>>,
     handler: &mut DecodeHandler,
     ctx: &DecodeRunContext<'_>,
+    drain_tx: &mpsc::Sender<u64>,
 ) -> Result<()> {
+    let mut idle_feeder = IdleFeeder::default();
     loop {
         if sys::shutdown::is_standby_requested() {
             run_standby_until_resume(rx, handler);
@@ -553,12 +630,21 @@ fn process_decoder_messages(
                     break;
                 }
                 handler.poll_runtime_state()?;
+                pump_idle_feed(&mut idle_feeder, handler, ctx, drain_tx)?;
                 continue;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         };
         match result {
-            Ok(DecoderMessage::AudioData(frame)) => handle_audio_message(handler, frame, ctx)?,
+            Ok(DecoderMessage::AudioData(frame)) => {
+                // Real input showing up (whatever its cadence) silences the
+                // idle feed; only frames the handler will actually accept
+                // count, so a stray producer can't starve the feed.
+                if handler.should_accept_source(frame.source) {
+                    idle_feeder.note_real_frame(std::time::Instant::now());
+                }
+                handle_audio_message(handler, frame, ctx)?
+            }
             Ok(DecoderMessage::FlushRequest(source)) => {
                 if handler.should_accept_source(source) {
                     handler.handle_decoder_flush_request();
@@ -635,7 +721,7 @@ fn run_render_message_phase(
     let run_ctx = DecodeRunContext { args };
 
     sys::notify_ready();
-    process_decoder_messages(&prepared.rx, handler, &run_ctx)
+    process_decoder_messages(&prepared.rx, handler, &run_ctx, &prepared.drain_tx)
 }
 
 fn finalize_render_run(

--- a/omniphony-studio/src-tauri/src/commands/gain.rs
+++ b/omniphony-studio/src-tauri/src/commands/gain.rs
@@ -102,6 +102,22 @@ pub fn control_auto_gain_ceiling(state: State<SharedState>, db: f32) {
 /// `id < 0` stops any running test. The trigger policy — hold, fixed burst or
 /// toggle — lives in the UI, so this is the whole renderer-facing contract:
 /// start this speaker, or stop.
+/// Arm/disarm the speaker-test idle feed: while armed the renderer fabricates
+/// silence input frames when nothing is playing, so the output chain is warm
+/// and a test is heard immediately. The arm expires renderer-side after a
+/// keepalive window; the UI re-sends it periodically while the Test pane is
+/// open.
+#[tauri::command]
+pub fn control_speaker_test_idle_feed(state: State<SharedState>, enable: bool) {
+    send_control(
+        &state.osc_tx,
+        OscControlMsg::SendInt {
+            address: "/omniphony/control/speaker_test/idle_feed".to_string(),
+            value: if enable { 1 } else { 0 },
+        },
+    );
+}
+
 #[tauri::command]
 pub fn control_speaker_test(state: State<SharedState>, id: i32, level: f32, isolation: String) {
     send_control(

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -234,6 +234,7 @@ fn main() {
             control_object_mute,
             control_speaker_mute,
             control_speaker_test,
+            control_speaker_test_idle_feed,
             control_master_gain,
             control_loudness,
             control_auto_gain,

--- a/omniphony-studio/src/controls/speaker-test.js
+++ b/omniphony-studio/src/controls/speaker-test.js
@@ -21,11 +21,21 @@ const BURST_MS = 2000;
 /** Toggle mode cannot run forever: an unattended test is a room full of noise. */
 const TOGGLE_SAFETY_MS = 60_000;
 
+/**
+ * The renderer expires an idle-feed arm after a keepalive window (10 min)
+ * rather than trust a client to always say goodbye; re-arm well inside it.
+ * The periodic re-send also re-covers a renderer restart mid-session.
+ */
+const IDLE_FEED_REARM_MS = 120_000;
+
 const DEFAULT_LEVEL_DB = -20;
 
 let stopTimer = null;
 /** Speaker index currently under test, or null. */
 let running = null;
+
+let idleFeedTimer = null;
+let idleFeedArmed = false;
 
 function el(id) { return document.getElementById(id); }
 
@@ -63,6 +73,33 @@ function send(id) {
     level: levelLinear(),
     isolation: load(ISOLATION_KEY, 'test_only')
   }).catch(() => { /* renderer gone: the test is moot */ });
+}
+
+function sendIdleFeed(enable) {
+  invoke('control_speaker_test_idle_feed', { enable })
+    .catch(() => { /* renderer gone: nothing to keep warm */ });
+}
+
+/**
+ * The idle feed keeps the renderer's input→output chain warm while the Test
+ * pane is open, so a test makes sound immediately even with nothing playing.
+ * Armed exactly while (Test pane visible AND a speaker is selected); re-sent
+ * periodically because the renderer expires the arm on a keepalive rather
+ * than trust a client to always say goodbye.
+ */
+function syncIdleFeed() {
+  const hasSpeaker = app.selectedSpeakerIndex !== null && app.selectedSpeakerIndex !== undefined;
+  const want = document.body.classList.contains('speaker-tab-test') && hasSpeaker;
+  if (want === idleFeedArmed) return;
+  idleFeedArmed = want;
+  if (want) {
+    sendIdleFeed(true);
+    idleFeedTimer = setInterval(() => sendIdleFeed(true), IDLE_FEED_REARM_MS);
+  } else {
+    clearInterval(idleFeedTimer);
+    idleFeedTimer = null;
+    sendIdleFeed(false);
+  }
 }
 
 /**
@@ -141,6 +178,7 @@ function setSpeakerTab(testTab) {
   const test = el('speakerTabTestBtn');
   if (edit) edit.classList.toggle('active', !testTab);
   if (test) test.classList.toggle('active', testTab);
+  syncIdleFeed();
 }
 
 export function setupSpeakerTestListeners() {
@@ -209,11 +247,15 @@ export function setupSpeakerTestListeners() {
 
   // A test belongs to the speaker it was started on: selecting another one, or
   // closing the editor, must not leave it playing.
-  window.addEventListener('beforeunload', () => stopSpeakerTest({ force: true }));
+  window.addEventListener('beforeunload', () => {
+    stopSpeakerTest({ force: true });
+    if (idleFeedArmed) sendIdleFeed(false);
+  });
 }
 
 /** Called when the speaker selection changes. */
 export function onSpeakerSelectionChanged() {
   if (running !== null && running !== app.selectedSpeakerIndex) stopSpeakerTest();
   else renderSpeakerTestUI();
+  syncIdleFeed();
 }


### PR DESCRIPTION
## Problem

The per-speaker test signal (#235) is only audible while the render loop runs, which means only while decoded frames arrive. With no input stream the test stayed silent, and the earlier idle-pump approach (reverted in 0910050) bypassed the input path entirely — the adaptive latency controller saw input starving against a draining output and did what it must: converge (~5 s), then hard-recover (the half-second cut).

## Approach

Mirror what PipeWire live capture does naturally: keep the **input** flowing. While the client's Test pane is armed (or a test is running), the decode loop's receive-timeout branch fabricates 2-channel silence frames and pushes them through `handle_audio_message` — the exact path real frames take — so the writer lifecycle, the latency controller and the metering all see an ordinary stream. In pure pipe-bridge mode each fabricated chunk also posts a pacer drain token, exactly like the decoder thread does for a real packet.

- New transient control `/omniphony/control/speaker_test/idle_feed` (generation counter in `LiveParams`, never persisted). Re-arms refresh a 10-min engine-side keepalive, so a dead client cannot leave the feed running; an active test feeds regardless of the arm.
- Studio arms exactly while (Test pane open AND speaker selected), re-sends every 2 min (also re-covers a renderer restart), disarms on pane leave / deselection / unload.
- Feeding continuously while the pane is open — the user's idea — means the chain is already warm and the noise starts the instant the button is pressed, instead of after writer + controller settling.
- Guards: yields within 250 ms of any accepted real frame; never feeds in PipeWire live input mode (self-feeding); stalls emit one capped 250 ms chunk, not a burst.

## Verification

Unit tests on the pacing/keepalive logic (8 cases). E2E on a live renderer with no writer on the input FIFO:

- **file backend**: arming creates the writer, output grows at exactly `rate × channels × 4` B/s; a test puts pink noise on the tested speaker's channel alone (all other channels bit-zero over 1 s); real WAV pushed into the FIFO stops the feed (`stopping (real input)`), which resumes when the stream ends; disarm → growth stops completely.
- **pipewire backend**: writer up after the normal 8-frame bootstrap (~350 ms); 20 s of armed silence with zero hard-recover and zero cadence anomalies.

Not covered here: the headphone/binaural output mode still renders no speaker test (known product gap, unchanged), and the mpv-embedded host feeds its own frames so this CLI-side feeder does not apply there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)