### PR TITLE
Studio: save footer back to bottom-center (unclosed Test-pane div)

### DIFF
--- a/omniphony-studio/src/bootstrap-ui.js
+++ b/omniphony-studio/src/bootstrap-ui.js
@@ -12,3 +12,20 @@ initSidePanels();
 // plus the just-mounted panels). Idempotent, so the renderer panel's own
 // mount-time pass is harmless to repeat here.
 wireInlineHelpFromMarkup(document);
+
+// These fixed-position roots must be direct children of <body>: an ancestor
+// with a backdrop-filter (like #speakersOverlay) becomes their containing
+// block, so `left: 50%` centers them inside the panel instead of the window.
+// An unbalanced </div> in the overlay markup has swallowed them twice already —
+// self-heal and complain loudly rather than let the Save/Reload cluster render
+// on top of the right panel again.
+for (const id of ['bandCursor', 'saveFooterRoot', 'rendererInfoModalsRoot']) {
+  const el = document.getElementById(id);
+  if (el && el.parentElement !== document.body) {
+    console.error(
+      `#${id} is nested under #${el.parentElement.id || el.parentElement.tagName} — `
+      + 'unbalanced overlay markup in index.html; reparenting to <body>'
+    );
+    document.body.appendChild(el);
+  }
+}

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -807,6 +807,7 @@
             <input id="speakerTestLevelSlider" class="gain-slider" type="range" min="-60" max="-6" step="1" value="-20" />
             <div id="speakerTestLevelBox" class="gain-box">-20 dBFS</div>
           </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem

Since #235, the scene-fx bar and the Save/Reload buttons rendered at the right of the window, on top of the speakers panel, instead of bottom-center.

## Cause

The speaker Test pane markup opened `<div id="speakerEditTabTest">` without a closing tag. Every subsequent `</div>` shifted one element up, so `#speakersOverlay` never closed and swallowed `#bandCursor`, `#saveFooterRoot` and `#rendererInfoModalsRoot`. The overlay's `backdrop-filter` makes it the containing block for `position: fixed` descendants, so the footer's `left: 50%` centered it inside the right panel rather than the viewport.

## Fix

- Add the missing `</div>` — the overlay closes before `#bandCursor` again.
- Boot-time guard in `bootstrap-ui.js`: these fixed-position roots must be direct children of `<body>`; this is the second time an unbalanced overlay edit has swallowed them, so they now reparent themselves with a loud console error naming the culprit instead of shipping mispositioned.

## Verification

Dev preview (vite): all three roots report `<body>` as parent, and the footer's center sits exactly at the window's horizontal midpoint (offset 0 px); screenshot checked with both side panels open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)