### PR TITLE
Studio: in toggle mode, the speaker test follows the selection

### DIFF
--- a/omniphony-studio/src/controls/speaker-test.js
+++ b/omniphony-studio/src/controls/speaker-test.js
@@ -245,8 +245,7 @@ export function setupSpeakerTestListeners() {
     });
   }
 
-  // A test belongs to the speaker it was started on: selecting another one, or
-  // closing the editor, must not leave it playing.
+  // Whatever the trigger mode, closing the window must not leave noise playing.
   window.addEventListener('beforeunload', () => {
     stopSpeakerTest({ force: true });
     if (idleFeedArmed) sendIdleFeed(false);
@@ -255,7 +254,18 @@ export function setupSpeakerTestListeners() {
 
 /** Called when the speaker selection changes. */
 export function onSpeakerSelectionChanged() {
-  if (running !== null && running !== app.selectedSpeakerIndex) stopSpeakerTest();
-  else renderSpeakerTestUI();
+  const selected = app.selectedSpeakerIndex;
+  const hasSpeaker = selected !== null && selected !== undefined;
+  if (running !== null && running !== selected) {
+    // Toggle means "keep testing until I say stop", and the whole point of
+    // testing several speakers is comparing them: walk the selection down the
+    // layout and the noise walks with it. Hold and burst each own an end
+    // condition of their own (release, timeout), so for those a selection
+    // change still ends the test rather than silently re-arming it elsewhere.
+    if (hasSpeaker && load(MODE_KEY, 'toggle') === 'toggle') startSpeakerTest(selected);
+    else stopSpeakerTest();
+  } else {
+    renderSpeakerTestUI();
+  }
   syncIdleFeed();
 }

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -1177,8 +1177,9 @@ export function applySpeakerPolarEdit(index, az, el, r, sendOsc = true) {
 // ---------------------------------------------------------------------------
 
 export function renderSpeakerEditor() {
-  // A running test belongs to the speaker it was started on; this both stops it
-  // on a selection change and refreshes the button's label/enabled state.
+  // Hands a selection change to the test controls: in toggle mode the running
+  // test follows the new speaker, otherwise it stops. Also refreshes the
+  // button's label/enabled state.
   onSpeakerSelectionChanged();
   const speakerEditSectionEl = getSpeakerEditSectionEl();
   const speakerEditBodyEl = getSpeakerEditBodyEl();


### PR DESCRIPTION
## Problem

With a pink-noise test running, selecting another speaker stopped the sound. Comparing two speakers meant stop → select → press play again, every time.

## Change

In **toggle** mode the running test now moves to the newly selected speaker. Toggle's contract is "keep testing until I say stop", and comparing speakers is what it is for.

**Hold** and **burst** still stop on a selection change: each owns an end condition tied to the speaker it started on (button release, fixed timeout), so following would strand it elsewhere. Deselecting entirely still stops in every mode, and the window-close guard is unchanged.

No renderer change — the engine already carries the speaker index in the test identity, so a start message on a different speaker switches in place (generator and band filters reset, elapsed clock restarts).

## Verification

Live renderer, file backend, 7.1.4, level 0.5, `test_only`; test started on speaker 0, then a switch to speaker 3 sent with **no stop in between**:

- **No gap**: ch0's last active frame (144782) and ch3's first (144783) are adjacent — zero all-silent samples anywhere inside the test region.
- **No click**: the step at the seam is 0.104 on the outgoing channel and 0.423 on the incoming, against the noise's own sample-to-sample slew of mean 0.252 / p99 0.632 / max 0.747. The discontinuity is smaller than the signal's natural slew.

Studio module loads clean in the dev preview (only the pre-existing "no Tauri in a plain browser" invoke errors). Click-through in the packaged app is left to the maintainer, as usual for Studio-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)