### PR TITLE
fix(studio): centre the injected source on the room's origin

### DIFF
--- a/omniphony-studio/src/controls/object-test.js
+++ b/omniphony-studio/src/controls/object-test.js
@@ -1203,7 +1203,14 @@ export function setupObjectTestListeners() {
   if (centre) {
     centre.addEventListener('click', (event) => {
       event.preventDefault();
-      setPosition([0, 1, 0]);
+      // The room's origin, not the front-centre the source starts at. This is
+      // the listener's own position: the one place with no direction at all,
+      // which is exactly what makes it worth being able to reach in one click
+      // — it is the reference every other placement is heard against.
+      //
+      // It is also an exact grid node whenever the interval counts are even,
+      // which the OAMD-derived default of 62 is, so snapping leaves it alone.
+      setPosition([0, 0, 0]);
     });
   }
 


### PR DESCRIPTION
Follow-up to #247.

## What

"Centre the source" put it at `(0, 1, 0)` — the front-centre it *starts* at, which is a sensible place to begin but is not the centre of anything. It now goes to `(0, 0, 0)`: the room's origin, and the listener's own position.

That is the one place with no direction at all, which is exactly what makes it worth reaching in one click — it is the reference every other placement is heard against. It is also an exact grid node whenever the interval counts are even, which the OAMD-derived default of 62 is, so snapping leaves it alone.

The **initial** position stays at front-centre: starting a source at the listener would put it somewhere a panner cannot point at, and the button is there for when you want that deliberately.

## Verified

| check | result |
|---|---|
| from an arbitrary placement | lands on exactly `0, 0, 0` |
| snapping on, default even grid (62) | stays exactly on `0, 0, 0` |
| snapping on, odd interval count (61) | comes to rest just off centre — zero is not a node there |

## A caveat about how it was verified

The button had to be exercised with a dispatched `MouseEvent` rather than `.click()`, because **without a renderer connected Studio disables 269 of its 327 controls** — including this one, and including buttons in unrelated panels (`saveConfigBtn`, `virtualBedResetBtn`, `speakerRemoveBtn`). `.click()` is a no-op on a disabled button; a dispatched event still runs the listener.

So the handler is verified, but the *real click path* is not: in the browser preview it cannot be, and that limitation applies to every Studio check in this series, not just this one.

## Gate

`vite build` clean, `npm run i18n:check` in parity. Frontend only — no Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)