### PR TITLE
fix: binaural output from the CLI renderer — sink width, and two ways the object test broke

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -234,7 +234,10 @@ impl ChannelDsp {
 /// stand-in, which is the whole reason a *binaural* object test is worth having
 /// where a binaural speaker test is not.
 pub struct ExtraSource<'a> {
-    /// Mono samples, `sample_length` of them.
+    /// Mono samples. Normally `sample_length` of them, but **may be shorter**:
+    /// the object test's safety cap ends a run mid-block, and the block it
+    /// returns then stops where the cap did. Only the samples present are
+    /// rendered; the rest of the frame gets nothing from this source.
     pub pcm: &'a [f32],
     /// World (ADM) position, same convention as `chan_pos`.
     pub position: [f64; 3],
@@ -282,6 +285,10 @@ pub struct BinauralRenderer {
     /// Per-input-channel DSP state, indexed directly by channel (sparse tail is
     /// fine; reset when the channel count shrinks).
     channels: Vec<Option<ChannelDsp>>,
+    /// DSP state for the extra source (the object test), kept apart from
+    /// `channels` on purpose: it is not a channel and the input width it would
+    /// otherwise be indexed past changes whenever playback starts or stops.
+    extra_dsp: Option<ChannelDsp>,
     /// Reusable HRIR scratch so `at()` writes in place (no per-channel alloc).
     hrir_scratch: HrirPair,
     /// Bumped every time a rebuilt grid is swapped in, so the per-channel
@@ -330,6 +337,7 @@ impl BinauralRenderer {
             incoming,
             rebuild_tx,
             channels: Vec::new(),
+            extra_dsp: None,
             hrir_scratch: HrirPair {
                 left: [0.0; HRIR_LEN],
                 right: [0.0; HRIR_LEN],
@@ -480,13 +488,24 @@ impl BinauralRenderer {
         if sample_length == 0 || (input_channel_count == 0 && extra.is_none()) {
             return;
         }
-        // The extra source gets a DSP slot of its own past the input channels,
-        // so its convolvers, delay lines and reflection bank persist across
-        // blocks like any channel's — that continuity is what lets it move
-        // without clicking.
+        // The extra source gets a DSP slot of its own — its convolvers, delay
+        // lines and reflection bank persist across blocks like any channel's,
+        // and that continuity is what lets it move without clicking.
+        //
+        // A *dedicated* slot, not one indexed past the input channels: the
+        // input width is not a constant. It is 2 while the idle feed fabricates
+        // silence and whatever the programme carries once one starts, so a slot
+        // at `input_channel_count` moves the moment playback begins or ends —
+        // landing on a fresh (silent, warming up) DSP, or on the state of a
+        // channel that used to live there.
         let source_count = input_channel_count + usize::from(extra.is_some());
-        if self.channels.len() < source_count {
-            self.channels.resize_with(source_count, || None);
+        if self.channels.len() < input_channel_count {
+            self.channels.resize_with(input_channel_count, || None);
+        }
+        if extra.is_none() {
+            // Nothing to carry over: the next test starts clean rather than
+            // spliced onto the tail of a source that was somewhere else.
+            self.extra_dsp = None;
         }
 
         // Late-reverb bus: per-channel sends accumulate here; the shared FDN
@@ -510,6 +529,18 @@ impl BinauralRenderer {
                 Some(e) => (e.pcm, 1usize, 0usize),
                 None => (input_pcm, input_channel_count, c),
             };
+            // How much of the frame this source actually has. Full length for a
+            // channel; for the extra source, however far its block got before
+            // the cap ended it (see `ExtraSource::pcm`). Reading `sample_length`
+            // regardless is an out-of-bounds panic on the render thread — which
+            // is how a binaural object test died at the two-minute mark.
+            let span = match extra_here {
+                Some(e) => sample_length.min(e.pcm.len()),
+                None => sample_length,
+            };
+            if span == 0 {
+                continue;
+            }
             let gain = match extra_here {
                 Some(e) => e.gain,
                 None => chan_gain.get(c).copied().unwrap_or(0.0),
@@ -517,7 +548,11 @@ impl BinauralRenderer {
             if gain == 0.0 {
                 // Keep an existing reflection bank fading out so a muted
                 // channel does not freeze its taps at full gain.
-                if let Some(Some(dsp)) = self.channels.get_mut(c) {
+                let slot = match extra_here {
+                    Some(_) => self.extra_dsp.as_mut(),
+                    None => self.channels.get_mut(c).and_then(|s| s.as_mut()),
+                };
+                if let Some(dsp) = slot {
                     if let Some(bank) = dsp.refl.as_mut() {
                         bank.mute_targets();
                     }
@@ -540,7 +575,7 @@ impl BinauralRenderer {
                     // reflections-disabled branch below).
                     dsp.refl = None;
                 }
-                for s in 0..sample_length {
+                for s in 0..span {
                     let v = src_pcm[s * src_stride + src_offset]
                         * gain
                         * std::f32::consts::FRAC_1_SQRT_2;
@@ -590,7 +625,11 @@ impl BinauralRenderer {
                     hrir_update_lattice.subdiv(),
                 ),
             );
-            let dsp = self.channels[c].get_or_insert_with(|| ChannelDsp::new(self.sample_rate));
+            let rate = self.sample_rate;
+            let dsp = match extra_here {
+                Some(_) => self.extra_dsp.get_or_insert_with(|| ChannelDsp::new(rate)),
+                None => self.channels[c].get_or_insert_with(|| ChannelDsp::new(rate)),
+            };
             if dsp.last_dir != Some(dir) {
                 dsp.last_dir = Some(dir);
                 self.hrir.set.at_key(dir.1, &mut self.hrir_scratch);
@@ -665,7 +704,7 @@ impl BinauralRenderer {
             }
 
             let air = dsp.air_coeff;
-            for s in 0..sample_length {
+            for s in 0..span {
                 // `raw` carries the object/metadata gain only; the direct path
                 // adds its distance gain, the reflection taps theirs. The air
                 // low-pass applies to the propagated wave, so it feeds the
@@ -800,6 +839,88 @@ mod tests {
             er > el,
             "a hard-right extra source must favour the right ear (L={el} R={er}) \
              — equal ears mean it bypassed the HRIR path"
+        );
+    }
+
+    /// The cap can end a test mid-block, and then the extra source's PCM is
+    /// shorter than the frame. Reported from use: binaural object injection
+    /// died after a couple of minutes with something in the log.
+    #[test]
+    fn a_short_extra_block_does_not_run_off_the_end() {
+        let mut r = BinauralRenderer::new(48_000);
+        let n = 512;
+        let input = vec![0.0f32; n];
+        let extra_pcm = vec![0.1f32; 200]; // the cap ran out 200 samples in
+        let mut out = vec![0.0f32; n * 2];
+        r.render_frame(
+            &input,
+            1,
+            n,
+            &dry_params(),
+            &[[0.0, 1.0, 0.0]],
+            &[0.0],
+            &[],
+            Some(ExtraSource {
+                pcm: &extra_pcm,
+                position: [1.0, 0.0, 0.0],
+                gain: 1.0,
+            }),
+            &mut out,
+        );
+    }
+
+    /// The extra source keeps its own DSP state when the input width changes.
+    ///
+    /// The input width is not a constant: it is 2 while the idle feed fabricates
+    /// silence and whatever the programme carries once one starts. A DSP slot
+    /// indexed past the input channels therefore moves the moment playback
+    /// begins — onto a fresh convolver that has to warm up again, or onto the
+    /// state of some channel that used to sit there. Either way the source
+    /// stutters, in the middle of the one gesture the test exists to judge.
+    ///
+    /// Asserted on continuity: a steady input through a settled convolver gives
+    /// a steady output, so a drop right after the width change is the warm-up of
+    /// a slot that should not have been touched.
+    #[test]
+    fn the_extra_source_survives_a_change_of_input_width() {
+        let mut r = BinauralRenderer::new(48_000);
+        let n = 512;
+        let extra_pcm = vec![0.5f32; n];
+        let steady = |r: &mut BinauralRenderer, channels: usize| -> f32 {
+            let input = vec![0.0f32; n * channels];
+            let mut out = vec![0.0f32; n * 2];
+            r.render_frame(
+                &input,
+                channels,
+                n,
+                &dry_params(),
+                &vec![[0.0, 1.0, 0.0]; channels],
+                &vec![0.0; channels],
+                &vec![false; channels],
+                Some(ExtraSource {
+                    pcm: &extra_pcm,
+                    position: [1.0, 0.0, 0.0],
+                    gain: 1.0,
+                }),
+                &mut out,
+            );
+            // RMS of the first 32 samples: where a warm-up would show.
+            let head: f32 = out[..64].iter().map(|v| v * v).sum::<f32>() / 32.0;
+            head.sqrt()
+        };
+
+        // Settle at the idle-feed width.
+        for _ in 0..4 {
+            steady(&mut r, 2);
+        }
+        let before = steady(&mut r, 2);
+        // Playback starts: the programme is wider than the silence was.
+        let after = steady(&mut r, 12);
+        assert!(before > 0.0, "the extra source produced nothing to compare");
+        assert!(
+            (after - before).abs() < before * 0.05,
+            "the extra source dropped from {before} to {after} when the input \
+             width changed — its DSP slot moved with the channel count"
         );
     }
 

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -497,11 +497,37 @@ impl DecodeHandler {
             let bed_indices = self.spatial.bed_indices.as_ref().unwrap_or(&empty_vec);
             ChannelCountCalculator::calculate_conformed_channel_count(channel_count, bed_indices)
         } else if let Some(ref renderer) = self.spatial_renderer {
-            // When VBAP is active, output channel count is the number of speakers
-            renderer.num_speakers()
+            // What the renderer EMITS, which is the speaker count only while it
+            // is rendering speakers: headphone mode emits a stereo pair from a
+            // wholly separate path. Sizing the sink from `num_speakers()`
+            // instead built a twelve-channel PipeWire stream and then fed it
+            // stereo frames, so the device consumed six frames' worth of
+            // channels per frame — heard as chopped noise, and the reason a
+            // binaural object test was unlistenable.
+            renderer.output_channel_count()
         } else {
             channel_count
         };
+
+        // A live headphone toggle changes that width under a writer that has
+        // already been built for the old one. Retire it here so the block below
+        // builds a new one; the alternative is the same mismatch, arrived at
+        // from the other direction.
+        if self
+            .output
+            .audio_writer_channels
+            .is_some_and(|built| built != effective_channel_count)
+        {
+            log::info!(
+                "Output width changed ({} → {} channels): rebuilding the audio writer",
+                self.output.audio_writer_channels.unwrap_or(0),
+                effective_channel_count,
+            );
+            if let Some(mut writer) = self.output.invalidate_writer() {
+                let _ = writer.flush();
+            }
+            self.output.reset_realtime_output_tracking();
+        }
 
         OutputRuntimeCoordinator::new(
             &mut self.output,
@@ -612,6 +638,7 @@ impl DecodeHandler {
                 None,
             )?,
         );
+        self.output.audio_writer_channels = Some(effective_channel_count);
         self.reset_spatial_state_for_segment();
         Ok(())
     }

--- a/omniphony-renderer/src/cli/decode/sample_write.rs
+++ b/omniphony-renderer/src/cli/decode/sample_write.rs
@@ -291,8 +291,24 @@ impl<'a> SampleWriteCoordinator<'a> {
                     let num_speakers = renderer.num_speakers();
 
                     let meter_snapshot = if has_metering_clients {
+                        // Which accumulators the frame belongs in depends on what
+                        // was rendered, not on the layout: a binaural frame is a
+                        // stereo pair and metering it as `num_speakers` speakers
+                        // strides through it wrongly and leaves the ear gauges
+                        // dead. Same policy as the engine host.
+                        let virtual_bus = renderer.virtual_bus();
+                        let binaural = renderer.output_is_binaural();
                         self.telemetry.audio_meter.as_mut().and_then(|m| {
-                            m.process_speakers(&rendered.samples, num_speakers);
+                            match (virtual_bus, binaural) {
+                                (Some((bus, n_bus)), _) => {
+                                    m.process_speakers(bus, n_bus);
+                                    m.process_ears(&rendered.samples);
+                                }
+                                (None, true) => m.process_ears(&rendered.samples),
+                                (None, false) => {
+                                    m.process_speakers(&rendered.samples, rendered.n_channels)
+                                }
+                            }
                             m.poll()
                         })
                     } else {
@@ -477,8 +493,24 @@ impl<'a> SampleWriteCoordinator<'a> {
                     let num_speakers = renderer.num_speakers();
 
                     let meter_snapshot = if has_metering_clients {
+                        // Which accumulators the frame belongs in depends on what
+                        // was rendered, not on the layout: a binaural frame is a
+                        // stereo pair and metering it as `num_speakers` speakers
+                        // strides through it wrongly and leaves the ear gauges
+                        // dead. Same policy as the engine host.
+                        let virtual_bus = renderer.virtual_bus();
+                        let binaural = renderer.output_is_binaural();
                         self.telemetry.audio_meter.as_mut().and_then(|m| {
-                            m.process_speakers(&rendered.samples, num_speakers);
+                            match (virtual_bus, binaural) {
+                                (Some((bus, n_bus)), _) => {
+                                    m.process_speakers(bus, n_bus);
+                                    m.process_ears(&rendered.samples);
+                                }
+                                (None, true) => m.process_ears(&rendered.samples),
+                                (None, false) => {
+                                    m.process_speakers(&rendered.samples, rendered.n_channels)
+                                }
+                            }
                             m.poll()
                         })
                     } else {

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -150,6 +150,13 @@ impl Default for SpatialState {
 
 pub struct OutputState {
     pub audio_writer: Option<AudioWriter>,
+    /// Channel count [`Self::audio_writer`] was built for.
+    ///
+    /// The sink is created once, from the width the renderer emitted at the
+    /// time; the output mode can change afterwards (a headphone toggle swaps a
+    /// speaker array for a stereo pair). Remembering what was built is what lets
+    /// the caller notice the two have parted company and rebuild.
+    pub audio_writer_channels: Option<usize>,
     pub bootstrap_frames_seen: u32,
     pub bootstrap_started_at: Option<Instant>,
     pub render_buf: Vec<f32>,
@@ -170,6 +177,7 @@ impl Default for OutputState {
     fn default() -> Self {
         Self {
             audio_writer: None,
+            audio_writer_channels: None,
             bootstrap_frames_seen: 0,
             bootstrap_started_at: None,
             render_buf: Vec::new(),
@@ -191,6 +199,7 @@ impl Default for OutputState {
 impl OutputState {
     pub fn invalidate_writer(&mut self) -> Option<AudioWriter> {
         self.output_init_failed = false;
+        self.audio_writer_channels = None;
         self.audio_writer.take()
     }
 

--- a/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
+++ b/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
@@ -69,6 +69,7 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                             self.runtime.output_file_format,
                         );
                         self.output.audio_writer = Some(writer);
+                        self.output.audio_writer_channels = Some(channel_count);
                         if let Some(control) = self.audio_control {
                             control.set_audio_error(None);
                         }
@@ -165,6 +166,7 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                             ic.install_output_pacer(handle);
                         }
                         self.output.audio_writer = Some(writer);
+                        self.output.audio_writer_channels = Some(channel_count);
                         self.output.bootstrap_frames_seen = 0;
                         self.output.bootstrap_started_at = None;
                         if let Some(control) = self.audio_control {
@@ -205,6 +207,7 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                 match self.build_audio_writer(output_backend, sample_rate, channel_count, None) {
                     Ok(writer) => {
                         self.output.audio_writer = Some(writer);
+                        self.output.audio_writer_channels = Some(channel_count);
                         if let Some(control) = self.audio_control {
                             control.set_audio_error(None);
                         }


### PR DESCRIPTION
Reported from use: *"je viens de tester en binaural, et le son est complètement haché, et au bout d'un moment ça coupe"*. Two independent faults, both reproduced before being fixed.

## The chopping: the sink was six times too wide

`orender render` built its output sink from `num_speakers()`. That is the right width only while the renderer is rendering speakers — headphone mode bypasses the VBAP chain entirely and emits a stereo pair from a separate path. `output_channel_count()` exists precisely to say which it is, and its doc tells hosts to size their sink from it. The engine host (liborender, so mpv) does. The CLI never did.

A binaural session therefore created a **twelve-channel** PipeWire stream and fed it **two-channel** frames: six frames' worth of channels consumed per frame delivered.

| on the live system | `pw-dump` |
|---|---|
| before | `omniphony-vbap-renderer`, **12 channels**, `AUX0..AUX11` — on a stereo headphone sink |
| after | `omniphony-vbap-renderer`, **2 channels**, `AUX0,AUX1` |

This is why it only showed up now: binaural through mpv goes via the engine and was always sized correctly. The object test is the first reason to listen in binaural through the standalone renderer, so it is the first thing to hit it.

The width can also change *under* a sink already built (a headphone toggle mid-session), so the writer now records what it was built for and is rebuilt when the two disagree. That path also covers startup, where the mode settles a beat after the first frame — the log shows the 12-channel stream retired and a stereo one built in its place.

Metering had the same blind spot: a stereo frame walked as `num_speakers` speakers, and the ear gauges never fed at all. Now the same policy as the engine host.

## The cutout: an index past the end of the block

`ExtraSource::pcm` is normally frame-length, but not always — the object test's safety cap ends a run mid-block, and the block stops where the cap did. The binaural loop read `sample_length` samples regardless.

```
thread panicked at renderer/src/binaural/mod.rs:673:31:
index out of bounds: the len is 200 but the index is 200
```

At exactly two minutes, on the render thread. The speaker path already clamped to `noise.len()`; this one did not. Test first, then the fix.

## And one the report did not mention

The extra source's DSP slot was `input_channel_count` — "past the end of the channels". But the input width is not a constant: 2 while the idle feed fabricates silence, whatever the programme carries once one starts. So the slot moved the moment playback began or ended, onto a cold convolver or onto the state of a channel that used to live there. The regression test measures an **83 % level drop** (0.315 → 0.054) across such a change. It now has a slot of its own.

## Verified

Live, binaural, idle feed, orbiting source, captured through the `file` backend:

| check | result |
|---|---|
| duration | 120 s of signal, then exact silence — the cap, doing its job |
| level | −20.2 dBFS RMS, spread ±0.3 dB across 120 one-second windows |
| gaps | zero-runs in the first 100 s: **none** |
| clicks | largest sample step 0.225 against a 99.99th percentile of 0.180 |
| the renderer | still running afterwards |

Gate: `cargo fmt --check`, `cargo build --release`, `cargo test --workspace` (31 suites, 0 failures).

**Not verified:** nobody has listened to it. The measurements say the stream is continuous, correctly sized and click-free; they do not say it sounds right.