### PR TITLE
fix(studio): draw the snap grid when snapping is switched, not later

### DIFF
--- a/omniphony-studio/src/controls/object-test.js
+++ b/omniphony-studio/src/controls/object-test.js
@@ -1471,6 +1471,12 @@ export function setupObjectTestListeners() {
       // Turning it on pulls the source onto the grid at once, rather than
       // waiting for the next drag to reveal what it does.
       if (snapOn) setPosition(position.slice());
+      // The ticks are drawn by `updateMarkers`, and nothing above reliably
+      // reaches it: `setPosition` returns early when the source was already on
+      // a node, and turning snapping *off* moves nothing at all. So the grid
+      // appeared only once something else redrew the sheet, and never went
+      // away by itself.
+      updateMarkers();
       renderObjectTestUI();
     });
   }


### PR DESCRIPTION
Reported: the snap ticks do not appear when Snap to grid is switched on — you have to toggle the ADM view to make them draw — and they do not disappear when it is switched off.

The ticks are painted by `updateMarkers`, and the switch never reliably reached it:

- **on** → went through `setPosition`, which returns early when the source is already on a node, so nothing redrew;
- **off** → moves nothing at all, so nothing redrew either.

The grid therefore appeared only once something else happened to rebuild the sheet, and never went away by itself. Redraw unconditionally from the switch.

Verified in the browser with the renderer's Cartesian sizes stood in (62/62/15/0):

| action | grid path data |
|---|---|
| before | 0 chars |
| snap on | 6361 chars — 128 / 96 / 96 ticks across the three faces |
| snap off | 0 chars |

No other behaviour touched: `setPosition` still pulls the source onto the grid when snapping is switched on.