### PR TITLE
docs: attach output-stage doc to finalize_output

### DIFF
--- a/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
@@ -801,11 +801,6 @@ impl SpeakerRenderStage {
         Ok(())
     }
 
-    /// Output stage: per-speaker gains (live gain/mute × `total_gain`), delay
-    /// lines, and peak detection over the interleaved buffer. Returns
-    /// `(peak_sample, peak_speaker_idx)`; the caller owns clip reporting and
-    /// auto-gain (a virtual stage must never fold reductions into the shared
-    /// master gain).
     /// Longest a test may run without the client refreshing it. A client that
     /// dies mid-test must not leave a speaker making noise indefinitely.
     const TEST_MAX_SECONDS: u64 = 120;
@@ -1089,6 +1084,11 @@ impl SpeakerRenderStage {
         true
     }
 
+    /// Output stage: per-speaker gains (live gain/mute × `total_gain`), delay
+    /// lines, and peak detection over the interleaved buffer. Returns
+    /// `(peak_sample, peak_speaker_idx)`; the caller owns clip reporting and
+    /// auto-gain (a virtual stage must never fold reductions into the shared
+    /// master gain).
     pub(super) fn finalize_output(
         &mut self,
         speaker_params: &[crate::live_params::SpeakerLiveParams],


### PR DESCRIPTION
## Problem

In `omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs`, the doc paragraph describing the output stage was glued onto `TEST_MAX_SECONDS`:

```rust
/// Output stage: per-speaker gains (live gain/mute × `total_gain`), delay
/// lines, and peak detection over the interleaved buffer. Returns
/// `(peak_sample, peak_speaker_idx)`; the caller owns clip reporting and
/// auto-gain (a virtual stage must never fold reductions into the shared
/// master gain).
/// Longest a test may run without the client refreshing it. A client that
/// dies mid-test must not leave a speaker making noise indefinitely.
const TEST_MAX_SECONDS: u64 = 120;
```

So the constant documented something else entirely, and `finalize_output` — the function actually described — had no doc comment.

## Fix

Move the "Output stage: …" paragraph down so it sits directly above `pub(super) fn finalize_output(`, leaving `TEST_MAX_SECONDS` with only its own two-line doc. `finalize_output` had no doc of its own, so nothing needed merging; its `-> (f32, usize)` signature matches the `(peak_sample, peak_speaker_idx)` the paragraph describes.

Comments only — a pure move, no behaviour change (5 lines out, the same 5 lines in).

## Verification

From `omniphony-renderer/`:

- `cargo fmt --check` — clean
- `cargo build --release` — finished, no warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)