### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/omniphony-renderer/orender_ffi/Cargo.toml
+++ b/omniphony-renderer/orender_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orender_ffi"
-version = "0.4.3"
+version = "0.5.0"
 # Edition 2021 (not 2024) so cbindgen sees plain #[no_mangle] and unsafe fn
 # bodies stay implicitly unsafe — simpler for a thin C ABI shim.
 edition = "2021"

--- a/omniphony-studio/package-lock.json
+++ b/omniphony-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniphony-studio",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniphony-studio",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "@codemirror/language": "^6",
         "@codemirror/legacy-modes": "^6",

--- a/omniphony-studio/package.json
+++ b/omniphony-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniphony-studio",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Visualisation 3D d'objets audio spatialisés via OSC",
   "scripts": {
     "dev": "vite",

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "omniphony-studio"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "flate2",
  "image",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omniphony-studio"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 
 [[bin]]

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fr.omniphony.studio",
   "productName": "Omniphony Studio",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",


### PR DESCRIPTION
Bumps Omniphony Studio from 0.4.2 and orender_ffi from 0.4.3 to 0.5.0, ahead of the v0.5.0 release (main → release promotion + tag on release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)