### PR TITLE
docs: point the player download badges at the v0.5.0 releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ or to **binaural headphones**, in real time. Open source, GPL-3.0.
 [![Website & Docs — omniphony.mgth.fr](https://img.shields.io/badge/Website%20%26%20Docs-omniphony.mgth.fr-56c9ff?style=for-the-badge&logo=astro&logoColor=white)](https://omniphony.mgth.fr)
 
 [![Download Omniphony Studio](https://img.shields.io/badge/Download-Omniphony-2ea44f?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/latest)
-[![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.2)
-[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.4.2-fel-beta.1)
+<!-- The player lives under the mpv-v* tag namespace, which /releases/latest never
+     resolves to (that is the Studio v* line) — bump these two on each mpv release. -->
+[![Download mpv-omniphony](https://img.shields.io/badge/Download-mpv--omniphony-1f6feb?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.5.0)
+[![Download mpv-omniphony FEL](https://img.shields.io/badge/Download-mpv--omniphony%20FEL-8957e5?style=for-the-badge&logo=github)](https://github.com/mgth/Omniphony/releases/tag/mpv-v0.5.0-fel-beta.4)
 
 ![Omniphony Studio rendering a spatial mix](Omniphony_capture.png)
 


### PR DESCRIPTION
The two mpv download badges in the root README still pointed at `mpv-v0.4.2` — the stable one had been stale through two releases (0.4.3 and 0.5.0). `/releases/latest` resolves to the Studio `v*` line and never to the `mpv-v*` namespace, so these have to be pinned; added a short comment next to them so the next release bumps both.

- player → `mpv-v0.5.0`
- FEL → `mpv-v0.5.0-fel-beta.4`

Both tag URLs verified to resolve. `docs/mpv-omniphony.md` already links the version-agnostic releases page, so it needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)