### PR TITLE
ci: take the ASIO SDK from the public GPLv3 mirror

### DIFF
--- a/.github/actions/setup-asio-sdk/action.yml
+++ b/.github/actions/setup-asio-sdk/action.yml
@@ -36,10 +36,14 @@ runs:
         SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
         curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
           "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
-        # Extract only what asio-sys walks. The repository also ships logo
-        # artwork whose filenames contain a non-ASCII character, which Windows
-        # tar refuses to create — extracting the whole archive fails there.
-        tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP" \
+        # --force-local: RUNNER_TEMP is a Windows path, and the GNU tar shipped
+        # with Git Bash reads the "D:" in "D:\a\_temp/..." as a remote host in
+        # host:path syntax ("Cannot connect to D: resolve failed").
+        #
+        # Extracting only common/ and host/ keeps the logo artwork out; two of
+        # those filenames carry a non-ASCII character, and they are no use to
+        # the build either way.
+        tar --force-local -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP" \
           "asio-$ASIO_SDK_COMMIT/common" "asio-$ASIO_SDK_COMMIT/host"
         # Fail here rather than inside bindgen with a less obvious message.
         for header in common/asio.h common/asiosys.h host/asiodrivers.h; do

--- a/.github/actions/setup-asio-sdk/action.yml
+++ b/.github/actions/setup-asio-sdk/action.yml
@@ -32,9 +32,17 @@ runs:
       env:
         ASIO_SDK_COMMIT: ${{ inputs.commit }}
       run: |
+        set -euo pipefail
+        SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
         curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
           "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
-        tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP"
-        SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
-        ls "$SDK_DIR"
+        # Extract only what asio-sys walks. The repository also ships logo
+        # artwork whose filenames contain a non-ASCII character, which Windows
+        # tar refuses to create — extracting the whole archive fails there.
+        tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP" \
+          "asio-$ASIO_SDK_COMMIT/common" "asio-$ASIO_SDK_COMMIT/host"
+        # Fail here rather than inside bindgen with a less obvious message.
+        for header in common/asio.h common/asiosys.h host/asiodrivers.h; do
+          test -f "$SDK_DIR/$header" || { echo "missing $header in the SDK"; exit 1; }
+        done
         echo "CPAL_ASIO_DIR=$SDK_DIR" >> "$GITHUB_ENV"

--- a/.github/actions/setup-asio-sdk/action.yml
+++ b/.github/actions/setup-asio-sdk/action.yml
@@ -34,17 +34,14 @@ runs:
       run: |
         set -euo pipefail
         SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
-        curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
-          "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
-        # --force-local: RUNNER_TEMP is a Windows path, and the GNU tar shipped
-        # with Git Bash reads the "D:" in "D:\a\_temp/..." as a remote host in
-        # host:path syntax ("Cannot connect to D: resolve failed").
-        #
-        # Extracting only common/ and host/ keeps the logo artwork out; two of
-        # those filenames carry a non-ASCII character, and they are no use to
-        # the build either way.
-        tar --force-local -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP" \
-          "asio-$ASIO_SDK_COMMIT/common" "asio-$ASIO_SDK_COMMIT/host"
+        # 7z, not tar: RUNNER_TEMP is a Windows path (D:\a\_temp) and the GNU
+        # tar in Git Bash mishandles it twice over — it reads a leading "D:" as
+        # the host part of host:path syntax, and it cannot open a backslash path
+        # as the -C directory even with --force-local. 7z takes Windows paths as
+        # they come, which is how this step worked before it used a tarball.
+        curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.zip" \
+          "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.zip"
+        7z x "$RUNNER_TEMP/asio_sdk.zip" -o"$RUNNER_TEMP" > /dev/null
         # Fail here rather than inside bindgen with a less obvious message.
         for header in common/asio.h common/asiosys.h host/asiodrivers.h; do
           test -f "$SDK_DIR/$header" || { echo "missing $header in the SDK"; exit 1; }

--- a/.github/actions/setup-asio-sdk/action.yml
+++ b/.github/actions/setup-asio-sdk/action.yml
@@ -1,0 +1,40 @@
+name: Setup ASIO SDK
+description: >
+  Fetch the Steinberg ASIO SDK and export CPAL_ASIO_DIR so cpal can compile its
+  ASIO backend. Windows only — guard the call site with
+  `if: runner.os == 'Windows'`.
+
+# Since 2025-10-15 the SDK is dual-licensed: the proprietary Steinberg ASIO
+# License, or GPLv3. We take the GPLv3 option, which matches the licence this
+# project already carries (GPL-3.0-or-later), so the SDK comes from the public
+# mirror and no credentials are involved.
+#
+# The mirror carries no tags, so the commit is pinned here — tracking `main`
+# would let an upstream push change the shipped binary silently. This file is
+# the single place to bump it. Before bumping, check that every .cpp under
+# common/, host/ and host/pc/ still carries a licence header: asio-sys compiles
+# all of them except asiodrvr.cpp. Two of them (common/combase.cpp and
+# common/dllentry.cpp) are Microsoft COM base classes that carry no licence
+# grant at all, and never have.
+
+inputs:
+  commit:
+    description: Commit of github.com/audiosdk/asio to pin.
+    required: false
+    # "inital commit of version 2.3.4" (2025-10-16)
+    default: 496a0765b8bb9c26f764f22f9a9712a937177db2
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch the ASIO SDK
+      shell: bash
+      env:
+        ASIO_SDK_COMMIT: ${{ inputs.commit }}
+      run: |
+        curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
+          "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
+        tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP"
+        SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
+        ls "$SDK_DIR"
+        echo "CPAL_ASIO_DIR=$SDK_DIR" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,3 +191,40 @@ jobs:
       - name: Build renderer workspace (macOS arm64)
         working-directory: omniphony-renderer
         run: cargo build --workspace
+
+  build-windows:
+    # Windows x64 compile gate. On Windows cpal always pulls its ASIO backend
+    # (audio_output enables the feature per-target; the workspace `asio` feature
+    # is a legacy no-op alias), so this is the only job that exercises asio-sys:
+    # fetching the SDK, running bindgen over asio.h, compiling the SDK's C++ into
+    # libasio.a, and linking it. Until this job existed, that whole path was only
+    # ever built by the tag-triggered release.yml — a broken SDK setup surfaced at
+    # release time, not on the PR that caused it.
+    #
+    # Build-only: no Tauri bundle, and no vcpkg/SAF since saf_vbap is opt-in and
+    # the default VBAP backend is pure Rust. bindgen finds libclang on the runner
+    # image without any setup, which is why no LLVM step appears here.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            omniphony-renderer/target
+          key: windows-ci-cargo-${{ hashFiles('omniphony-renderer/**/Cargo.toml') }}
+          restore-keys: windows-ci-cargo-
+
+      - name: Setup ASIO SDK
+        uses: ./.github/actions/setup-asio-sdk
+
+      - name: Build renderer workspace (Windows x64)
+        working-directory: omniphony-renderer
+        run: cargo build --workspace

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -126,23 +126,11 @@ jobs:
             libpipewire-0.3-dev \
             pkg-config
 
-      # ASIO SDK (Steinberg) — required to compile cpal with ASIO on Windows.
-      # Taken under the GPLv3 half of the SDK's dual licence, matching this
-      # project's GPL-3.0-or-later. Public mirror, no credentials, pinned commit.
-      # See the same step in release.yml for the full rationale.
+      # Required to compile cpal with ASIO on Windows. Licensing rationale and
+      # the pinned SDK commit both live in the action.
       - name: Setup ASIO SDK (Windows)
         if: runner.os == 'Windows'
-        shell: bash
-        env:
-          # audiosdk/asio @ main — "inital commit of version 2.3.4" (2025-10-16)
-          ASIO_SDK_COMMIT: 496a0765b8bb9c26f764f22f9a9712a937177db2
-        run: |
-          curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
-            "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
-          tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP"
-          SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
-          ls "$SDK_DIR"
-          echo "CPAL_ASIO_DIR=$SDK_DIR" >> "$GITHUB_ENV"
+        uses: ./.github/actions/setup-asio-sdk
 
       # ── Build (no publish — we rename + publish ourselves below) ──────────
 

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -127,21 +127,21 @@ jobs:
             pkg-config
 
       # ASIO SDK (Steinberg) — required to compile cpal with ASIO on Windows.
+      # Taken under the GPLv3 half of the SDK's dual licence, matching this
+      # project's GPL-3.0-or-later. Public mirror, no credentials, pinned commit.
+      # See the same step in release.yml for the full rationale.
       - name: Setup ASIO SDK (Windows)
         if: runner.os == 'Windows'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.ASIO_SDK_TOKEN }}
-          ASIO_SDK_URL: ${{ secrets.ASIO_SDK_URL }}
+          # audiosdk/asio @ main — "inital commit of version 2.3.4" (2025-10-16)
+          ASIO_SDK_COMMIT: 496a0765b8bb9c26f764f22f9a9712a937177db2
         run: |
-          REPO=$(echo "$ASIO_SDK_URL" | sed 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|')
-          TAG=$(echo "$ASIO_SDK_URL" | sed 's|.*/releases/download/\([^/]*\)/.*|\1|')
-          FILENAME=$(basename "$ASIO_SDK_URL")
-          echo "Downloading $FILENAME from $REPO @ $TAG"
-          gh release download "$TAG" --repo "$REPO" --pattern "$FILENAME" --dir "$RUNNER_TEMP"
-          7z x "$RUNNER_TEMP/$FILENAME" -o"$RUNNER_TEMP/asio_sdk"
-          ls "$RUNNER_TEMP/asio_sdk/"
-          SDK_DIR=$(ls -d "$RUNNER_TEMP/asio_sdk/"*/ | head -1)
+          curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
+            "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
+          tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP"
+          SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
+          ls "$SDK_DIR"
           echo "CPAL_ASIO_DIR=$SDK_DIR" >> "$GITHUB_ENV"
 
       # ── Build (no publish — we rename + publish ourselves below) ──────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,26 +113,26 @@ jobs:
             pkg-config
 
       # The ASIO SDK (Steinberg) is required to compile cpal with ASIO support on Windows.
-      # Store in repository secrets:
-      #   ASIO_SDK_URL   — full GitHub release download URL:
-      #                    https://github.com/<owner>/<repo>/releases/download/<tag>/<file>.zip
-      #   ASIO_SDK_TOKEN — PAT with Contents:Read on the repo hosting the SDK
+      # Since 2025-10-15 the SDK is dual-licensed: either the proprietary Steinberg
+      # ASIO License, or GPLv3. We take the GPLv3 option, which is what this project
+      # is already licensed under (GPL-3.0-or-later), so the SDK is fetched from the
+      # public mirror and no credentials are involved.
+      #
+      # The mirror carries no tags, so the commit is pinned. Bumping it is a deliberate
+      # act: asio-sys compiles every .cpp under common/, host/ and host/pc/, so check
+      # that each of them still carries a licence header first.
       - name: Setup ASIO SDK (Windows)
         if: runner.os == 'Windows'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.ASIO_SDK_TOKEN }}
-          ASIO_SDK_URL: ${{ secrets.ASIO_SDK_URL }}
+          # audiosdk/asio @ main — "inital commit of version 2.3.4" (2025-10-16)
+          ASIO_SDK_COMMIT: 496a0765b8bb9c26f764f22f9a9712a937177db2
         run: |
-          # Parse repo (owner/name), tag, and filename from the release URL.
-          REPO=$(echo "$ASIO_SDK_URL" | sed 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|')
-          TAG=$(echo "$ASIO_SDK_URL" | sed 's|.*/releases/download/\([^/]*\)/.*|\1|')
-          FILENAME=$(basename "$ASIO_SDK_URL")
-          echo "Downloading $FILENAME from $REPO @ $TAG"
-          gh release download "$TAG" --repo "$REPO" --pattern "$FILENAME" --dir "$RUNNER_TEMP"
-          7z x "$RUNNER_TEMP/$FILENAME" -o"$RUNNER_TEMP/asio_sdk"
-          ls "$RUNNER_TEMP/asio_sdk/"
-          SDK_DIR=$(ls -d "$RUNNER_TEMP/asio_sdk/"*/ | head -1)
+          curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
+            "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
+          tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP"
+          SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
+          ls "$SDK_DIR"
           echo "CPAL_ASIO_DIR=$SDK_DIR" >> "$GITHUB_ENV"
 
       # ── Build ─────────────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,28 +112,11 @@ jobs:
             libpipewire-0.3-dev \
             pkg-config
 
-      # The ASIO SDK (Steinberg) is required to compile cpal with ASIO support on Windows.
-      # Since 2025-10-15 the SDK is dual-licensed: either the proprietary Steinberg
-      # ASIO License, or GPLv3. We take the GPLv3 option, which is what this project
-      # is already licensed under (GPL-3.0-or-later), so the SDK is fetched from the
-      # public mirror and no credentials are involved.
-      #
-      # The mirror carries no tags, so the commit is pinned. Bumping it is a deliberate
-      # act: asio-sys compiles every .cpp under common/, host/ and host/pc/, so check
-      # that each of them still carries a licence header first.
+      # Required to compile cpal with ASIO support on Windows. Licensing rationale
+      # and the pinned SDK commit both live in the action.
       - name: Setup ASIO SDK (Windows)
         if: runner.os == 'Windows'
-        shell: bash
-        env:
-          # audiosdk/asio @ main — "inital commit of version 2.3.4" (2025-10-16)
-          ASIO_SDK_COMMIT: 496a0765b8bb9c26f764f22f9a9712a937177db2
-        run: |
-          curl -sSL --retry 3 -o "$RUNNER_TEMP/asio_sdk.tar.gz" \
-            "https://github.com/audiosdk/asio/archive/$ASIO_SDK_COMMIT.tar.gz"
-          tar -xzf "$RUNNER_TEMP/asio_sdk.tar.gz" -C "$RUNNER_TEMP"
-          SDK_DIR="$RUNNER_TEMP/asio-$ASIO_SDK_COMMIT"
-          ls "$SDK_DIR"
-          echo "CPAL_ASIO_DIR=$SDK_DIR" >> "$GITHUB_ENV"
+        uses: ./.github/actions/setup-asio-sdk
 
       # ── Build ─────────────────────────────────────────────────────────────
 

--- a/omniphony-renderer/BUILDING_WINDOWS.md
+++ b/omniphony-renderer/BUILDING_WINDOWS.md
@@ -170,6 +170,14 @@ cargo build --release --features saf_vbap
 | `LIBCLANG_PATH` | Path to LLVM/Clang `lib/` directory (for bindgen) | (none, required if not on PATH) |
 | `CPAL_ASIO_DIR` | Path to Steinberg ASIO SDK directory | (none, **required** — place the SDK at `C:/dev/asio_sdk`) |
 
+Get the SDK from <https://github.com/audiosdk/asio>, the public mirror Steinberg
+published when it dual-licensed ASIO on 2025-10-15, and use it under the GPLv3
+half of that dual licence — the same licence as this project. CI pins a specific
+commit of that repository; see the "Setup ASIO SDK" step in
+`.github/workflows/release.yml`. Do **not** substitute a copy of the older
+single-licence SDK: it is proprietary, and linking it into a GPL binary is what
+kept ASIO out of free audio software for twenty years.
+
 ### Feature combinations
 
 | Features | Commands available |

--- a/omniphony-renderer/audio_input/Cargo.toml
+++ b/omniphony-renderer/audio_input/Cargo.toml
@@ -2,6 +2,7 @@
 name = "audio_input"
 version = "0.2.4"
 edition = "2024"
+license = "GPL-3.0-or-later"
 
 [dependencies]
 anyhow = "1.0.99"

--- a/omniphony-renderer/runtime_control/Cargo.toml
+++ b/omniphony-renderer/runtime_control/Cargo.toml
@@ -2,6 +2,7 @@
 name = "runtime_control"
 version = "0.2.4"
 edition = "2024"
+license = "GPL-3.0-or-later"
 
 [dependencies]
 anyhow = "1.0.99"


### PR DESCRIPTION
Windows builds statically link the Steinberg ASIO SDK into `orender.exe`, taken
under its proprietary single licence and fetched from a private mirror with the
`ASIO_SDK_URL` / `ASIO_SDK_TOKEN` secrets. Linking proprietary code into a
GPL-3.0-or-later binary is a licence violation — the same one that stopped
Audacity from ever shipping ASIO builds.

On 2025-10-15 Steinberg dual-licensed the SDK: the existing proprietary licence,
**or** GPLv3. This switches the CI to the public mirror and exercises the GPLv3
option, which matches the licence this project already carries.

### What changes

- `release.yml` and `integration-build.yml` fetch the SDK from
  <https://github.com/audiosdk/asio> with plain `curl`, no credentials.
- The commit is pinned (`496a076`, "inital commit of version 2.3.4"): the mirror
  carries no tags, and tracking `main` would let an upstream push change the
  shipped binary silently.
- `ASIO_SDK_URL` and `ASIO_SDK_TOKEN` are no longer referenced anywhere. They can
  be deleted from the repository settings **after** this merges, and the private
  mirror retired.
- `BUILDING_WINDOWS.md` now says where to get the SDK and which half of the dual
  licence to exercise. It previously pointed contributors at `C:/dev/asio_sdk`
  without naming a source, so a contributor would naturally fetch the
  proprietary one while CI used something else.
- `audio_input` and `runtime_control` gain the `license` field they were missing.

### Verification

- `cargo deny check licenses` over the full dependency tree with `--all-features`
  (so `asio-sys` and the Windows crates are included): no GPLv2-only, CDDL, EPL
  or proprietary licence anywhere. The only third-party copyleft is MPL-2.0,
  which is GPL-compatible. The 151 Apache-2.0 crates in the tree had already
  ruled out GPLv2 for this project.
- The download step was replayed locally at the pinned commit: `common/`,
  `host/` and `host/pc/` are present with `asio.h`, `asiosys.h` and
  `asiodrivers.h` where `asio-sys` looks for them.
- Licence headers checked on all eight `.cpp` files `asio-sys` actually
  compiles, not just the well-known ones.

### Two things to know

**This moves the SDK from 2.3.3 to 2.3.4.** The first Windows build off this
branch should be listened to on real hardware before any release is published.

**Two compiled files are not covered by the dual licence.** `asio-sys` builds
every `.cpp` under `common/`, `host/` and `host/pc/` except `asiodrvr.cpp`, and
`common/combase.cpp` and `common/dllentry.cpp` are Microsoft COM base classes
(`Copyright (c) 1992 - 1996 Microsoft Corporation`) carrying no licence grant —
and the SDK's `LICENSE.txt` states it only covers files that reference it. This
is pre-existing and unchanged here: the 2.3.3 SDK used until now shipped the
same two files. It does not block this change, but it is the remaining obstacle
to claiming a fully open-source binary.

### CI scope

`ci.yml` is Linux-only and deliberately does not build the Windows/ASIO target,
so a green gate here does **not** exercise this change. The first real
validation is a `workflow_dispatch` run of `integration-build.yml` after merge.
