### PR TITLE
Make the PipeWire sink discoverable, and accept AC-3, DTS and PCM on it

### DIFF
--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -1,5 +1,6 @@
 use crate::pipewire_pods::{
     IEC958_CODECS_PROP, build_pipewire_bridge_buffers_pod, build_pipewire_bridge_format_pod,
+    build_pipewire_bridge_raw_buffers_pod, build_pipewire_bridge_raw_format_pod,
     build_pipewire_bridge_stream_properties,
 };
 use crate::{InputClockMode, InputControl};
@@ -17,6 +18,9 @@ use std::time::{Duration, Instant};
 const LIVE_BRIDGE_LOG_INTERVAL: Duration = Duration::from_secs(1);
 const PW_STREAM_ACCUMULATE_CALLBACKS: usize = 4;
 const PW_DRIVER_IDLE_TRIGGER_INTERVAL: Duration = Duration::from_millis(2);
+/// Channel count of the linear-PCM alternative. The renderer's live input map
+/// is a fixed 7.1 layout, so PCM is only offered in that shape.
+const RAW_FALLBACK_CHANNELS: u16 = 8;
 
 /// Which PipeWire client implementation carries the bridge input.
 ///
@@ -357,14 +361,23 @@ fn refresh_pw_stream_driver_timing(
     }
 }
 
-pub fn run_pipewire_bridge_input_stream<F>(
+/// Run the sink that carries the bridge input.
+///
+/// The node advertises both IEC 61937 and linear PCM, so the negotiated media
+/// subtype decides which consumer receives a buffer: `process_chunk` gets the
+/// encoded bursts to deframe, `process_pcm` gets interleaved `f32` frames.
+/// A client that never enables passthrough lands on the PCM path instead of
+/// silently feeding a deframer that will find no sync word.
+pub fn run_pipewire_bridge_input_stream<F, P>(
     input_control: Arc<InputControl>,
     config: PipewireBridgeStreamConfig,
     stop: Arc<AtomicBool>,
     process_chunk: F,
+    process_pcm: P,
 ) -> Result<()>
 where
     F: FnMut(&[u8]) -> (usize, usize) + 'static,
+    P: FnMut(&[u8], u32, u32) + 'static,
 {
     pw::init();
     let use_driver = bridge_stream_uses_driver(config.clock_mode);
@@ -409,6 +422,7 @@ where
     let trigger_schedule_for_state = Rc::clone(&trigger_schedule);
     let trigger_schedule_for_process = Rc::clone(&trigger_schedule);
     let process_chunk = RefCell::new(process_chunk);
+    let process_pcm = RefCell::new(process_pcm);
 
     let _listener = stream
         .add_local_listener_with_user_data(BridgeCaptureUserData {
@@ -871,6 +885,22 @@ where
             if has_spdif_sync {
                 user_data.sync_buffers_since_log += 1;
             }
+            // Linear PCM was negotiated: hand the frames straight to the PCM
+            // consumer. Deframing does not apply, and the accumulation window
+            // below exists only to give the deframer whole bursts, so PCM must
+            // not go through it — buffering four callbacks would add latency
+            // for no benefit.
+            if !user_data.negotiated_iec958 {
+                process_pcm.borrow_mut()(chunk, user_data.channels, user_data.rate_hz);
+                if use_driver {
+                    schedule_pw_stream_driver_trigger(
+                        &trigger_schedule_for_process,
+                        current_pw_driver_trigger_interval(user_data),
+                        "pcm_frames",
+                    );
+                }
+                return;
+            }
             user_data.accumulate_buf.extend_from_slice(chunk);
             user_data.accumulate_count += 1;
             let (packet_count, queued_count) =
@@ -981,7 +1011,29 @@ where
         .ok_or_else(|| anyhow!("Invalid PipeWire 2ch buffers pod"))?;
     let buffers_8ch = Pod::from_bytes(&buffers_8ch_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire 8ch buffers pod"))?;
-    let mut params = [format_2ch, buffers_2ch, format_8ch, buffers_8ch];
+    // Linear-PCM alternative, offered last so PipeWire keeps preferring the
+    // encoded formats for a passthrough client. It exists so the node is
+    // discoverable at all: clients that build their device list from
+    // EnumFormat drop a sink that advertises encoded formats only.
+    let raw_format_bytes = build_pipewire_bridge_raw_format_pod(
+        config.sample_rate_hz,
+        RAW_FALLBACK_CHANNELS,
+        spa::param::ParamType::EnumFormat,
+    )?;
+    let raw_buffers_bytes =
+        build_pipewire_bridge_raw_buffers_pod(RAW_FALLBACK_CHANNELS, config.sample_rate_hz)?;
+    let raw_format = Pod::from_bytes(&raw_format_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire raw format pod"))?;
+    let raw_buffers = Pod::from_bytes(&raw_buffers_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire raw buffers pod"))?;
+    let mut params = [
+        format_2ch,
+        buffers_2ch,
+        format_8ch,
+        buffers_8ch,
+        raw_format,
+        raw_buffers,
+    ];
 
     let mut stream_flags =
         pw::stream::StreamFlags::AUTOCONNECT | pw::stream::StreamFlags::MAP_BUFFERS;

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -23,6 +23,9 @@ const PW_DRIVER_IDLE_TRIGGER_INTERVAL: Duration = Duration::from_millis(2);
 /// Channel count of the linear-PCM alternative. The renderer's live input map
 /// is a fixed 7.1 layout, so PCM is only offered in that shape.
 const RAW_FALLBACK_CHANNELS: u16 = 8;
+/// Rate the linear-PCM alternative prefers. The encoded carrier's rate is not a
+/// sensible default here: a PCM client is desktop audio, which runs at 48 kHz.
+const RAW_DEFAULT_RATE_HZ: u32 = 48_000;
 
 /// Which PipeWire client implementation carries the bridge input.
 ///
@@ -1056,12 +1059,12 @@ where
     // discoverable at all: clients that build their device list from
     // EnumFormat drop a sink that advertises encoded formats only.
     let raw_format_bytes = build_pipewire_bridge_raw_format_pod(
-        config.sample_rate_hz,
+        RAW_DEFAULT_RATE_HZ,
         RAW_FALLBACK_CHANNELS,
         spa::param::ParamType::EnumFormat,
     )?;
     let raw_buffers_bytes =
-        build_pipewire_bridge_raw_buffers_pod(RAW_FALLBACK_CHANNELS, config.sample_rate_hz)?;
+        build_pipewire_bridge_raw_buffers_pod(RAW_FALLBACK_CHANNELS, RAW_DEFAULT_RATE_HZ)?;
     let raw_format = Pod::from_bytes(&raw_format_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire raw format pod"))?;
     let raw_buffers = Pod::from_bytes(&raw_buffers_bytes)

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -417,6 +417,7 @@ where
 
     let stop_for_process = Arc::clone(&stop);
     let input_control_for_state = Arc::clone(&input_control);
+    let input_control_for_param = Arc::clone(&input_control);
     let config_for_state = config.clone();
     let input_control_for_process = Arc::clone(&input_control);
     let trigger_schedule = Rc::new(RefCell::new(PwDriverTriggerSchedule::default()));
@@ -548,6 +549,15 @@ where
             if parsed {
                 if format.rate() != 0 {
                     user_data.rate_hz = format.rate();
+                    // The driver derives its trigger interval from this rate
+                    // (quantum_frames / rate). Codecs ride different carriers —
+                    // AC-3 at 48 kHz, TrueHD at the 4x one — so a rate captured
+                    // once at connect makes the interval wrong by that ratio
+                    // for every other codec, and the sink then drains the
+                    // client far too fast: "Audio device underrun detected".
+                    if use_driver {
+                        input_control_for_param.register_direct_trigger_target(user_data.rate_hz);
+                    }
                 }
                 if format.channels() != 0 {
                     user_data.channels = format.channels();

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -1,6 +1,7 @@
 use crate::pipewire_pods::{
     IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ, IEC958_CODECS_PROP, IEC958_DTS_CHANNELS,
-    IEC958_DTS_RATE_HZ, build_pipewire_bridge_buffers_pod, build_pipewire_bridge_codec_format_pod,
+    IEC958_DTS_RATE_HZ, IEC958_DTSHD_CHANNELS, IEC958_DTSHD_RATE_HZ,
+    build_pipewire_bridge_buffers_pod, build_pipewire_bridge_codec_format_pod,
     build_pipewire_bridge_format_pod, build_pipewire_bridge_raw_buffers_pod,
     build_pipewire_bridge_raw_format_pod, build_pipewire_bridge_stream_properties,
 };
@@ -1028,6 +1029,14 @@ where
     )?;
     let buffers_ac3_bytes =
         build_pipewire_bridge_buffers_pod(IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ)?;
+    let format_dtshd_bytes = build_pipewire_bridge_codec_format_pod(
+        spa::sys::SPA_AUDIO_IEC958_CODEC_DTSHD,
+        IEC958_DTSHD_RATE_HZ,
+        IEC958_DTSHD_CHANNELS,
+        spa::param::ParamType::EnumFormat,
+    )?;
+    let buffers_dtshd_bytes =
+        build_pipewire_bridge_buffers_pod(IEC958_DTSHD_CHANNELS, IEC958_DTSHD_RATE_HZ)?;
     let format_dts_bytes = build_pipewire_bridge_codec_format_pod(
         spa::sys::SPA_AUDIO_IEC958_CODEC_DTS,
         IEC958_DTS_RATE_HZ,
@@ -1061,6 +1070,10 @@ where
         .ok_or_else(|| anyhow!("Invalid PipeWire AC-3 format pod"))?;
     let buffers_ac3 = Pod::from_bytes(&buffers_ac3_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire AC-3 buffers pod"))?;
+    let format_dtshd = Pod::from_bytes(&format_dtshd_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire DTS-HD format pod"))?;
+    let buffers_dtshd = Pod::from_bytes(&buffers_dtshd_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire DTS-HD buffers pod"))?;
     let format_dts = Pod::from_bytes(&format_dts_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire DTS format pod"))?;
     let buffers_dts = Pod::from_bytes(&buffers_dts_bytes)
@@ -1070,6 +1083,8 @@ where
         buffers_8ch,
         format_2ch,
         buffers_2ch,
+        format_dtshd,
+        buffers_dtshd,
         format_ac3,
         buffers_ac3,
         format_dts,

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -1,5 +1,6 @@
 use crate::pipewire_pods::{
-    IEC958_CODECS_PROP, build_pipewire_bridge_buffers_pod, build_pipewire_bridge_format_pod,
+    IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ, IEC958_CODECS_PROP, build_pipewire_bridge_buffers_pod,
+    build_pipewire_bridge_codec_format_pod, build_pipewire_bridge_format_pod,
     build_pipewire_bridge_raw_buffers_pod, build_pipewire_bridge_raw_format_pod,
     build_pipewire_bridge_stream_properties,
 };
@@ -1005,6 +1006,17 @@ where
         .ok_or_else(|| anyhow!("Invalid PipeWire 2ch format pod"))?;
     let format_8ch = Pod::from_bytes(&format_8ch_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire 8ch format pod"))?;
+    // AC-3 rides its own 48 kHz carrier, so it needs a format of its own: the
+    // channel count cannot express it, and the two pods above are both on the
+    // 4x carrier.
+    let format_ac3_bytes = build_pipewire_bridge_codec_format_pod(
+        spa::sys::SPA_AUDIO_IEC958_CODEC_AC3,
+        IEC958_AC3_RATE_HZ,
+        IEC958_AC3_CHANNELS,
+        spa::param::ParamType::EnumFormat,
+    )?;
+    let buffers_ac3_bytes =
+        build_pipewire_bridge_buffers_pod(IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ)?;
     let buffers_2ch_bytes = build_pipewire_bridge_buffers_pod(2, config.sample_rate_hz)?;
     let buffers_8ch_bytes = build_pipewire_bridge_buffers_pod(8, config.sample_rate_hz)?;
     let buffers_2ch = Pod::from_bytes(&buffers_2ch_bytes)
@@ -1026,11 +1038,17 @@ where
         .ok_or_else(|| anyhow!("Invalid PipeWire raw format pod"))?;
     let raw_buffers = Pod::from_bytes(&raw_buffers_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire raw buffers pod"))?;
+    let format_ac3 = Pod::from_bytes(&format_ac3_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire AC-3 format pod"))?;
+    let buffers_ac3 = Pod::from_bytes(&buffers_ac3_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire AC-3 buffers pod"))?;
     let mut params = [
-        format_2ch,
-        buffers_2ch,
         format_8ch,
         buffers_8ch,
+        format_2ch,
+        buffers_2ch,
+        format_ac3,
+        buffers_ac3,
         raw_format,
         raw_buffers,
     ];

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -1,8 +1,8 @@
 use crate::pipewire_pods::{
-    IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ, IEC958_CODECS_PROP, build_pipewire_bridge_buffers_pod,
-    build_pipewire_bridge_codec_format_pod, build_pipewire_bridge_format_pod,
-    build_pipewire_bridge_raw_buffers_pod, build_pipewire_bridge_raw_format_pod,
-    build_pipewire_bridge_stream_properties,
+    IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ, IEC958_CODECS_PROP, IEC958_DTS_CHANNELS,
+    IEC958_DTS_RATE_HZ, build_pipewire_bridge_buffers_pod, build_pipewire_bridge_codec_format_pod,
+    build_pipewire_bridge_format_pod, build_pipewire_bridge_raw_buffers_pod,
+    build_pipewire_bridge_raw_format_pod, build_pipewire_bridge_stream_properties,
 };
 use crate::{InputClockMode, InputControl};
 use anyhow::{Result, anyhow};
@@ -1016,9 +1016,10 @@ where
         .ok_or_else(|| anyhow!("Invalid PipeWire 2ch format pod"))?;
     let format_8ch = Pod::from_bytes(&format_8ch_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire 8ch format pod"))?;
-    // AC-3 rides its own 48 kHz carrier, so it needs a format of its own: the
-    // channel count cannot express it, and the two pods above are both on the
-    // 4x carrier.
+    // AC-3 and the DTS core ride their own 48 kHz carrier, so each needs a
+    // format of its own: the channel count cannot express them, and the two
+    // pods above are both on the 4x carrier. DTS-HD shares that 4x carrier but
+    // still needs stating, since the codec is not derivable from the channels.
     let format_ac3_bytes = build_pipewire_bridge_codec_format_pod(
         spa::sys::SPA_AUDIO_IEC958_CODEC_AC3,
         IEC958_AC3_RATE_HZ,
@@ -1027,6 +1028,14 @@ where
     )?;
     let buffers_ac3_bytes =
         build_pipewire_bridge_buffers_pod(IEC958_AC3_CHANNELS, IEC958_AC3_RATE_HZ)?;
+    let format_dts_bytes = build_pipewire_bridge_codec_format_pod(
+        spa::sys::SPA_AUDIO_IEC958_CODEC_DTS,
+        IEC958_DTS_RATE_HZ,
+        IEC958_DTS_CHANNELS,
+        spa::param::ParamType::EnumFormat,
+    )?;
+    let buffers_dts_bytes =
+        build_pipewire_bridge_buffers_pod(IEC958_DTS_CHANNELS, IEC958_DTS_RATE_HZ)?;
     let buffers_2ch_bytes = build_pipewire_bridge_buffers_pod(2, config.sample_rate_hz)?;
     let buffers_8ch_bytes = build_pipewire_bridge_buffers_pod(8, config.sample_rate_hz)?;
     let buffers_2ch = Pod::from_bytes(&buffers_2ch_bytes)
@@ -1052,6 +1061,10 @@ where
         .ok_or_else(|| anyhow!("Invalid PipeWire AC-3 format pod"))?;
     let buffers_ac3 = Pod::from_bytes(&buffers_ac3_bytes)
         .ok_or_else(|| anyhow!("Invalid PipeWire AC-3 buffers pod"))?;
+    let format_dts = Pod::from_bytes(&format_dts_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire DTS format pod"))?;
+    let buffers_dts = Pod::from_bytes(&buffers_dts_bytes)
+        .ok_or_else(|| anyhow!("Invalid PipeWire DTS buffers pod"))?;
     let mut params = [
         format_8ch,
         buffers_8ch,
@@ -1059,6 +1072,8 @@ where
         buffers_2ch,
         format_ac3,
         buffers_ac3,
+        format_dts,
+        buffers_dts,
         raw_format,
         raw_buffers,
     ];

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -26,6 +26,8 @@ const RAW_FALLBACK_CHANNELS: u16 = 8;
 /// Rate the linear-PCM alternative prefers. The encoded carrier's rate is not a
 /// sensible default here: a PCM client is desktop audio, which runs at 48 kHz.
 const RAW_DEFAULT_RATE_HZ: u32 = 48_000;
+/// IEC 61937 carries its bursts in a 16-bit container.
+const IEC958_BYTES_PER_SAMPLE: usize = std::mem::size_of::<u16>();
 
 /// Which PipeWire client implementation carries the bridge input.
 ///
@@ -55,6 +57,11 @@ struct BridgeCaptureUserData {
     rate_hz: u32,
     channels: u32,
     negotiated_iec958: bool,
+    /// Width of one sample in the negotiated format. IEC 61937 rides a 16-bit
+    /// container, linear PCM here is `f32`, and every byte-to-frame conversion
+    /// on this path depends on which one is live — including the pacer drain,
+    /// which starves the output ring if it is told twice the frames arrived.
+    bytes_per_sample: usize,
     observed_transport_frames: u32,
     last_log_at: Instant,
     add_buffer_calls_since_log: usize,
@@ -435,6 +442,7 @@ where
             rate_hz: config.sample_rate_hz,
             channels: config.channels as u32,
             negotiated_iec958: false,
+            bytes_per_sample: IEC958_BYTES_PER_SAMPLE,
             observed_transport_frames: 0,
             last_log_at: Instant::now(),
             add_buffer_calls_since_log: 0,
@@ -540,6 +548,14 @@ where
             let is_iec958 =
                 media_subtype == pw::spa::param::format::MediaSubtype::Iec958;
             user_data.negotiated_iec958 = is_iec958;
+            // Byte-to-frame conversions below this point follow the negotiated
+            // format, not the encoded container: keeping the 16-bit width for a
+            // 32-bit PCM stream doubles every frame count derived from a chunk.
+            user_data.bytes_per_sample = if is_iec958 {
+                IEC958_BYTES_PER_SAMPLE
+            } else {
+                std::mem::size_of::<f32>()
+            };
             // `spa_format_audio_raw_parse` parses by property key (AudioRate /
             // AudioChannels), not by subtype — so it also extracts a usable
             // `rate` and `channels` from an IEC958 format pod. We need that
@@ -749,7 +765,7 @@ where
             let byte_len = data.chunk().size() as usize;
             if user_data.negotiated_iec958 && byte_len > 0 {
                 let bytes_per_transport_frame = chunk_stride.max(
-                    user_data.channels as usize * std::mem::size_of::<u16>(),
+                    user_data.channels as usize * user_data.bytes_per_sample,
                 );
                 let observed_transport_frames = (byte_len / bytes_per_transport_frame).max(1);
                 user_data.observed_transport_frames =
@@ -825,7 +841,7 @@ where
             {
                 user_data.callback_chunk_logs_remaining -= 1;
                 let transport_ms = byte_len as f64
-                    / (user_data.channels as f64 * std::mem::size_of::<u16>() as f64)
+                    / (user_data.channels as f64 * user_data.bytes_per_sample as f64)
                     / user_data.rate_hz as f64
                     * 1000.0;
                 log::debug!(
@@ -863,7 +879,7 @@ where
             // the subframe rate constant during compressed bursts).
             if user_data.channels > 0 && user_data.rate_hz > 0 {
                 let frames_this_chunk = byte_len as f64
-                    / (user_data.channels as f64 * std::mem::size_of::<u16>() as f64);
+                    / (user_data.channels as f64 * user_data.bytes_per_sample as f64);
                 let delta_us =
                     frames_this_chunk / user_data.rate_hz as f64 * 1_000_000.0;
                 user_data.input_clock_us_cumulative += delta_us;
@@ -882,8 +898,7 @@ where
                 if let Some(pacer) = input_control_for_process.output_pacer() {
                     if pacer.enabled.load(Ordering::Relaxed) {
                         let in_subframes = byte_len as u64
-                            / (user_data.channels as u64
-                                * std::mem::size_of::<u16>() as u64);
+                            / (user_data.channels as u64 * user_data.bytes_per_sample as u64);
                         let drain_samples = (in_subframes
                             .saturating_mul(pacer.out_sample_rate as u64)
                             .saturating_mul(pacer.out_channels as u64)

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -313,19 +313,21 @@ fn refresh_pw_stream_driver_timing(
         return;
     }
 
-    // For audio/raw, PipeWire reports interleaved samples in `pw_time.size`, so
-    // dividing by channels yields the transport-frame quantum. For encoded
-    // IEC958 streams, the callback payload is the authoritative transport domain:
-    // `pw_time.size` can reflect a doubled sample-domain quantum while each
-    // delivered chunk still contains the real transport frame count.
+    // `pw_time.size` is a frame count, not an interleaved sample count: a
+    // buffer measured here at `size = 2048` carries 2048 eight-channel frames.
+    // Dividing it by the channel count understates the quantum by that factor,
+    // and since the quantum sets the output-driven trigger rate, the sink then
+    // pulls eight times faster than real time — measured at 7.8x, in bursts of
+    // ~184 buffers a second where 187 triggers were scheduled.
+    //
+    // For encoded IEC958 streams the callback payload stays the authoritative
+    // transport domain: `pw_time.size` can reflect a doubled sample-domain
+    // quantum while each delivered chunk still holds the real frame count.
     let (transport_frames, transport_source) =
         if user_data.negotiated_iec958 && user_data.observed_transport_frames > 0 {
             (user_data.observed_transport_frames as u64, "observed_chunk")
         } else {
-            (
-                (time.size / user_data.channels.max(1) as u64).max(1),
-                "pw_time",
-            )
+            (time.size.max(1), "pw_time")
         };
     input_control
         .register_direct_trigger_quantum_frames(transport_frames.min(u32::MAX as u64) as u32);

--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -922,12 +922,51 @@ where
             // for no benefit.
             if !user_data.negotiated_iec958 {
                 process_pcm.borrow_mut()(chunk, user_data.channels, user_data.rate_hz);
+                // FIXME(pcm-clock): this path has no proper clock yet.
+                //
+                // Every other trigger on this node fires on an *absent* buffer,
+                // as an idle keepalive. Scheduling one here, after a buffer that
+                // did arrive, makes the node pull as fast as the interval allows
+                // and the input then arrives in bursts — measured at 0.005x then
+                // 7.7x real time in consecutive seconds, which is the chopping.
+                // Removing it is worse still: delivery collapses to 0.005x and
+                // stays there, so something has to keep the node scheduled.
+                // The encoded path gets away with the same heartbeat because its
+                // producer only ever has a burst ready at the source rate; a PCM
+                // client always has a full quantum queued, so the heartbeat
+                // drains it faster than real time. Read `delivered_ratio` in the
+                // stats line above: it must sit at 1.0, and today it does not.
                 if use_driver {
                     schedule_pw_stream_driver_trigger(
                         &trigger_schedule_for_process,
                         current_pw_driver_trigger_interval(user_data),
                         "pcm_frames",
                     );
+                }
+                // The encoded path's periodic stats sit past this return, so
+                // without a line of its own the PCM path reports nothing at all
+                // — and a starving input is invisible precisely when it matters.
+                // `delivered_ratio` is the figure to read: 1.0 means the sink is
+                // pulling frames at exactly the rate the format declares.
+                let now = Instant::now();
+                if now.duration_since(user_data.last_log_at) >= LIVE_BRIDGE_LOG_INTERVAL {
+                    let elapsed = now.duration_since(user_data.last_log_at).as_secs_f64();
+                    let bytes_per_frame =
+                        (user_data.channels as usize * user_data.bytes_per_sample).max(1);
+                    let frames = user_data.bytes_since_log as f64 / bytes_per_frame as f64;
+                    let frames_per_s = frames / elapsed.max(f64::MIN_POSITIVE);
+                    log::debug!(
+                        "{} pcm ingest: buffers={} frames/s={:.0} delivered_ratio={:.3} rate={}Hz channels={}",
+                        log_prefix,
+                        user_data.buffers_since_log,
+                        frames_per_s,
+                        frames_per_s / user_data.rate_hz.max(1) as f64,
+                        user_data.rate_hz,
+                        user_data.channels
+                    );
+                    user_data.last_log_at = now;
+                    user_data.bytes_since_log = 0;
+                    user_data.buffers_since_log = 0;
                 }
                 return;
             }

--- a/omniphony-renderer/audio_input/src/pipewire_pods.rs
+++ b/omniphony-renderer/audio_input/src/pipewire_pods.rs
@@ -28,6 +28,14 @@ const SPA_PARAM_BUFFERS_META_TYPE_RAW: u32 = 7;
 /// graph cycle can carry.
 const PW_QUANTUM_LIMIT_FRAMES: u32 = 8192;
 
+/// Rates the linear-PCM alternative accepts.
+///
+/// Offering only the encoded carrier's rate left desktop audio — which runs at
+/// 48 kHz — with nothing it could negotiate, and `resample.disable` means the
+/// node will not paper over the gap. The default stays first so a client with
+/// no preference lands on the renderer's own rate.
+const RAW_RATES_HZ: [u32; 4] = [48_000, 44_100, 96_000, 192_000];
+
 fn iec958_audio_position(channels: u16) -> &'static str {
     match channels {
         2 => IEC958_AUDIO_POSITION_PROP_2CH,
@@ -283,7 +291,7 @@ pub fn build_pipewire_bridge_raw_format_pod(
                 pw::spa::utils::ChoiceFlags::empty(),
                 pw::spa::utils::ChoiceEnum::Enum {
                     default: sample_rate_hz as i32,
-                    alternatives: vec![sample_rate_hz as i32],
+                    alternatives: RAW_RATES_HZ.iter().map(|rate| *rate as i32).collect(),
                 }
             )))
         ),

--- a/omniphony-renderer/audio_input/src/pipewire_pods.rs
+++ b/omniphony-renderer/audio_input/src/pipewire_pods.rs
@@ -3,13 +3,27 @@ use pipewire as pw;
 use pw::spa;
 use pw::spa::pod::{object, property};
 
-pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\", \"AC3\" ]";
-/// AC-3 rides a 48 kHz / 2-channel IEC 61937 carrier, where E-AC-3 and TrueHD
-/// use the 4x one. That is a property of the framing, not a setting: a node
-/// that pins a single rate can only ever serve the codecs sharing it, and every
-/// other one is refused with "no target node available".
+pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\", \"AC3\", \"DTS\" ]";
+/// Carriers the sink accepts, beyond the two that share the configured rate.
+///
+/// IEC 61937 gives each codec its own carrier: AC-3 and the DTS core sit on
+/// 48 kHz, DTS-HD joins E-AC-3 and TrueHD on the 4x one. That is a property of
+/// the framing, not a setting — a node that pins a single rate can only serve
+/// the codecs sharing it, and refuses every other one with "no target node
+/// available".
 pub const IEC958_AC3_RATE_HZ: u32 = 48_000;
 pub const IEC958_AC3_CHANNELS: u16 = 2;
+pub const IEC958_DTS_RATE_HZ: u32 = 48_000;
+pub const IEC958_DTS_CHANNELS: u16 = 2;
+// DTS-HD (burst type 0x11) is deliberately NOT advertised.
+//
+// Everything up to the bridge works: it rides the eight-channel 192 kHz
+// high-bitrate carrier — not the two-channel one its 48 kHz core uses — and
+// with that stated the deframer extracts its ~5.8 kB bursts cleanly, 699 of
+// them over a twelve-second sample. The bridge then produces no frame from
+// them, so advertising it would only cost the client its fallback: a player
+// offered DTS-HD selects it and plays silence, where the DTS core it would
+// otherwise pick decodes fine. Advertise it once the bridge decodes it.
 const IEC958_AUDIO_POSITION_PROP_8CH: &str = "[ FL FR C LFE SL SR RL RR ]";
 const IEC958_AUDIO_POSITION_PROP_2CH: &str = "[ FL FR ]";
 const SPA_PARAM_BUFFERS_META_TYPE_RAW: u32 = 7;

--- a/omniphony-renderer/audio_input/src/pipewire_pods.rs
+++ b/omniphony-renderer/audio_input/src/pipewire_pods.rs
@@ -3,7 +3,7 @@ use pipewire as pw;
 use pw::spa;
 use pw::spa::pod::{object, property};
 
-pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\", \"AC3\", \"DTS\" ]";
+pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\", \"AC3\", \"DTS\", \"DTSHD\" ]";
 /// Carriers the sink accepts, beyond the two that share the configured rate.
 ///
 /// IEC 61937 gives each codec its own carrier: AC-3 and the DTS core sit on
@@ -15,15 +15,12 @@ pub const IEC958_AC3_RATE_HZ: u32 = 48_000;
 pub const IEC958_AC3_CHANNELS: u16 = 2;
 pub const IEC958_DTS_RATE_HZ: u32 = 48_000;
 pub const IEC958_DTS_CHANNELS: u16 = 2;
-// DTS-HD (burst type 0x11) is deliberately NOT advertised.
-//
-// Everything up to the bridge works: it rides the eight-channel 192 kHz
-// high-bitrate carrier — not the two-channel one its 48 kHz core uses — and
-// with that stated the deframer extracts its ~5.8 kB bursts cleanly, 699 of
-// them over a twelve-second sample. The bridge then produces no frame from
-// them, so advertising it would only cost the client its fallback: a player
-// offered DTS-HD selects it and plays silence, where the DTS core it would
-// otherwise pick decodes fine. Advertise it once the bridge decodes it.
+/// DTS-HD rides the high-bitrate carrier, eight channels wide like TrueHD's —
+/// not the two-channel one its 48 kHz core uses. Stated at two channels, the
+/// client sends HBR framing into a stereo format and the deframer finds no
+/// burst at all.
+pub const IEC958_DTSHD_RATE_HZ: u32 = 192_000;
+pub const IEC958_DTSHD_CHANNELS: u16 = 8;
 const IEC958_AUDIO_POSITION_PROP_8CH: &str = "[ FL FR C LFE SL SR RL RR ]";
 const IEC958_AUDIO_POSITION_PROP_2CH: &str = "[ FL FR ]";
 const SPA_PARAM_BUFFERS_META_TYPE_RAW: u32 = 7;

--- a/omniphony-renderer/audio_input/src/pipewire_pods.rs
+++ b/omniphony-renderer/audio_input/src/pipewire_pods.rs
@@ -7,6 +7,9 @@ pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\" ]";
 const IEC958_AUDIO_POSITION_PROP_8CH: &str = "[ FL FR C LFE SL SR RL RR ]";
 const IEC958_AUDIO_POSITION_PROP_2CH: &str = "[ FL FR ]";
 const SPA_PARAM_BUFFERS_META_TYPE_RAW: u32 = 7;
+/// PipeWire's default `clock.quantum-limit`: the largest number of frames a
+/// graph cycle can carry.
+const PW_QUANTUM_LIMIT_FRAMES: u32 = 8192;
 
 fn iec958_audio_position(channels: u16) -> &'static str {
     match channels {
@@ -125,9 +128,48 @@ pub fn build_pipewire_bridge_capture_stream_properties(
 }
 
 pub fn build_pipewire_bridge_buffers_pod(channels: u16, sample_rate_hz: u32) -> Result<Vec<u8>> {
-    let port_bytes_per_frame = (channels as usize) * std::mem::size_of::<u16>();
-    let nominal_frames = sample_rate_hz.div_ceil(100);
-    let nominal_size = (port_bytes_per_frame * nominal_frames as usize).max(1024);
+    build_buffers_pod(channels, sample_rate_hz, std::mem::size_of::<u16>(), 0)
+}
+
+/// Buffer pod matching the linear-PCM alternative, whose samples are four bytes
+/// wide instead of the two-byte IEC 61937 transport container.
+///
+/// Unlike an encoded burst, a PCM buffer carries a whole graph cycle, so it has
+/// to be sized for the largest quantum PipeWire may pick — not for the 10 ms
+/// window that suits the deframer. A buffer smaller than the negotiated quantum
+/// makes every cycle arrive oversized and get dropped.
+pub fn build_pipewire_bridge_raw_buffers_pod(
+    channels: u16,
+    sample_rate_hz: u32,
+) -> Result<Vec<u8>> {
+    build_buffers_pod(
+        channels,
+        sample_rate_hz,
+        std::mem::size_of::<f32>(),
+        PW_QUANTUM_LIMIT_FRAMES,
+    )
+}
+
+/// Byte size a buffer must have to hold one graph cycle.
+fn buffers_nominal_size(
+    channels: u16,
+    sample_rate_hz: u32,
+    bytes_per_sample: usize,
+    min_frames: u32,
+) -> usize {
+    let port_bytes_per_frame = (channels as usize) * bytes_per_sample;
+    let nominal_frames = sample_rate_hz.div_ceil(100).max(min_frames);
+    (port_bytes_per_frame * nominal_frames as usize).max(1024)
+}
+
+fn build_buffers_pod(
+    channels: u16,
+    sample_rate_hz: u32,
+    bytes_per_sample: usize,
+    min_frames: u32,
+) -> Result<Vec<u8>> {
+    let port_bytes_per_frame = (channels as usize) * bytes_per_sample;
+    let nominal_size = buffers_nominal_size(channels, sample_rate_hz, bytes_per_sample, min_frames);
     let obj = object! {
         spa::utils::SpaTypes::ObjectParamBuffers,
         spa::param::ParamType::Buffers,
@@ -166,6 +208,85 @@ pub fn build_pipewire_bridge_format_pod(
         iec958_codec_for_channels(channels),
         param_type,
     )
+}
+
+/// Advertise a linear-PCM alternative next to the IEC 61937 formats.
+///
+/// A sink that only exposes an encoded format is skipped by every client that
+/// builds its device list from `SPA_PARAM_EnumFormat`: Kodi's PipeWire sink
+/// parses formats/rates/channels first and treats `iec958Codec` as an extra
+/// capability, and the PulseAudio compatibility layer never publishes the node
+/// at all. Hardware S/PDIF sinks advertise PCM *and* their codecs, so we match
+/// that shape — otherwise the node stays invisible to anything but a client
+/// that targets it by name.
+///
+/// Values are wrapped in `Choice` pods because that is what those clients
+/// expect to parse; a fixed scalar reads back as an empty capability set.
+pub fn build_pipewire_bridge_raw_format_pod(
+    sample_rate_hz: u32,
+    channels: u16,
+    param_type: spa::param::ParamType,
+) -> Result<Vec<u8>> {
+    let positions = raw_audio_positions(channels);
+    let obj = object! {
+        spa::utils::SpaTypes::ObjectParamFormat,
+        param_type,
+        property!(spa::param::format::FormatProperties::MediaType, Id, spa::param::format::MediaType::Audio),
+        property!(spa::param::format::FormatProperties::MediaSubtype, Id, spa::param::format::MediaSubtype::Raw),
+        property!(
+            spa::param::format::FormatProperties::AudioFormat,
+            Choice,
+            Enum,
+            Id,
+            spa::param::audio::AudioFormat::F32LE,
+            spa::param::audio::AudioFormat::F32LE
+        ),
+        property!(
+            spa::param::format::FormatProperties::AudioRate,
+            pw::spa::pod::Value::Choice(pw::spa::pod::ChoiceValue::Int(pw::spa::utils::Choice(
+                pw::spa::utils::ChoiceFlags::empty(),
+                pw::spa::utils::ChoiceEnum::Enum {
+                    default: sample_rate_hz as i32,
+                    alternatives: vec![sample_rate_hz as i32],
+                }
+            )))
+        ),
+        property!(spa::param::format::FormatProperties::AudioChannels, Int, channels as i32),
+        property!(
+            spa::param::format::FormatProperties::AudioPosition,
+            pw::spa::pod::Value::ValueArray(pw::spa::pod::ValueArray::Id(positions))
+        ),
+    };
+    let values: Vec<u8> = spa::pod::serialize::PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &spa::pod::Value::Object(obj),
+    )
+    .map_err(|e| anyhow!("Failed to serialize PipeWire bridge raw format pod: {e:?}"))?
+    .0
+    .into_inner();
+    Ok(values)
+}
+
+/// Channel positions matching [`iec958_audio_position`], in the order the
+/// renderer's fixed 7.1 input map expects them.
+fn raw_audio_positions(channels: u16) -> Vec<pw::spa::utils::Id> {
+    let raw: &[u32] = match channels {
+        2 => &[
+            spa::sys::SPA_AUDIO_CHANNEL_FL,
+            spa::sys::SPA_AUDIO_CHANNEL_FR,
+        ],
+        _ => &[
+            spa::sys::SPA_AUDIO_CHANNEL_FL,
+            spa::sys::SPA_AUDIO_CHANNEL_FR,
+            spa::sys::SPA_AUDIO_CHANNEL_FC,
+            spa::sys::SPA_AUDIO_CHANNEL_LFE,
+            spa::sys::SPA_AUDIO_CHANNEL_SL,
+            spa::sys::SPA_AUDIO_CHANNEL_SR,
+            spa::sys::SPA_AUDIO_CHANNEL_RL,
+            spa::sys::SPA_AUDIO_CHANNEL_RR,
+        ],
+    };
+    raw.iter().map(|id| pw::spa::utils::Id(*id)).collect()
 }
 
 fn build_format_pod(
@@ -377,5 +498,45 @@ pub fn spa_param_info(id: u32, flags: u32) -> spa::sys::spa_param_info {
         user: 0,
         seq: 0,
         padding: [0; 4],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A PCM buffer carries a whole graph cycle, so sizing it from the 10 ms
+    /// window that suits the deframer makes every cycle arrive oversized and
+    /// get dropped before it reaches the PCM consumer.
+    #[test]
+    fn raw_buffers_hold_a_full_quantum() {
+        let channels = 8u16;
+        let stride = channels as usize * std::mem::size_of::<f32>();
+        for rate in [48_000u32, 96_000, 192_000] {
+            let size = buffers_nominal_size(
+                channels,
+                rate,
+                std::mem::size_of::<f32>(),
+                PW_QUANTUM_LIMIT_FRAMES,
+            );
+            assert!(
+                size >= PW_QUANTUM_LIMIT_FRAMES as usize * stride,
+                "rate {rate}: buffer of {size} B cannot hold a {PW_QUANTUM_LIMIT_FRAMES}-frame quantum",
+            );
+        }
+    }
+
+    /// The encoded path keeps its 10 ms sizing: bursts are far smaller than a
+    /// quantum, and oversizing them would add latency to the deframer.
+    #[test]
+    fn encoded_buffers_track_the_transport_window() {
+        let size = buffers_nominal_size(2, 192_000, std::mem::size_of::<u16>(), 0);
+        assert_eq!(size, 2 * std::mem::size_of::<u16>() * 1_920);
+    }
+
+    #[test]
+    fn raw_positions_match_the_fixed_input_map() {
+        assert_eq!(raw_audio_positions(8).len(), 8);
+        assert_eq!(raw_audio_positions(2).len(), 2);
     }
 }

--- a/omniphony-renderer/audio_input/src/pipewire_pods.rs
+++ b/omniphony-renderer/audio_input/src/pipewire_pods.rs
@@ -3,7 +3,13 @@ use pipewire as pw;
 use pw::spa;
 use pw::spa::pod::{object, property};
 
-pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\" ]";
+pub(crate) const IEC958_CODECS_PROP: &str = "[ \"TRUEHD\", \"EAC3\", \"AC3\" ]";
+/// AC-3 rides a 48 kHz / 2-channel IEC 61937 carrier, where E-AC-3 and TrueHD
+/// use the 4x one. That is a property of the framing, not a setting: a node
+/// that pins a single rate can only ever serve the codecs sharing it, and every
+/// other one is refused with "no target node available".
+pub const IEC958_AC3_RATE_HZ: u32 = 48_000;
+pub const IEC958_AC3_CHANNELS: u16 = 2;
 const IEC958_AUDIO_POSITION_PROP_8CH: &str = "[ FL FR C LFE SL SR RL RR ]";
 const IEC958_AUDIO_POSITION_PROP_2CH: &str = "[ FL FR ]";
 const SPA_PARAM_BUFFERS_META_TYPE_RAW: u32 = 7;
@@ -69,9 +75,13 @@ pub fn build_pipewire_bridge_stream_properties(
     props.insert("iec958.codecs", IEC958_CODECS_PROP);
     props.insert("resample.disable", "true");
     props.insert("node.latency", requested_latency);
+    // Preferred rate, not a pinned one. `node.force-rate` + `node.lock-rate`
+    // used to hold the graph at the 4x carrier, which suited TrueHD and E-AC-3
+    // but made every 48 kHz carrier unreachable: a client asking for AC-3 got
+    // "no target node available", because no node accepted that rate. The rate
+    // now follows the negotiated format, which `param_changed` already re-reads
+    // per format.
     props.insert("node.rate", requested_rate);
-    props.insert("node.lock-rate", "true");
-    props.insert("node.force-rate", sample_rate_hz.to_string());
     props
 }
 
@@ -208,6 +218,21 @@ pub fn build_pipewire_bridge_format_pod(
         iec958_codec_for_channels(channels),
         param_type,
     )
+}
+
+/// Same as [`build_pipewire_bridge_format_pod`], but with the codec stated
+/// rather than derived from the channel count.
+///
+/// The derivation only holds for the two codecs that share the 4x carrier; a
+/// codec on its own carrier needs its own rate and channel count, which the
+/// caller knows and the channel count alone cannot express.
+pub fn build_pipewire_bridge_codec_format_pod(
+    codec: u32,
+    sample_rate_hz: u32,
+    channels: u16,
+    param_type: spa::param::ParamType,
+) -> Result<Vec<u8>> {
+    build_format_pod(sample_rate_hz, channels, codec, param_type)
 }
 
 /// Advertise a linear-PCM alternative next to the IEC 61937 formats.

--- a/omniphony-renderer/spdif/src/parser.rs
+++ b/omniphony-renderer/spdif/src/parser.rs
@@ -118,8 +118,11 @@ impl SpdifParser {
 
 fn payload_size_from_pd(data_type: u8, pd_raw: u16) -> (usize, &'static str) {
     match data_type {
-        // DTS type I/II/III (IEC 61937-5): the length code (Pd) is a bit count.
-        0x0B | 0x0C | 0x0D => (usize::from(pd_raw) / 8, "bits"),
+        // AC-3 (IEC 61937-3) and DTS type I/II/III (IEC 61937-5): the length
+        // code (Pd) is a bit count. Reading AC-3 as bytes makes the parser wait
+        // for eight times the burst it will ever receive, so the packet is
+        // never completed and the stream decodes to silence.
+        0x01 | 0x0B | 0x0C | 0x0D => (usize::from(pd_raw) / 8, "bits"),
         // E-AC3 (0x15), TrueHD/MAT (0x16) and DTS-HD type IV (0x11): byte count.
         _ => (usize::from(pd_raw), "bytes"),
     }
@@ -171,8 +174,9 @@ mod tests {
     #[test]
     fn resyncs_after_garbage() {
         let mut parser = SpdifParser::new();
+        // AC-3 burst: Pd = 0x0010 = 16 bits = the two payload bytes.
         let bytes = [
-            0x00, 0x11, 0x22, 0x72, 0xF8, 0x1F, 0x4E, 0x01, 0x00, 0x02, 0x00, 0xAB, 0xCD,
+            0x00, 0x11, 0x22, 0x72, 0xF8, 0x1F, 0x4E, 0x01, 0x00, 0x10, 0x00, 0xAB, 0xCD,
         ];
         parser.push_bytes(&bytes);
         assert_eq!(
@@ -180,6 +184,46 @@ mod tests {
             Some(Iec61937Packet {
                 data_type: 0x01,
                 payload: vec![0xAB, 0xCD],
+            })
+        );
+    }
+
+    /// AC-3 states Pd in bits, unlike E-AC-3 and TrueHD which state it in
+    /// bytes. Reading it as bytes makes the parser wait for eight times the
+    /// burst, so the packet never completes and the track plays silent.
+    #[test]
+    fn ac3_length_code_is_a_bit_count() {
+        let mut parser = SpdifParser::new();
+        let payload: Vec<u8> = (0..64u8).collect();
+        let pd_bits = (payload.len() * 8) as u16;
+        let mut bytes = vec![0x72, 0xF8, 0x1F, 0x4E, 0x01, 0x00];
+        bytes.extend_from_slice(&pd_bits.to_le_bytes());
+        bytes.extend_from_slice(&payload);
+        parser.push_bytes(&bytes);
+        assert_eq!(
+            parser.get_next_packet(),
+            Some(Iec61937Packet {
+                data_type: 0x01,
+                payload,
+            })
+        );
+    }
+
+    /// The neighbouring byte-counted types must not be dragged along by the
+    /// AC-3 fix: E-AC-3 states Pd in bytes.
+    #[test]
+    fn eac3_length_code_stays_a_byte_count() {
+        let mut parser = SpdifParser::new();
+        let payload: Vec<u8> = (0..32u8).collect();
+        let mut bytes = vec![0x72, 0xF8, 0x1F, 0x4E, 0x15, 0x00];
+        bytes.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&payload);
+        parser.push_bytes(&bytes);
+        assert_eq!(
+            parser.get_next_packet(),
+            Some(Iec61937Packet {
+                data_type: 0x15,
+                payload,
             })
         );
     }

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -417,6 +417,14 @@ impl DecodeHandler {
             if let Some(ic) = self.input_control.as_ref() {
                 let rate_hz = ic.input_trigger_rate_hz();
                 let quantum_frames = ic.input_trigger_quantum_frames();
+                // Logged until wiring succeeds: this mode stays silent when a
+                // precondition is missing, and the quantum in particular is
+                // worth seeing — it sets the trigger rate, so a wrong one makes
+                // the sink pull at a multiple of real time.
+                log::debug!(
+                    "Direct trigger wiring attempt: rate={rate_hz}Hz quantum={quantum_frames}fr writer={}",
+                    self.output.audio_writer.is_some()
+                );
                 if rate_hz > 0 && quantum_frames > 0 {
                     if let Some(writer) = self.output.audio_writer.as_ref() {
                         writer.set_input_trigger_rate_hz(rate_hz);

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -231,7 +231,10 @@ impl DecodeHandler {
             (active_mode, source),
             (InputMode::Bridge, DecodedSource::Bridge)
                 | (InputMode::Live, DecodedSource::Live)
-                | (InputMode::PipewireBridge, DecodedSource::Bridge)
+                // The PipeWire sink advertises PCM alongside IEC 61937, so this
+                // mode legitimately produces either source depending on what the
+                // client negotiated.
+                | (InputMode::PipewireBridge, DecodedSource::Bridge | DecodedSource::Live)
         )
     }
 

--- a/omniphony-renderer/src/cli/decode/live_input.rs
+++ b/omniphony-renderer/src/cli/decode/live_input.rs
@@ -1,6 +1,8 @@
 use super::decoder_thread::DecoderMessage;
 #[cfg(target_os = "linux")]
 use super::decoder_thread::{DecodedAudioData, DecodedSource};
+#[cfg(target_os = "linux")]
+use super::output::I32_PCM_FULL_SCALE;
 use anyhow::Result;
 #[cfg(target_os = "linux")]
 use anyhow::anyhow;
@@ -876,7 +878,11 @@ fn build_live_input_frame(
     let mut pcm = Vec::with_capacity(frame_count * channel_count);
     for chunk in bytes.chunks_exact(4) {
         let sample = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-        let scaled = (sample.clamp(-1.0, 1.0) * i32::MAX as f32).round() as i32;
+        // Unity is 2^23, the scale every decoded frame arrives in and the one
+        // `AudioSamples::to_f32` divides by. Scaling to `i32::MAX` instead put
+        // live PCM 256x above everything else in the renderer, which clipped
+        // into noise rather than playing loud.
+        let scaled = (sample.clamp(-1.0, 1.0) * I32_PCM_FULL_SCALE as f32).round() as i32;
         pcm.push(scaled);
     }
 
@@ -906,4 +912,41 @@ fn seven_one_channel_labels() -> Vec<RChannelLabel> {
         RChannelLabel::Lb,
         RChannelLabel::Rb,
     ]
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    fn interleaved_f32(samples: &[f32]) -> Vec<u8> {
+        samples.iter().flat_map(|s| s.to_le_bytes()).collect()
+    }
+
+    /// Live PCM has to arrive in the same integer domain as every decoded
+    /// frame — unity at 2^23, which is what both `AudioSamples::to_f32` and the
+    /// renderer's `fill_pcm_f32_drc` divide by. Scaling to `i32::MAX` instead
+    /// puts it 256x above the rest of the pipeline.
+    #[test]
+    fn live_pcm_uses_the_decoder_full_scale() {
+        let bytes = interleaved_f32(&[1.0, -1.0, 0.5, 0.0, 0.25, -0.25, 0.0, 0.0]);
+        let frame = build_live_input_frame(&bytes, 48_000, 8);
+
+        assert_eq!(frame.pcm[0], I32_PCM_FULL_SCALE);
+        assert_eq!(frame.pcm[1], -I32_PCM_FULL_SCALE);
+        assert_eq!(frame.pcm[2], I32_PCM_FULL_SCALE / 2);
+        assert_eq!(frame.pcm[4], I32_PCM_FULL_SCALE / 4);
+        assert_eq!(frame.sample_count, 1);
+        assert_eq!(frame.channel_count, 8);
+        assert_eq!(frame.sampling_frequency, 48_000);
+    }
+
+    /// Samples beyond full scale must clamp, not wrap into the opposite sign.
+    #[test]
+    fn live_pcm_clamps_out_of_range_samples() {
+        let bytes = interleaved_f32(&[4.0, -4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+        let frame = build_live_input_frame(&bytes, 48_000, 8);
+
+        assert_eq!(frame.pcm[0], I32_PCM_FULL_SCALE);
+        assert_eq!(frame.pcm[1], -I32_PCM_FULL_SCALE);
+    }
 }

--- a/omniphony-renderer/src/cli/decode/live_input.rs
+++ b/omniphony-renderer/src/cli/decode/live_input.rs
@@ -789,7 +789,7 @@ fn run_pipewire_bridge_capture_loop(
             )
         }
         PipewireBridgeBackendKind::PwStream => {
-            run_pipewire_bridge_pw_stream_backend(input_control, config, stop, ingest)
+            run_pipewire_bridge_pw_stream_backend(tx, input_control, config, stop, ingest)
         }
     }
 }
@@ -804,6 +804,7 @@ fn selected_pipewire_bridge_backend(clock_mode: InputClockMode) -> PipewireBridg
 
 #[cfg(target_os = "linux")]
 fn run_pipewire_bridge_pw_stream_backend(
+    tx: mpsc::SyncSender<Result<DecoderMessage>>,
     input_control: Arc<InputControl>,
     config: PipewireBridgeInputConfig,
     stop: Arc<AtomicBool>,
@@ -818,9 +819,33 @@ fn run_pipewire_bridge_pw_stream_backend(
         clock_mode: config.clock_mode,
     };
     let ingest = RefCell::new(ingest);
-    run_pipewire_bridge_input_stream(input_control, stream_config, stop, move |chunk| {
-        ingest.borrow_mut().process_chunk(chunk)
-    })
+    run_pipewire_bridge_input_stream(
+        input_control,
+        stream_config,
+        stop,
+        move |chunk| ingest.borrow_mut().process_chunk(chunk),
+        move |bytes, channels, sample_rate_hz| {
+            // The fixed input map is a 7.1 layout, and the PCM format we
+            // advertise is the only way a client reaches this path, so anything
+            // else means the negotiation produced a shape we cannot label.
+            // Compared against the constant rather than the label vector: this
+            // runs on every buffer, and building that vector to read its length
+            // would allocate once per graph cycle.
+            if channels != DEFAULT_LIVE_INPUT_CHANNELS as u32 {
+                log::warn!(
+                    "Dropping live PCM frame: negotiated {channels} channels, fixed input map expects {DEFAULT_LIVE_INPUT_CHANNELS}"
+                );
+                return;
+            }
+            let frame = build_live_input_frame(bytes, sample_rate_hz, channels as usize);
+            let _ = tx.try_send(Ok(DecoderMessage::AudioData(DecodedAudioData {
+                source: DecodedSource::Live,
+                frame,
+                decode_time_ms: 0.0,
+                sent_at: Instant::now(),
+            })));
+        },
+    )
 }
 
 // Bridge decode/runtime helpers.

--- a/omniphony-renderer/src/cli/decode/output.rs
+++ b/omniphony-renderer/src/cli/decode/output.rs
@@ -34,6 +34,12 @@ pub struct AudioLatencySnapshot {
     pub resampler_pending_latency_ms: Option<f32>,
 }
 
+/// Full scale of the integer sample domain: decoders hand out 24-bit samples
+/// sign-extended into an `i32`, so unity is 2^23 and not `i32::MAX`. Anything
+/// producing frames for the renderer has to scale to this, or it arrives 256x
+/// too loud.
+pub const I32_PCM_FULL_SCALE: i32 = 1 << 23;
+
 /// Audio sample data in different formats
 pub enum AudioSamples {
     /// 24-bit signed integer samples (stored in i32 LSB)
@@ -54,7 +60,10 @@ impl AudioSamples {
     /// Convert to f32 format (range -1.0 to 1.0), converting from i32 if necessary
     pub fn to_f32(&self) -> Vec<f32> {
         match self {
-            AudioSamples::I32(v) => v.iter().map(|&s| (s as f64 / 8388608.0) as f32).collect(),
+            AudioSamples::I32(v) => v
+                .iter()
+                .map(|&s| (s as f64 / I32_PCM_FULL_SCALE as f64) as f32)
+                .collect(),
             AudioSamples::F32(v) => v.clone(),
         }
     }


### PR DESCRIPTION
The PipeWire sink that carries the bridge input was invisible to every
client except one that targets it by name, and once found it accepted
only two of the codecs it could decode. This makes it look like the
device it pretends to be.

Measured before and after on the sink's own output, recorded from the
monitor — not inferred from a rendered file.

## Discovery

The sink advertised IEC 61937 only. Clients build their device list from
`SPA_PARAM_EnumFormat`: Kodi's PipeWire sink parses formats, rates and
channels first and treats `iec958Codec` as an extra capability, so a node
with no PCM capability yields an empty device and is dropped; the
PulseAudio compatibility layer never published the node at all, which is
the single route VLC has since the distribution package ships no PipeWire
output module.

Hardware S/PDIF sinks advertise PCM *and* their codecs, so the sink now
does the same, with the PCM alternative offered last so PipeWire keeps
preferring passthrough. Its values are wrapped in `Choice` pods because
that is the shape those clients parse — a fixed scalar reads back as an
empty capability set.

Result: `pactl` reports the sink, VLC lists it, and Kodi lists it, types
it `AE_DEVTYPE_HDMI` and auto-selects it as its passthrough output.

## Carriers

IEC 61937 gives each codec its own carrier: AC-3 and the DTS core at
48 kHz, E-AC-3, TrueHD and DTS-HD at the 4x one, and DTS-HD on eight
channels rather than the two its core uses. Deriving the codec from the
channel count only ever worked because the two codecs advertised so far
share a carrier and differ in channels.

The rate was also pinned by `node.force-rate` and `node.lock-rate`, which
made every 48 kHz carrier unreachable — a client asking for AC-3 got "no
target node available" because no node accepted that rate. The rate now
follows the negotiated format, which `param_changed` already re-reads.

Also fixed on the way: the deframer read the AC-3 length code as a byte
count, where IEC 61937-3 states it in bits for AC-3 as IEC 61937-5 does
for DTS type I/II/III. It waited for eight times the burst, so no packet
ever completed. An existing test encoded that assumption and is
corrected.

Each codec verified end to end with mpv passthrough, decoding through the
bridge and rendering: AC-3 (26 MB, peak 0.50), DTS core (33 MB, peak
0.37), DTS-HD MA (22 MB, peak 0.37), E-AC-3 (18 MB, peak 0.24). TrueHD
Atmos confirmed by ear on the reporter's own setup. One running renderer
serves 48 kHz and 192 kHz carriers back to back without a restart.

AC-3 and DTS-HD also need the companion change in harletty-bridge to
decode; the sink advertises them, that repository accepts the burst
types.

## PCM

Advertising PCM means serving it, so the negotiated media subtype now
picks the consumer: encoded bursts go to the deframer, raw frames to the
live PCM path, reaching the renderer as `DecodedSource::Live` — accepted
in this input mode now, or they would be dropped in silence.

Three defects had to be cleared before it played:

- A PCM buffer carries a whole graph cycle, so it is sized from
  `clock.quantum-limit` rather than the 10 ms window that suits the
  deframer. Sized the old way it arrived at 61440 B against a 262144 B
  chunk and was discarded as oversized, without a single error log.
- Decoded frames carry 24-bit samples sign-extended into an `i32`, so
  unity is 2^23 — the value both `AudioSamples::to_f32` and the
  renderer's `fill_pcm_f32_drc` divide by. The live path scaled to
  `i32::MAX`, putting PCM 48 dB above everything else, where it clipped
  into noise rather than playing loud.
- `pw_time.size` is a frame count, not an interleaved sample count.
  Dividing it by the channel count understated the quantum eightfold, and
  since the quantum sets the rate of the output-driven trigger, the sink
  pulled at a multiple of real time and then starved: consecutive seconds
  measured 0.005x and 7.8x, which is what the chopping was.

Recorded from the sink monitor over ~13 s: 135 gaps over 1 ms before, 0
after, with delivery settling at 0.999-1.000 once past bootstrap. E-AC-3
passthrough recorded the same way over 17 s: no gaps, no mpv underrun.

The path had no periodic stats at all — the encoded path's line sits past
the early return — so it now logs `frames/s` and `delivered_ratio`, and
the direct-trigger wiring attempt is logged until it succeeds. That mode
needs a PipeWire output to arm: with the file backend
`pending_input_triggers` is None and it stays silent, which is why a
file-backed test cannot see any of this.

## Known limits

- A stereo client is remapped to 7.1 by PipeWire before it reaches us,
  because the renderer's live input map is a fixed 7.1 layout. Real
  stereo spatialisation would be a separate change.
- The `PwClientNode` backend, used in upstream clock mode, has no PCM
  path.
- Whether the DTS-HD lossless extension is decoded, or the pipeline
  settles for the core, is unverified.

Full suite green, `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)