### PR TITLE
Share the channel-object stages between both hosts

### DIFF
--- a/omniphony-renderer/orender_engine/src/channel_objects.rs
+++ b/omniphony-renderer/orender_engine/src/channel_objects.rs
@@ -22,6 +22,7 @@ use renderer::live_params::PhantomExtractMode;
 use renderer::spatial_renderer::SpatialChannelEvent;
 
 use crate::object_gen::{ObjectGenStage, ObjectGeneratorFactory, PrepareCtx, SynthObjectSpec};
+use crate::osc::ObjectMeta;
 use crate::phantom_extract::PhantomExtractStage;
 
 /// What the live options ask of the two stages this frame.
@@ -172,6 +173,29 @@ impl ChannelObjectStages {
                 position: Some(spec.position),
                 sample_pos: Some(0),
             })
+    }
+
+    /// The synthesized objects as OSC object metadata, for Studio's 3D view and
+    /// object list.
+    ///
+    /// Alongside [`events`](Self::events) because the two go together: a host
+    /// that emits the events renders the objects, and a host that skips these
+    /// renders them without ever showing them — audible but invisible, which
+    /// reads as the feature being broken.
+    pub fn object_metas(&self) -> impl Iterator<Item = ObjectMeta> + '_ {
+        self.specs().map(|spec| ObjectMeta {
+            name: spec.name.clone(),
+            x: spec.position[0] as f32,
+            y: spec.position[1] as f32,
+            z: spec.position[2] as f32,
+            coord_mode: "cartesian".to_string(),
+            direct_speaker_index: None,
+            gain: spec.gain_db as i32,
+            priority: 0.0,
+            size: spec.size,
+            fixed: false,
+            label: String::new(),
+        })
     }
 
     /// Run both stages over the bed and return the extended interleaved buffer

--- a/omniphony-renderer/orender_engine/src/channel_objects.rs
+++ b/omniphony-renderer/orender_engine/src/channel_objects.rs
@@ -19,6 +19,7 @@
 use std::collections::HashMap;
 
 use renderer::live_params::PhantomExtractMode;
+use renderer::spatial_renderer::SpatialChannelEvent;
 
 use crate::object_gen::{ObjectGenStage, ObjectGeneratorFactory, PrepareCtx, SynthObjectSpec};
 use crate::phantom_extract::PhantomExtractStage;
@@ -151,6 +152,26 @@ impl ChannelObjectStages {
     /// phantom objects first, then the height objects.
     pub fn specs(&self) -> impl Iterator<Item = &SynthObjectSpec> {
         self.phantom_specs().iter().chain(self.object_specs())
+    }
+
+    /// The channel events these objects need, in the slots they occupy past the
+    /// bed — `channel_count` being the bed width before extension.
+    ///
+    /// The slot arithmetic lives here so the two hosts cannot disagree about
+    /// it: the order matches [`specs`](Self::specs), which matches the order
+    /// [`process_and_extend`](Self::process_and_extend) appends the audio in.
+    pub fn events(&self, channel_count: usize) -> impl Iterator<Item = SpatialChannelEvent> + '_ {
+        self.specs()
+            .enumerate()
+            .map(move |(index, spec)| SpatialChannelEvent {
+                channel_idx: channel_count + index,
+                is_bed: false,
+                gain_db: Some(spec.gain_db),
+                ramp_length: Some(0),
+                size: Some(spec.size),
+                position: Some(spec.position),
+                sample_pos: Some(0),
+            })
     }
 
     /// Run both stages over the bed and return the extended interleaved buffer

--- a/omniphony-renderer/orender_engine/src/channel_objects.rs
+++ b/omniphony-renderer/orender_engine/src/channel_objects.rs
@@ -1,0 +1,248 @@
+//! The two stages that synthesize objects from channel content, and the policy
+//! that drives them.
+//!
+//! Both hosts render channel content — the mpv-embedded [`Engine`] and the
+//! `orender render` CLI that serves the PipeWire sink — so both need these
+//! stages. They lived inline in the engine, which is why the CLI silently had
+//! neither: selecting a generator in Studio did nothing for anything played
+//! through the sink, with no error to say so.
+//!
+//! Order matters and is fixed here rather than at each call site. The phantom
+//! pre-stage subtracts correlated content from the bed *in place* and appends
+//! its planar objects; the height lift then runs on the reduced bed and appends
+//! its own. The renderer sees one extended interleaved buffer,
+//! `bed | phantom objects | height objects`, and the object channels ride the
+//! existing object/VBAP path. Both stages are zero-cost when inactive.
+//!
+//! [`Engine`]: crate::engine::Engine
+
+use std::collections::HashMap;
+
+use renderer::live_params::PhantomExtractMode;
+
+use crate::object_gen::{ObjectGenStage, ObjectGeneratorFactory, PrepareCtx, SynthObjectSpec};
+use crate::phantom_extract::PhantomExtractStage;
+
+/// What the live options ask of the two stages this frame.
+///
+/// `synthetic_objects_enabled` is the master: with it off both stages stay
+/// inactive whatever else is selected, so a host can bypass the processing
+/// without losing the user's setup.
+#[derive(Clone, Debug)]
+pub struct StageSelection<'a> {
+    pub synthetic_objects_enabled: bool,
+    pub phantom_mode: PhantomExtractMode,
+    pub generator_id: &'a str,
+}
+
+impl StageSelection<'_> {
+    /// Whether a generator is selected at all, independent of the master —
+    /// what the diagnostic state reports as the generator being "on".
+    pub fn generator_selected(&self) -> bool {
+        let id = self.generator_id.trim();
+        !id.is_empty() && !id.eq_ignore_ascii_case("none")
+    }
+}
+
+/// How many objects each stage planned. Zero on both means neither runs, and
+/// the bed is handed through untouched.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StageCounts {
+    pub phantom: usize,
+    pub synth: usize,
+}
+
+impl StageCounts {
+    pub fn total(&self) -> usize {
+        self.phantom + self.synth
+    }
+
+    pub fn any(&self) -> bool {
+        self.total() > 0
+    }
+}
+
+/// The phantom-extraction and height-lift stages, driven as one.
+pub struct ChannelObjectStages {
+    phantom: PhantomExtractStage,
+    object_gen: ObjectGenStage,
+}
+
+impl ChannelObjectStages {
+    pub fn new() -> Self {
+        Self {
+            phantom: PhantomExtractStage::new(),
+            object_gen: ObjectGenStage::new(),
+        }
+    }
+
+    /// Register a host-supplied (out-of-tree) generator factory.
+    pub fn register_generator(&mut self, factory: Box<dyn ObjectGeneratorFactory>) {
+        self.object_gen.register(factory);
+    }
+
+    /// The generator catalogue, as published to Studio.
+    pub fn generator_listings_json(&self) -> String {
+        self.object_gen.registry().listings_json()
+    }
+
+    /// The phantom-extraction parameter schema, as published to Studio's
+    /// sliders. Alongside the catalogue so a host publishes both from one
+    /// place, or neither.
+    pub fn phantom_schema_json() -> String {
+        crate::phantom_extract::phantom_schema_json()
+    }
+
+    /// (Re)plan both stages for this frame and return what each will synthesize.
+    ///
+    /// Cheap when nothing changed: each stage compares a plan signature and
+    /// only rebuilds on a real change.
+    pub fn sync(
+        &mut self,
+        ctx: &PrepareCtx,
+        selection: &StageSelection,
+        options_epoch: u64,
+    ) -> StageCounts {
+        self.phantom.set_mode(selection.phantom_mode);
+        let phantom_enabled = selection.synthetic_objects_enabled
+            && selection.phantom_mode != PhantomExtractMode::Off;
+        let phantom = self.phantom.sync(phantom_enabled, ctx, options_epoch);
+
+        // The master gates the generator by selecting "none" rather than by
+        // skipping the sync, so the stage tears its plan down instead of
+        // leaving stale objects behind.
+        let effective_id = if selection.synthetic_objects_enabled {
+            selection.generator_id
+        } else {
+            "none"
+        };
+        let synth = self.object_gen.sync(effective_id, ctx, options_epoch);
+
+        StageCounts { phantom, synth }
+    }
+
+    /// Push each stage's live parameter overrides.
+    ///
+    /// Sparse: absent keys keep the stage default. Cheap and idempotent, so a
+    /// freshly rebuilt stage re-receives them on the next frame.
+    pub fn push_params(
+        &mut self,
+        phantom_params: &HashMap<String, f32>,
+        generator_params: &HashMap<String, f32>,
+        sample_rate: u32,
+    ) {
+        for (key, &value) in phantom_params.iter() {
+            self.phantom.set_param(key, value, sample_rate);
+        }
+        for (key, &value) in generator_params.iter() {
+            self.object_gen.set_param(key, value, sample_rate);
+        }
+    }
+
+    pub fn phantom_specs(&self) -> &[SynthObjectSpec] {
+        self.phantom.specs()
+    }
+
+    pub fn object_specs(&self) -> &[SynthObjectSpec] {
+        self.object_gen.specs()
+    }
+
+    /// Every synthesized object, in the channel order they occupy past the bed:
+    /// phantom objects first, then the height objects.
+    pub fn specs(&self) -> impl Iterator<Item = &SynthObjectSpec> {
+        self.phantom_specs().iter().chain(self.object_specs())
+    }
+
+    /// Run both stages over the bed and return the extended interleaved buffer
+    /// with its new channel count.
+    ///
+    /// `bed` is modified in place by the phantom pre-stage. Pass the counts from
+    /// [`sync`](Self::sync) for this frame: a stage that planned nothing is
+    /// skipped rather than asked for an empty extension.
+    ///
+    /// The result borrows from the stages when either ran and from `bed` when
+    /// neither did, so both are held for as long as it lives — the caller gets
+    /// one buffer to render from and cannot disturb the bed underneath it.
+    pub fn process_and_extend<'a>(
+        &'a mut self,
+        bed: &'a mut [f32],
+        channel_count: usize,
+        sample_count: usize,
+        sample_rate: u32,
+        counts: StageCounts,
+    ) -> (&'a [f32], usize) {
+        let (mid_pcm, mid_channels): (&[f32], usize) = if counts.phantom > 0 {
+            self.phantom
+                .process_and_extend(bed, channel_count, sample_count, sample_rate)
+        } else {
+            (&*bed, channel_count)
+        };
+        if counts.synth > 0 {
+            self.object_gen
+                .fill_and_extend(mid_pcm, mid_channels, sample_count, sample_rate)
+        } else {
+            (mid_pcm, mid_channels)
+        }
+    }
+}
+
+impl Default for ChannelObjectStages {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selection(master: bool, id: &str) -> StageSelection<'_> {
+        StageSelection {
+            synthetic_objects_enabled: master,
+            phantom_mode: PhantomExtractMode::Off,
+            generator_id: id,
+        }
+    }
+
+    #[test]
+    fn generator_selected_treats_none_and_blank_as_unselected() {
+        assert!(!selection(true, "").generator_selected());
+        assert!(!selection(true, "   ").generator_selected());
+        assert!(!selection(true, "none").generator_selected());
+        assert!(!selection(true, "NONE").generator_selected());
+        assert!(selection(true, "copy_up").generator_selected());
+    }
+
+    /// The master gates the stages, not the selection: a host turning it off
+    /// must not lose which generator the user picked.
+    #[test]
+    fn master_off_leaves_the_selection_readable() {
+        let sel = selection(false, "copy_up");
+        assert!(sel.generator_selected());
+        assert!(!sel.synthetic_objects_enabled);
+    }
+
+    #[test]
+    fn counts_report_emptiness() {
+        assert!(!StageCounts::default().any());
+        assert_eq!(StageCounts::default().total(), 0);
+        let counts = StageCounts {
+            phantom: 2,
+            synth: 3,
+        };
+        assert!(counts.any());
+        assert_eq!(counts.total(), 5);
+    }
+
+    /// With nothing planned the bed must come back untouched, not copied into
+    /// an extension buffer.
+    #[test]
+    fn inactive_stages_hand_the_bed_through() {
+        let mut stages = ChannelObjectStages::new();
+        let mut bed = vec![0.25f32, -0.25, 0.5, -0.5];
+        let (out, channels) =
+            stages.process_and_extend(&mut bed, 2, 2, 48_000, StageCounts::default());
+        assert_eq!(channels, 2);
+        assert_eq!(out, &[0.25f32, -0.25, 0.5, -0.5]);
+    }
+}

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -1085,28 +1085,7 @@ impl Engine {
             }
             // Phantom objects first (channels [channel_count ..]), then the height
             // objects offset past them.
-            for (p, spec) in self.stages.phantom_specs().iter().enumerate() {
-                self.frame_events.push(SpatialChannelEvent {
-                    channel_idx: channel_count + p,
-                    is_bed: false,
-                    gain_db: Some(spec.gain_db),
-                    ramp_length: Some(0),
-                    size: Some(spec.size),
-                    position: Some(spec.position),
-                    sample_pos: Some(0),
-                });
-            }
-            for (k, spec) in self.stages.object_specs().iter().enumerate() {
-                self.frame_events.push(SpatialChannelEvent {
-                    channel_idx: channel_count + phantom_count + k,
-                    is_bed: false,
-                    gain_db: Some(spec.gain_db),
-                    ramp_length: Some(0),
-                    size: Some(spec.size),
-                    position: Some(spec.position),
-                    sample_pos: Some(0),
-                });
-            }
+            self.frame_events.extend(self.stages.events(channel_count));
 
             // Outgoing: broadcast the virtual-bed channel poses + any synthesized
             // height objects as OSC objects and/or feed the in-process mpv

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -10,7 +10,7 @@ use crate::events::Configuration;
 use crate::osc::{ObjectMeta, OscSender};
 use crate::overlay;
 use crate::renderer_build::{SpatialRendererParams, build_spatial_renderer};
-use crate::{object_gen, phantom_extract, render, spatial, virtual_bed};
+use crate::{channel_objects, object_gen, render, spatial, virtual_bed};
 use anyhow::{Result, anyhow, bail};
 use bridge_api::{RChannelLabel, RCoordinateFormat, RDecodedFrame, RInputTransport};
 use renderer::config::Config;
@@ -98,16 +98,11 @@ pub struct Engine {
     /// (zero overhead). Diagnostic only; safe to remove once perf work lands.
     perf: Option<PerfLog>,
 
-    /// Pluggable bed→height object generator stage (2D upmix). Off by default;
-    /// active only for channel content on a height-capable layout. Selected by
-    /// the live param `object_generator_id`. See [`crate::object_gen`].
-    object_gen: object_gen::ObjectGenStage,
-
-    /// Phantom-source extraction pre-stage: runs before the height lift, pulling
-    /// correlated content out of channel pairs as planar objects and reducing the
-    /// bed. Off by default (live param `phantom_extract_mode`). See
-    /// [`crate::phantom_extract`].
-    phantom: phantom_extract::PhantomExtractStage,
+    /// The two stages that synthesize objects from channel content: phantom
+    /// extraction, then the bed→height lift. Both off by default and driven by
+    /// the live params `phantom_extract_mode` / `object_generator_id`. Shared
+    /// with the CLI host — see [`crate::channel_objects`].
+    stages: channel_objects::ChannelObjectStages,
 
     /// Signature of the last published fixed-channel applicability state. The
     /// JSON snapshot is rebuilt only when this changes, never every frame.
@@ -261,8 +256,7 @@ impl Engine {
             perf: std::env::var_os("ORENDER_PERF_LOG")
                 .is_some()
                 .then(PerfLog::new),
-            object_gen: object_gen::ObjectGenStage::new(),
-            phantom: phantom_extract::PhantomExtractStage::new(),
+            stages: channel_objects::ChannelObjectStages::new(),
             fixed_processing_sig: None,
         };
         engine
@@ -279,10 +273,10 @@ impl Engine {
         &mut self,
         factory: Box<dyn object_gen::ObjectGeneratorFactory>,
     ) {
-        self.object_gen.register(factory);
+        self.stages.register_generator(factory);
         self.renderer
             .renderer_control()
-            .set_object_generators_schema(self.object_gen.registry().listings_json());
+            .set_object_generators_schema(self.stages.generator_listings_json());
     }
 
     /// Record the hosting FFI shim's C-ABI version so the live-state snapshot
@@ -310,11 +304,11 @@ impl Engine {
         // carries it to Studio.
         self.renderer
             .renderer_control()
-            .set_object_generators_schema(self.object_gen.registry().listings_json());
+            .set_object_generators_schema(self.stages.generator_listings_json());
         // Publish the phantom-extraction param schema for Studio's sliders.
         self.renderer
             .renderer_control()
-            .set_phantom_schema(phantom_extract::phantom_schema_json());
+            .set_phantom_schema(channel_objects::ChannelObjectStages::phantom_schema_json());
 
         let target = SocketAddrV4::from_str(&format!("{}:{}", opts.host, opts.port_out))
             .map_err(|e| anyhow!("invalid OSC target {}:{}: {e}", opts.host, opts.port_out))?;
@@ -1061,18 +1055,14 @@ impl Engine {
             // Phantom-extraction pre-stage runs first: its planar objects occupy the
             // channel slots right after the bed; the height-lift objects follow. The
             // audio (and the bed reduction) is applied after the bed PCM is built.
-            self.phantom.set_mode(phantom_extract_mode);
-            let phantom_enabled = synthetic_objects_enabled
-                && phantom_extract_mode != renderer::live_params::PhantomExtractMode::Off;
-            phantom_count = self.phantom.sync(phantom_enabled, &ctx, options_epoch);
-            let effective_generator_id = if synthetic_objects_enabled {
-                object_generator_id.as_str()
-            } else {
-                "none"
+            let selection = channel_objects::StageSelection {
+                synthetic_objects_enabled,
+                phantom_mode: phantom_extract_mode,
+                generator_id: object_generator_id.as_str(),
             };
-            synth_count = self
-                .object_gen
-                .sync(effective_generator_id, &ctx, options_epoch);
+            let counts = self.stages.sync(&ctx, &selection, options_epoch);
+            phantom_count = counts.phantom;
+            synth_count = counts.synth;
             self.publish_fixed_processing_state(
                 false,
                 &labels,
@@ -1082,25 +1072,20 @@ impl Engine {
                 synth_count,
                 synthetic_objects_enabled,
                 phantom_extract_mode,
-                !object_generator_id.trim().is_empty()
-                    && !object_generator_id.eq_ignore_ascii_case("none"),
+                selection.generator_selected(),
             );
-            if phantom_count > 0 || synth_count > 0 {
-                // Push each stage's live param overrides (declared schema; sparse —
-                // absent keys keep the stage's default). Cheap + idempotent, so a
-                // freshly (re)built stage re-receives them next frame.
+            if counts.any() {
                 let control = self.renderer.renderer_control();
                 let live = control.live.read();
-                for (key, &value) in live.phantom_params.iter() {
-                    self.phantom.set_param(key, value, sample_rate);
-                }
-                for (key, &value) in live.object_generator_params.iter() {
-                    self.object_gen.set_param(key, value, sample_rate);
-                }
+                self.stages.push_params(
+                    &live.phantom_params,
+                    &live.object_generator_params,
+                    sample_rate,
+                );
             }
             // Phantom objects first (channels [channel_count ..]), then the height
             // objects offset past them.
-            for (p, spec) in self.phantom.specs().iter().enumerate() {
+            for (p, spec) in self.stages.phantom_specs().iter().enumerate() {
                 self.frame_events.push(SpatialChannelEvent {
                     channel_idx: channel_count + p,
                     is_bed: false,
@@ -1111,7 +1096,7 @@ impl Engine {
                     sample_pos: Some(0),
                 });
             }
-            for (k, spec) in self.object_gen.specs().iter().enumerate() {
+            for (k, spec) in self.stages.object_specs().iter().enumerate() {
                 self.frame_events.push(SpatialChannelEvent {
                     channel_idx: channel_count + phantom_count + k,
                     is_bed: false,
@@ -1138,12 +1123,7 @@ impl Engine {
                     surround_placement,
                 )
                 .unwrap_or_default();
-                for spec in self
-                    .phantom
-                    .specs()
-                    .iter()
-                    .chain(self.object_gen.specs().iter())
-                {
+                for spec in self.stages.specs() {
                     objects.push(ObjectMeta {
                         name: spec.name.clone(),
                         x: spec.position[0] as f32,
@@ -1203,18 +1183,16 @@ impl Engine {
         // planar objects; then the height lift runs on the reduced bed and appends
         // its objects. The renderer sees one extended interleaved buffer
         // (bed | phantom objects | height objects). Both zero-cost when inactive.
-        let (mid_pcm, mid_channels): (&[f32], usize) = if phantom_count > 0 {
-            self.phantom
-                .process_and_extend(&mut pcm_f32, channel_count, sample_count, sample_rate)
-        } else {
-            (pcm_f32.as_slice(), channel_count)
-        };
-        let (render_pcm, render_channels): (&[f32], usize) = if synth_count > 0 {
-            self.object_gen
-                .fill_and_extend(mid_pcm, mid_channels, sample_count, sample_rate)
-        } else {
-            (mid_pcm, mid_channels)
-        };
+        let (render_pcm, render_channels): (&[f32], usize) = self.stages.process_and_extend(
+            &mut pcm_f32,
+            channel_count,
+            sample_count,
+            sample_rate,
+            channel_objects::StageCounts {
+                phantom: phantom_count,
+                synth: synth_count,
+            },
+        );
 
         // VU metering (outgoing): feed object PCM pre-render; speakers post-render.
         // Needed for OSC metering clients and/or the in-process overlay (object

--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -1102,21 +1102,7 @@ impl Engine {
                     surround_placement,
                 )
                 .unwrap_or_default();
-                for spec in self.stages.specs() {
-                    objects.push(ObjectMeta {
-                        name: spec.name.clone(),
-                        x: spec.position[0] as f32,
-                        y: spec.position[1] as f32,
-                        z: spec.position[2] as f32,
-                        coord_mode: "cartesian".to_string(),
-                        direct_speaker_index: None,
-                        gain: spec.gain_db as i32,
-                        priority: 0.0,
-                        size: spec.size,
-                        fixed: false,
-                        label: String::new(),
-                    });
-                }
+                objects.extend(self.stages.object_metas());
                 if !objects.is_empty() {
                     if want_osc {
                         if let Some(osc) = self.osc.as_mut() {

--- a/omniphony-renderer/orender_engine/src/lib.rs
+++ b/omniphony-renderer/orender_engine/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod bridge_loader;
 pub mod channel_layout;
+pub mod channel_objects;
 pub mod degraded;
 pub mod engine;
 pub mod events;

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -587,10 +587,10 @@ impl DecodeHandler {
             self.input_control.as_deref(),
             self.spatial_renderer.as_mut(),
         );
-        if ctx.bed_conform && sample_write.spatial_has_objects() {
+        if ctx.bed_conform && sample_write.frame_has_objects(source) {
             sample_write.write_audio_samples_bed_conform(&frame, ctx.decode_time_ms)?;
         } else {
-            sample_write.write_audio_samples(&frame, ctx.decode_time_ms)?;
+            sample_write.write_audio_samples(&frame, ctx.decode_time_ms, source)?;
         }
 
         Ok(())

--- a/omniphony-renderer/src/cli/decode/sample_write.rs
+++ b/omniphony-renderer/src/cli/decode/sample_write.rs
@@ -649,7 +649,12 @@ impl<'a> SampleWriteCoordinator<'a> {
                         .as_ref()
                         .is_some_and(|sender| sender.has_osc_clients())
                     {
-                        if let (Some(ref mut osc_sender), Some(objects)) = (
+                        // The synthesized objects ride the same frame as the
+                        // virtual bed: emitted here they appear in Studio's 3D
+                        // view, omitted they are rendered but never shown.
+                        let synthesized: Vec<_> =
+                            self.spatial.channel_objects.object_metas().collect();
+                        if let (Some(ref mut osc_sender), Some(mut objects)) = (
                             self.telemetry.osc_sender.as_mut(),
                             build_virtual_bed_objects(
                                 &labels,
@@ -662,6 +667,7 @@ impl<'a> SampleWriteCoordinator<'a> {
                                 surround_placement,
                             ),
                         ) {
+                            objects.extend(synthesized);
                             let sample_pos = self
                                 .session
                                 .decoded_samples

--- a/omniphony-renderer/src/cli/decode/sample_write.rs
+++ b/omniphony-renderer/src/cli/decode/sample_write.rs
@@ -1,3 +1,4 @@
+use super::decoder_thread::DecodedSource;
 use super::handler::{BedChannelMapper, ChannelCountCalculator};
 use super::output::AudioSamples;
 use super::state::{DecodeSessionState, OutputState, SpatialState, TelemetryState};
@@ -21,8 +22,17 @@ pub struct SampleWriteCoordinator<'a> {
 }
 
 impl<'a> SampleWriteCoordinator<'a> {
-    pub fn spatial_has_objects(&self) -> bool {
-        self.spatial.has_objects
+    /// Whether this frame carries objects, and so takes the object render path.
+    ///
+    /// Derived from the frame's source, not from `spatial.has_objects` alone:
+    /// that flag latches on the first frame carrying metadata and is only
+    /// cleared at a segment reset, so once an object stream has played, plain
+    /// channel content arriving afterwards would keep taking the object path.
+    /// The sink switches between encoded and linear PCM at will, so that
+    /// happens in one session. A live PCM frame is channel content by
+    /// construction — fixed labels, no metadata — whatever played before it.
+    pub fn frame_has_objects(&self, source: DecodedSource) -> bool {
+        self.spatial.has_objects && !matches!(source, DecodedSource::Live)
     }
 
     pub fn new(
@@ -47,7 +57,11 @@ impl<'a> SampleWriteCoordinator<'a> {
         &mut self,
         frame: &RDecodedFrame,
         decode_time_ms: f32,
+        source: DecodedSource,
     ) -> Result<()> {
+        // Resolved before the renderer is borrowed for the render itself, and
+        // kept for the whole frame so the branch cannot change under us.
+        let frame_has_objects = self.frame_has_objects(source);
         let channel_count = frame.channel_count as usize;
         let sample_count = frame.sample_count as usize;
         let frame_duration_ms =
@@ -243,7 +257,7 @@ impl<'a> SampleWriteCoordinator<'a> {
                 };
                 self.output.drc_ramp_samples_remaining = frame.drc_ramp_duration;
 
-                if self.spatial.has_objects {
+                if frame_has_objects {
                     log::trace!(
                         "Using VBAP spatial rendering (metadata source: {})",
                         if frame.metadata.is_empty() {

--- a/omniphony-renderer/src/cli/decode/sample_write.rs
+++ b/omniphony-renderer/src/cli/decode/sample_write.rs
@@ -457,6 +457,49 @@ impl<'a> SampleWriteCoordinator<'a> {
                         }
                     };
 
+                    // Synthesize objects from the bed, as the embedded engine
+                    // does: plan first so each object gets its channel event,
+                    // then extend the PCM below with its audio.
+                    let (master, phantom_mode, generator_id, options_epoch) = {
+                        let control = renderer.renderer_control();
+                        let live = control.live.read();
+                        (
+                            live.synthetic_objects_enabled,
+                            live.phantom_extract_mode,
+                            live.object_generator_id.clone(),
+                            control.options_epoch(),
+                        )
+                    };
+                    let stage_counts = {
+                        let ctx = orender_engine::object_gen::PrepareCtx {
+                            input_labels: &labels,
+                            output_layout: &output_layout,
+                            sample_rate: frame.sampling_frequency,
+                            surround_placement,
+                        };
+                        let selection = orender_engine::channel_objects::StageSelection {
+                            synthetic_objects_enabled: master,
+                            phantom_mode,
+                            generator_id: generator_id.as_str(),
+                        };
+                        self.spatial
+                            .channel_objects
+                            .sync(&ctx, &selection, options_epoch)
+                    };
+                    let mut virtual_events = virtual_events;
+                    if stage_counts.any() {
+                        {
+                            let control = renderer.renderer_control();
+                            let live = control.live.read();
+                            self.spatial.channel_objects.push_params(
+                                &live.phantom_params,
+                                &live.object_generator_params,
+                                frame.sampling_frequency,
+                            );
+                        }
+                        virtual_events.extend(self.spatial.channel_objects.events(channel_count));
+                    }
+
                     fill_pcm_f32_drc(
                         &mut pcm_f32_scratch,
                         &frame.pcm,
@@ -465,18 +508,28 @@ impl<'a> SampleWriteCoordinator<'a> {
                         self.output.drc_target_gain,
                         &mut self.output.drc_ramp_samples_remaining,
                     );
-                    let pcm_data_f32 = &pcm_f32_scratch;
+                    let (pcm_data_f32, render_channel_count) =
+                        self.spatial.channel_objects.process_and_extend(
+                            &mut pcm_f32_scratch,
+                            channel_count,
+                            sample_count,
+                            frame.sampling_frequency,
+                            stage_counts,
+                        );
 
                     let has_metering_clients = self
                         .telemetry
                         .osc_sender
                         .as_ref()
                         .is_some_and(|sender| sender.has_metering_clients());
+                    // Meter and render the extended width: the synthesized
+                    // object channels sit past the bed, and striding by the bed
+                    // width alone would walk through them wrongly.
                     if has_metering_clients {
                         if let Some(ref mut meter) = self.telemetry.audio_meter {
-                            meter.update_channel_count(channel_count);
-                            for chunk in pcm_data_f32.chunks_exact(channel_count) {
-                                meter.process_objects(chunk, channel_count);
+                            meter.update_channel_count(render_channel_count);
+                            for chunk in pcm_data_f32.chunks_exact(render_channel_count) {
+                                meter.process_objects(chunk, render_channel_count);
                             }
                         }
                     }
@@ -484,8 +537,8 @@ impl<'a> SampleWriteCoordinator<'a> {
                     let donated_buf = std::mem::take(&mut self.output.render_buf);
                     let render_started_at = Instant::now();
                     let rendered = renderer.render_frame(
-                        &pcm_data_f32,
-                        channel_count,
+                        pcm_data_f32,
+                        render_channel_count,
                         &virtual_events,
                         donated_buf,
                         has_metering_clients,

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -116,6 +116,10 @@ pub struct SpatialState {
     /// Shared fixed-channel planner (routing + plan cache), mirroring the
     /// embedded engine.
     pub fixed_planner: orender_engine::virtual_bed::FixedChannelPlanner,
+    /// Phantom extraction + bed→height lift, the same stages the embedded
+    /// engine drives. Channel content reaches this host too — everything played
+    /// through the PipeWire sink does — so it needs them just as much.
+    pub channel_objects: orender_engine::channel_objects::ChannelObjectStages,
     /// Cached object↔channel declaration from the bridge (sparse emission),
     /// sorted by channel.
     pub object_channels: Vec<(u32, usize)>,
@@ -135,6 +139,7 @@ impl Default for SpatialState {
             has_objects: false,
             bed_indices: None,
             fixed_planner: orender_engine::virtual_bed::FixedChannelPlanner::new(),
+            channel_objects: orender_engine::channel_objects::ChannelObjectStages::new(),
             object_channels: Vec::new(),
             object_names: std::collections::HashMap::new(),
             au_index: 0,


### PR DESCRIPTION
Selecting a synthetic-object generator in Studio did nothing for anything
played through the PipeWire sink. The stages that synthesize objects from
channel content — phantom extraction, then the bed→height lift — were
fields of `Engine` with their policy inlined around them, and the
`orender render` CLI never builds an `Engine`. `object_gen` appeared
nowhere under `src/cli/`, so channel content reaching that host was
rendered as a plain bed, silently.

## What moved

`ChannelObjectStages` owns both stages and everything between them: which
one runs, in which order, with which parameters, how the bed is extended,
which channel events the objects need, and how they are described to
Studio. The ordering that used to be a comment at the call site is now a
property of the type — phantom subtracts from the bed in place and appends
its objects, the height lift then runs on the reduced bed and appends its
own.

The first commit rewires the engine onto it and is behaviour-preserving:
same call order, same gating, same skip conditions, same spec order.
`Engine` loses sixty lines and gains one field. Verified by ear on the mpv
path before anything else was built on top.

## What the CLI needed

Five wiring points, each of which failed differently and visibly only in
its own way:

- plan the stages for the frame, and push their live parameters;
- append their channel events past the bed;
- render — and meter — the extended width, since striding by the bed width
  alone walks through the object channels wrongly;
- decide the object-vs-channel path from the frame's source rather than
  `spatial.has_objects`. That flag latches on the first frame carrying
  metadata and is only cleared at a segment reset, so once an object
  stream had played, plain channel content kept taking the object path for
  the rest of the session. Lifting the sink's rate pinning is what made
  encoded↔PCM switching common enough for this to bite;
- broadcast the synthesized objects over OSC. Without this last one they
  were rendered but never published, so they were audible and invisible —
  which reads as the feature not working at all.

`events` and `object_metas` sit next to each other on the façade for that
reason: a host that emits one without the other produces objects nobody
can see.

## Verified

On an AC-3 5.1 track through the sink: 250 frames, six bed channels
extended to nineteen — eight phantom objects and five height objects —
nineteen channel events, 18 MB rendered. Confirmed by ear on the reporter's
setup for system audio through the sink, for mpv natively, and for the
objects appearing in Studio's view.

## Known gaps

- `publish_fixed_processing_state`, the applicability state Studio
  displays, is still engine-only: the CLI runs the stages without
  reporting why they are or are not active.
- The generator registry has only the built-ins on the CLI side;
  registering an out-of-tree factory is an `Engine` API.
- A stereo client is remapped to 7.1 by PipeWire before it reaches us, so
  the stages see six filler channels. Whether they should run at all on a
  bed that was fabricated from stereo is an open question, not addressed
  here.

Full suite green, `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)