### PR TITLE
Stop taking a blocking lock in the realtime output callback

### DIFF
--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -1362,6 +1362,15 @@ fn run_pipewire_loop(
     let samples_per_ms_f64 = samples_per_ms as f64;
     let mut adaptive_update_interval =
         adaptive_config_snapshot.update_interval_callbacks.max(1) as u64;
+    // The live config as this callback sees it.
+    //
+    // The config is pushed from the control thread and read from the realtime
+    // callback, which used to take the mutex — blocking — up to three times per
+    // callback, and could see a different value at each. It is a handful of
+    // scalars, so the callback keeps its own copy and refreshes it once, at
+    // entry, without blocking: on contention the previous copy stands until the
+    // next callback, a few milliseconds later.
+    let mut adaptive_cfg = adaptive_config_snapshot.clone();
 
     log::info!(
         "PipeWire buffer thresholds ({}ch): latency={}ms max={}ms quantum={}fr | \
@@ -1410,10 +1419,13 @@ fn run_pipewire_loop(
                 desired_rate_for_callback.store(1.0f32.to_bits(), Ordering::Relaxed);
                 current_adaptive_band.store(reset.adaptive_band, Ordering::Relaxed);
             }
-            let is_pi_paused = live_adaptive_config_for_callback
-                .try_lock()
-                .map(|cfg| cfg.paused)
-                .unwrap_or(false);
+            // The one config read of this callback. Everything downstream uses
+            // `adaptive_cfg`, so the whole callback also sees one consistent
+            // config rather than re-reading a value that can change under it.
+            if let Some(cfg) = live_adaptive_config_for_callback.try_lock() {
+                adaptive_cfg.clone_from(&cfg);
+            }
+            let is_pi_paused = adaptive_cfg.paused;
 
             if let Some(mut buffer) = stream.dequeue_buffer() {
                 // Per-cycle frame count requested by PipeWire for THIS callback.
@@ -1553,7 +1565,6 @@ fn run_pipewire_loop(
                         (control_available_override as f64).to_bits(),
                         Ordering::Relaxed,
                     );
-                    let current_adaptive_cfg = live_adaptive_config_for_callback.lock().clone();
                     // Classical control_available calculation (ring + FIFO +
                     // pending - callback/2). The cumulative-flow override was
                     // tried during the 0.4 Hz investigation but caused
@@ -1603,8 +1614,8 @@ fn run_pipewire_loop(
                         channel_count as usize,
                         sample_rate,
                         f32::from_bits(graph_latency_for_callback.load(Ordering::Relaxed)),
-                        current_adaptive_cfg.control_smoothing_cutoff_hz,
-                        current_adaptive_cfg.control_smoothing_order,
+                        adaptive_cfg.control_smoothing_cutoff_hz,
+                        adaptive_cfg.control_smoothing_order,
                         callback_dt_s,
                         LatencyMetricTargets {
                             measured_latency_ms_bits: &measured_latency_ms_out,
@@ -1626,7 +1637,7 @@ fn run_pipewire_loop(
                     // metrics (control_available, control_latency_ms).
                     let input_clock_us_now =
                         f64::from_bits(input_clock_us_for_callback.load(Ordering::Relaxed));
-                    let pre_bridge_requested = current_adaptive_cfg.use_pre_bridge_clock;
+                    let pre_bridge_requested = adaptive_cfg.use_pre_bridge_clock;
                     let pre_bridge_ready = pre_bridge_requested && input_clock_us_now > 0.0;
                     if pre_bridge_ready {
                         let input_clock_samples_eq = (input_clock_us_now / 1_000_000.0
@@ -1745,7 +1756,7 @@ fn run_pipewire_loop(
                     // raw control_available so the hysteresis bands act on the real
                     // buffer level. (The servo gets the smoothed value separately.)
                     let fallback_band = far_mode_band_from_latency(
-                        &current_adaptive_cfg,
+                        &adaptive_cfg,
                         metrics.control_available,
                         runtime_target_buffer_fill,
                         samples_per_ms,
@@ -1756,10 +1767,8 @@ fn run_pipewire_loop(
                             && !is_pi_paused
                             && runtime_state.low_recover_phase == LowRecoverPhase::Inactive
                         {
-                            // Refresh config from the live Arc (non-blocking; keep stale on contention).
-                            if let Some(cfg) = live_adaptive_config_for_callback.try_lock() {
-                                adaptive_update_interval = cfg.update_interval_callbacks.max(1) as u64;
-                            }
+                            adaptive_update_interval =
+                                adaptive_cfg.update_interval_callbacks.max(1) as u64;
                             if should_run_adaptive_servo(
                                 callback_count,
                                 adaptive_update_interval as u32,
@@ -1768,12 +1777,12 @@ fn run_pipewire_loop(
                             ) {
                                 let mut decision = run_adaptive_servo(
                                     &mut runtime_state,
-                                    &current_adaptive_cfg,
+                                    &adaptive_cfg,
                                     metrics,
                                     runtime_target_buffer_fill,
                                     resample_ratio,
                                     480,
-                                    current_adaptive_cfg.max_adjust.max(0.000_001),
+                                    adaptive_cfg.max_adjust.max(0.000_001),
                                     samples_per_ms,
                                     samples_per_ms_f64,
                                 );
@@ -1835,7 +1844,6 @@ fn run_pipewire_loop(
                         }
 
                         let audio_samples_needed = max_samples;
-                        let far_mode_cfg = live_adaptive_config_for_callback.lock().clone();
                         let low_recover_was_active =
                             runtime_state.low_recover_phase != LowRecoverPhase::Inactive;
                         // State machine on raw: its entry/exit/settle bands are
@@ -1843,7 +1851,7 @@ fn run_pipewire_loop(
                         // that drove a slow oscillation.
                         let far_decision = update_far_mode_state(
                             &mut runtime_state,
-                            &far_mode_cfg,
+                            &adaptive_cfg,
                             current_adaptive_band.load(Ordering::Relaxed) == ADAPTIVE_BAND_FAR,
                             metrics.control_available,
                             metrics.smoothed_control_available,
@@ -2085,10 +2093,9 @@ fn run_pipewire_loop(
                             && callback_count % adaptive_update_interval == 0
                             && runtime_state.low_recover_phase == LowRecoverPhase::Inactive
                         {
-                            // Refresh config from live Arc (non-blocking; keep stale on contention).
-                            let native_servo_cfg = live_adaptive_config_for_callback.lock().clone();
                             if adaptive_resampling_enabled {
-                                adaptive_update_interval = native_servo_cfg.update_interval_callbacks.max(1) as u64;
+                                adaptive_update_interval =
+                                    adaptive_cfg.update_interval_callbacks.max(1) as u64;
                             }
                             let drift = metrics.smoothed_control_available as i64
                                 - runtime_target_buffer_fill as i64;
@@ -2096,12 +2103,12 @@ fn run_pipewire_loop(
                             if adaptive_resampling_enabled {
                                 let decision = run_adaptive_servo(
                                     &mut runtime_state,
-                                    &native_servo_cfg,
+                                    &adaptive_cfg,
                                     metrics,
                                     runtime_target_buffer_fill,
                                     1.0,
                                     480,
-                                    native_servo_cfg.max_adjust.max(0.000_001),
+                                    adaptive_cfg.max_adjust.max(0.000_001),
                                     samples_per_ms,
                                     samples_per_ms_f64,
                                 );
@@ -2139,7 +2146,7 @@ fn run_pipewire_loop(
                                 }
                                 // Band classification on raw — see resampler path.
                                 let far_band = far_mode_band_from_latency(
-                                    &native_servo_cfg,
+                                    &adaptive_cfg,
                                     metrics.control_available,
                                     runtime_target_buffer_fill,
                                     samples_per_ms,
@@ -2180,11 +2187,10 @@ fn run_pipewire_loop(
                         let frames_to_read = available_frames.min(max_frames);
                         let samples_to_read = frames_to_read * ch;
 
-                        let far_mode_cfg2 = live_adaptive_config_for_callback.lock().clone();
                         // State machine on raw — see resampler path.
                         let far_decision: FarModeDecision = update_far_mode_state(
                             &mut runtime_state,
-                            &far_mode_cfg2,
+                            &adaptive_cfg,
                             current_adaptive_band.load(Ordering::Relaxed) == ADAPTIVE_BAND_FAR,
                             metrics.control_available,
                             metrics.smoothed_control_available,

--- a/omniphony-renderer/audio_output/src/resampler_fifo.rs
+++ b/omniphony-renderer/audio_output/src/resampler_fifo.rs
@@ -1,3 +1,16 @@
+//! Chunked resampling with an output FIFO, driven from the audio callback.
+//!
+//! Everything here runs on the realtime thread, so the steady state must not
+//! allocate: the resampler writes into a buffer this struct owns, because
+//! rubato's `process` hands back a freshly allocated `Vec<Vec<f32>>` per chunk.
+//!
+//! The output FIFO is a plain `Vec` drained from the front. That memmoves what
+//! is left behind, which looks like the wrong shape — but at these sizes
+//! (a few thousand samples) it measures faster than a `VecDeque`, whose
+//! per-element wraparound handling costs more than the move it saves. Measured
+//! at 0.30 vs 0.52 us per callback for a 2048-sample push and a 1024-sample
+//! drain; revisit if the FIFO ever grows by an order of magnitude.
+
 use anyhow::Result;
 use crossbeam::queue::ArrayQueue;
 use rubato::Resampler;
@@ -7,6 +20,9 @@ pub const RESAMPLER_CHUNK_SIZE: usize = 1024;
 pub struct ResamplerFifoEngine {
     channel_count: usize,
     resampler_input: Vec<Vec<f32>>,
+    /// Planar output the resampler writes into, reused across chunks. Grown on
+    /// first use to the resampler's maximum output frames, never after.
+    resampler_output: Vec<Vec<f32>>,
     input_frames_collected: usize,
     output_fifo: Vec<f32>,
 }
@@ -16,6 +32,9 @@ impl ResamplerFifoEngine {
         Self {
             channel_count,
             resampler_input: vec![vec![0.0; RESAMPLER_CHUNK_SIZE]; channel_count],
+            // Sized on first use: the frame count depends on the resampler's
+            // ratio bounds, which this type is not given.
+            resampler_output: vec![Vec::new(); channel_count],
             input_frames_collected: 0,
             output_fifo: Vec::with_capacity(RESAMPLER_CHUNK_SIZE * channel_count * 4),
         }
@@ -68,13 +87,26 @@ impl ResamplerFifoEngine {
             }
 
             if self.input_frames_collected == RESAMPLER_CHUNK_SIZE {
-                let output_planar = resampler
-                    .process(&self.resampler_input, None)
+                // Grow to what this resampler can ever emit, so the call below
+                // never has to (rubato validates the length and would fail
+                // rather than reallocate).
+                let max_frames = resampler.output_frames_max();
+                if self
+                    .resampler_output
+                    .first()
+                    .is_none_or(|channel| channel.len() < max_frames)
+                {
+                    for channel in &mut self.resampler_output {
+                        channel.resize(max_frames, 0.0);
+                    }
+                }
+
+                let (_, output_frames) = resampler
+                    .process_into_buffer(&self.resampler_input, &mut self.resampler_output, None)
                     .map_err(anyhow::Error::from)?;
-                let output_frames = output_planar[0].len();
                 for i in 0..output_frames {
                     for ch in 0..self.channel_count {
-                        self.output_fifo.push(output_planar[ch][i]);
+                        self.output_fifo.push(self.resampler_output[ch][i]);
                     }
                 }
                 self.input_frames_collected = 0;
@@ -88,8 +120,8 @@ impl ResamplerFifoEngine {
 
     pub fn drain_into_slice(&mut self, dest: &mut [f32]) -> usize {
         let count = dest.len().min(self.output_fifo.len());
-        for (i, sample) in self.output_fifo.drain(0..count).enumerate() {
-            dest[i] = sample;
+        for (slot, sample) in dest.iter_mut().zip(self.output_fifo.drain(0..count)) {
+            *slot = sample;
         }
         count
     }
@@ -103,5 +135,150 @@ impl ResamplerFifoEngine {
     pub fn drain_to_vec(&mut self, sample_count: usize) -> Vec<f32> {
         let count = sample_count.min(self.output_fifo.len());
         self.output_fifo.drain(0..count).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rubato::{SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction};
+
+    const CHANNELS: usize = 2;
+
+    fn resampler(ratio: f64) -> SincFixedIn<f32> {
+        SincFixedIn::<f32>::new(
+            ratio,
+            1.1,
+            SincInterpolationParameters {
+                sinc_len: 64,
+                f_cutoff: 0.95,
+                interpolation: SincInterpolationType::Linear,
+                oversampling_factor: 64,
+                window: WindowFunction::BlackmanHarris2,
+            },
+            RESAMPLER_CHUNK_SIZE,
+            CHANNELS,
+        )
+        .expect("resampler")
+    }
+
+    /// Feed one full chunk per channel, interleaved, as the callback does.
+    fn feed_one_chunk(queue: &ArrayQueue<f32>) {
+        for frame in 0..RESAMPLER_CHUNK_SIZE {
+            for ch in 0..CHANNELS {
+                // Distinct per channel so a channel swap would show up.
+                let _ = queue.push(frame as f32 + ch as f32 * 1000.0);
+            }
+        }
+    }
+
+    #[test]
+    fn resamples_a_chunk_into_the_fifo() {
+        let mut engine = ResamplerFifoEngine::new(CHANNELS);
+        let mut rs = resampler(1.0);
+        let queue = ArrayQueue::new(RESAMPLER_CHUNK_SIZE * CHANNELS * 2);
+        feed_one_chunk(&queue);
+
+        engine
+            .ensure_output_samples(&queue, &mut rs, RESAMPLER_CHUNK_SIZE)
+            .expect("resample");
+
+        assert!(engine.output_len() > 0, "a full chunk must produce output");
+        assert_eq!(
+            engine.output_len() % CHANNELS,
+            0,
+            "the FIFO holds whole interleaved frames"
+        );
+        assert_eq!(engine.pending_input_samples(), 0, "the chunk was consumed");
+    }
+
+    /// The output buffer is grown once and reused: a second chunk goes through
+    /// the same path and still produces a full chunk of output.
+    ///
+    /// It produces *more* than the first, not the same: the sinc filter's
+    /// history starts empty, so the first chunk is short by the interpolator's
+    /// startup delay and only the steady state emits a full chunk.
+    #[test]
+    fn a_second_chunk_reuses_the_output_buffer() {
+        let mut engine = ResamplerFifoEngine::new(CHANNELS);
+        let mut rs = resampler(1.0);
+        let queue = ArrayQueue::new(RESAMPLER_CHUNK_SIZE * CHANNELS * 4);
+
+        feed_one_chunk(&queue);
+        engine
+            .ensure_output_samples(&queue, &mut rs, RESAMPLER_CHUNK_SIZE)
+            .expect("resample");
+        let first = engine.output_len();
+        assert!(first > 0);
+        engine.discard_samples(first);
+
+        feed_one_chunk(&queue);
+        engine
+            .ensure_output_samples(&queue, &mut rs, RESAMPLER_CHUNK_SIZE)
+            .expect("resample");
+        let second = engine.output_len();
+        assert_eq!(
+            second,
+            RESAMPLER_CHUNK_SIZE * CHANNELS,
+            "at ratio 1.0 the steady state emits one frame per input frame"
+        );
+        assert!(
+            second >= first,
+            "the startup transient only shortens the first"
+        );
+    }
+
+    /// Draining takes from the front, in order, and leaves the rest intact —
+    /// the property any future change of FIFO container has to preserve.
+    #[test]
+    fn draining_takes_the_oldest_samples_in_order() {
+        let mut engine = ResamplerFifoEngine::new(CHANNELS);
+        let mut rs = resampler(1.0);
+        let queue = ArrayQueue::new(RESAMPLER_CHUNK_SIZE * CHANNELS * 2);
+        feed_one_chunk(&queue);
+        engine
+            .ensure_output_samples(&queue, &mut rs, RESAMPLER_CHUNK_SIZE)
+            .expect("resample");
+
+        let total = engine.output_len();
+        let all = {
+            let mut engine = ResamplerFifoEngine::new(CHANNELS);
+            let mut rs = resampler(1.0);
+            let queue = ArrayQueue::new(RESAMPLER_CHUNK_SIZE * CHANNELS * 2);
+            feed_one_chunk(&queue);
+            engine
+                .ensure_output_samples(&queue, &mut rs, RESAMPLER_CHUNK_SIZE)
+                .expect("resample");
+            engine.drain_to_vec(total)
+        };
+
+        let mut head = vec![0.0; 8];
+        assert_eq!(engine.drain_into_slice(&mut head), 8);
+        assert_eq!(head, all[..8], "the front of the FIFO comes out first");
+        assert_eq!(engine.output_len(), total - 8);
+
+        engine.discard_samples(4);
+        let mut next = vec![0.0; 8];
+        assert_eq!(engine.drain_into_slice(&mut next), 8);
+        assert_eq!(
+            next,
+            all[12..20],
+            "discarding advances the front by exactly that many samples"
+        );
+    }
+
+    /// Asking for more than the FIFO holds copies what there is and says so,
+    /// rather than padding or panicking.
+    #[test]
+    fn draining_more_than_available_is_a_short_copy() {
+        let mut engine = ResamplerFifoEngine::new(CHANNELS);
+        let mut dest = vec![-1.0f32; 4];
+        assert_eq!(engine.drain_into_slice(&mut dest), 0);
+        assert_eq!(
+            dest,
+            vec![-1.0; 4],
+            "nothing written when the FIFO is empty"
+        );
+        assert_eq!(engine.discard_samples(16), 0);
     }
 }


### PR DESCRIPTION
The PipeWire output callback read the live adaptive-resampling config by **locking a mutex — three times per callback** on the resampler path, twice on the direct path (`pipewire.rs` 1556, 1838, 2089, 2183).

The locking is the problem, not the copying. The writer is the control thread (`*self.live_adaptive_config.lock() = config`), so a config push could hold off the audio callback — a priority inversion in the one place that must never wait. The three reads could also disagree *within a single callback*, each taking a fresh snapshot.

## The change

The config is a handful of scalars. Keep one copy alongside the callback's other persistent state and refresh it once, at entry, with `try_lock`; on contention the previous copy stands until the next callback a few milliseconds later. Everything downstream reads that copy, so the callback now also sees **one consistent config** instead of up to three.

After: zero blocking locks in the callback, exactly one `try_lock`.

**One behavioural change worth naming:** `is_pi_paused` used to fall back to `false` when its `try_lock` failed — a contended callback would briefly resume a servo the user had deliberately frozen. It now keeps the last known value, which is what "keep stale on contention" was meant to do everywhere else.

## Also: rubato allocating in the callback

`process` returns a freshly allocated `Vec<Vec<f32>>` per chunk. Switched to `process_into_buffer` with an output buffer the FIFO owns, grown once to `output_frames_max()`.

Measured: ~1 µs saved per chunk out of the ~20 µs the resampling itself costs. Small — but it is an allocation on the realtime path, which is the point.

## What I did *not* change, and why

The review that prompted this also flagged the output FIFO: a `Vec` drained from the front memmoves the remainder, which looks like the wrong shape for a queue. **I implemented the `VecDeque` swap, measured it, and reverted it** — at these sizes it is *slower*:

| | per callback |
|---|---|
| `Vec` (memmove) | 0.30 µs |
| `VecDeque` | 0.52 µs |

(2048-sample push + 1024-sample drain.) `VecDeque`'s per-element wraparound handling costs more than the move it saves. My first benchmark was wrong — it let the buffer drain down instead of holding a steady length — and only the corrected one showed this. The rationale is now a comment in the file so the next reader doesn't redo the experiment.

## Tests

Four new tests on the resampling path this touches: a chunk through the FIFO, buffer reuse across chunks, that draining takes the oldest samples in order and that discarding advances the front by exactly that much, and short-copy behaviour on an empty FIFO.

Writing them surfaced that the first chunk is *shorter* than the steady state (1980 vs 2048 samples) — the sinc filter's history starts empty, so the interpolator's startup delay eats the difference. The test documents it rather than asserting equality.

## Risk

597 workspace tests pass, fmt clean. **Not verified by ear, and not run against a live PipeWire graph** — the lock change is the kind that only misbehaves under real contention. Worth a session with Studio open pushing adaptive-resampling config changes while audio plays, watching for xruns and confirming the PI pause toggle still takes effect immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)