### PR TITLE
Fix three places where the two hosts had drifted apart

### DIFF
--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -20,6 +20,14 @@ use renderer::speaker_layout::SpeakerLayout;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Monitoring cadences this host falls back to when the config declares none.
+///
+/// Lower than the CLI's: embedded in a player, the only consumer is the
+/// in-process overlay, and the host is the one that may be running on
+/// constrained hardware.
+const EMBEDDED_METER_RATE_HZ: f32 = 10.0;
+const EMBEDDED_DIAG_RATE_HZ: f32 = 10.0;
+
 /// Options for the engine's OSC live-control server.
 pub struct OscOptions {
     /// Monitoring target host (where outgoing VU/state bundles are sent).
@@ -383,7 +391,24 @@ impl Engine {
         // configure it before building the renderer.
         let t_bridge = std::time::Instant::now();
         let mut bridge = LoadedBridge::load_with_params(&resolved_bridge)?;
-        bridge.configure("presentation", "best");
+        // Honour `render.presentation` like the CLI does. This host has no
+        // flags, so the config is the only way to ask for anything other than
+        // the default — hard-coding it here made the setting silently
+        // inoperative for everything played through mpv.
+        let presentation = render_cfg
+            .as_ref()
+            .and_then(renderer::config_fields::presentation::get)
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| renderer::config_fields::presentation::DEFAULT.to_string());
+        if !bridge.configure("presentation", presentation.as_str()) {
+            // Not fatal here, unlike the CLI: this host is a decoder inside a
+            // player, and refusing to start would drop playback entirely where
+            // falling back to the bridge's own default still plays.
+            log::warn!(
+                "Bridge rejected presentation '{}'; keeping the bridge default",
+                presentation
+            );
+        }
         if let Some(codec) = input_codec {
             // Disambiguates the bridge's `Raw` transport (no data_type byte).
             // Unknown to older bridges → harmless `false`, which falls back to
@@ -455,6 +480,12 @@ impl Engine {
         if let Some(info) = profiles_info {
             control.set_profiles_info(info);
         }
+
+        // This host publishes monitoring slower than the CLI: it is embedded in
+        // a player, where the overlay is the only consumer. Declared before the
+        // seed below, which falls back to it, and re-read by any later profile
+        // switch.
+        control.set_cadence_defaults_hz(EMBEDDED_METER_RATE_HZ, EMBEDDED_DIAG_RATE_HZ);
 
         // Monitoring cadences, ramp mode, declared live options and the DRC
         // selection: seeded through the shared runtime seed — the same call

--- a/omniphony-renderer/orender_engine/src/renderer_build.rs
+++ b/omniphony-renderer/orender_engine/src/renderer_build.rs
@@ -748,8 +748,13 @@ pub fn seed_runtime_state_from_render_config(
     control: &RendererControl,
     render_cfg: Option<&RenderConfig>,
 ) {
-    control.set_meter_rate_hz(render_cfg.and_then(|c| c.meter_rate).unwrap_or(10.0));
-    control.set_diag_rate_hz(render_cfg.and_then(|c| c.diag_rate).unwrap_or(10.0));
+    // Fallback comes from the host (recorded on the control at boot), not from
+    // a literal here: this same seed is replayed by the live profile switch,
+    // which has no idea which host it is running in.
+    control.seed_cadences_from_config(
+        render_cfg.and_then(|c| c.meter_rate),
+        render_cfg.and_then(|c| c.diag_rate),
+    );
 
     // Object-transition ramp mode: honour `render.ramp_mode` (default "frame";
     // per-sample `compute_gains` is the most expensive path and must be an
@@ -899,4 +904,52 @@ pub fn apply_render_config_live(
     seed_control_from_render_config(control, Some(render_cfg));
     seed_runtime_state_from_render_config(control, Some(render_cfg));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_renderer() -> renderer::spatial_renderer::SpatialRenderer {
+        let params = SpatialRendererParams::from_render_config(None);
+        let layout = SpeakerLayout::preset("7.1.4").expect("preset layout");
+        build_spatial_renderer(
+            &params,
+            layout,
+            48_000,
+            bridge_api::RVbapCartesianDefaults {
+                x_size: 9,
+                y_size: 9,
+                z_size: 5,
+                allow_negative_z: true,
+            },
+            bridge_api::RVbapTableMode::Cartesian,
+            None,
+        )
+        .expect("renderer")
+    }
+
+    /// The shared runtime seed must not carry a cadence of its own.
+    ///
+    /// It is replayed wholesale by the live profile switch, on whichever host
+    /// happens to be running. When it hard-coded the embedded host's 10 Hz, a
+    /// profile switch on the CLI silently dropped Studio's meters from 50 Hz to
+    /// 10 — the bug this pins.
+    #[test]
+    fn the_runtime_seed_keeps_the_host_cadence_default() {
+        let renderer = test_renderer();
+        let control = renderer.renderer_control();
+
+        control.set_cadence_defaults_hz(50.0, 50.0);
+        seed_runtime_state_from_render_config(&control, None);
+        assert_eq!(control.meter_rate_hz(), 50.0);
+        assert_eq!(control.diag_rate_hz(), 50.0);
+
+        // A second host, slower on purpose, gets its own value from the same
+        // call — the seed reads the host, it does not decide.
+        control.set_cadence_defaults_hz(10.0, 10.0);
+        seed_runtime_state_from_render_config(&control, None);
+        assert_eq!(control.meter_rate_hz(), 10.0);
+        assert_eq!(control.diag_rate_hz(), 10.0);
+    }
 }

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -1515,6 +1515,16 @@ pub struct RendererControl {
     /// OSC diag-publication cadence in Hz (`f32::to_bits`). Read lock-free by
     /// the diag publisher; OSC-adjustable and persisted to config.
     pub diag_rate_hz_bits: Arc<std::sync::atomic::AtomicU32>,
+    /// This host's fallback cadences (`f32::to_bits`), used when the config
+    /// declares none.
+    ///
+    /// They are host policy, not config: the embedded host publishes slower
+    /// than the CLI, which drives Studio's meters and plots. Recorded here at
+    /// boot so every later re-seed — a live profile switch replays the whole
+    /// runtime seed — falls back to the value this host chose, instead of
+    /// whichever literal the shared seed happened to carry.
+    meter_rate_default_hz_bits: std::sync::atomic::AtomicU32,
+    diag_rate_default_hz_bits: std::sync::atomic::AtomicU32,
 
     /// Available render backends, queried by `prepare_topology_rebuild_for_layout`
     /// to build the active backend by id. Defaults to the built-ins; a host
@@ -1612,6 +1622,8 @@ impl RendererControl {
             // Seeded from config (or a host default) after construction.
             meter_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
             diag_rate_hz_bits: Arc::new(std::sync::atomic::AtomicU32::new(50.0_f32.to_bits())),
+            meter_rate_default_hz_bits: std::sync::atomic::AtomicU32::new(50.0_f32.to_bits()),
+            diag_rate_default_hz_bits: std::sync::atomic::AtomicU32::new(50.0_f32.to_bits()),
             backend_registry: RwLock::new(BackendRegistry::builtin()),
             backend_params: RwLock::new(HashMap::new()),
             object_generators_schema: RwLock::new("[]".to_string()),
@@ -1799,6 +1811,40 @@ impl RendererControl {
     pub fn set_diag_rate_hz(&self, hz: f32) {
         self.diag_rate_hz_bits
             .store(hz.clamp(1.0, 1000.0).to_bits(), Ordering::Relaxed);
+    }
+
+    /// Record this host's fallback cadences, once, at boot.
+    ///
+    /// See [`seed_cadences_from_config`](Self::seed_cadences_from_config) for
+    /// what they are for.
+    pub fn set_cadence_defaults_hz(&self, meter_hz: f32, diag_hz: f32) {
+        self.meter_rate_default_hz_bits
+            .store(meter_hz.clamp(1.0, 1000.0).to_bits(), Ordering::Relaxed);
+        self.diag_rate_default_hz_bits
+            .store(diag_hz.clamp(1.0, 1000.0).to_bits(), Ordering::Relaxed);
+    }
+
+    /// This host's fallback meter cadence in Hz.
+    pub fn meter_rate_default_hz(&self) -> f32 {
+        f32::from_bits(self.meter_rate_default_hz_bits.load(Ordering::Relaxed))
+    }
+
+    /// This host's fallback diag cadence in Hz.
+    pub fn diag_rate_default_hz(&self) -> f32 {
+        f32::from_bits(self.diag_rate_default_hz_bits.load(Ordering::Relaxed))
+    }
+
+    /// Apply the config's cadences, falling back to this host's defaults.
+    ///
+    /// The fallback has to come from the host and not from the caller, because
+    /// the callers are not all the host: boot passes the config it loaded, but
+    /// so does the live profile switch, which runs inside the OSC dispatcher
+    /// and has no idea which host it is serving. Resolving it here is what
+    /// stops a profile switch from quietly re-seeding a CLI session at the
+    /// embedded host's slower cadence.
+    pub fn seed_cadences_from_config(&self, meter_hz: Option<f32>, diag_hz: Option<f32>) {
+        self.set_meter_rate_hz(meter_hz.unwrap_or_else(|| self.meter_rate_default_hz()));
+        self.set_diag_rate_hz(diag_hz.unwrap_or_else(|| self.diag_rate_default_hz()));
     }
 
     /// Store the active config file path so the save-config OSC handler can use it.

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -2271,3 +2271,83 @@ fn clearing_the_test_restores_normal_output() {
         "with the test cleared and a silent programme the output must be silent"
     );
 }
+
+/// The monitoring cadences fall back to the *host's* default, not to a literal
+/// living in whichever code path happens to re-seed them.
+///
+/// This is a regression test for a shipped bug: the CLI host booted its meters
+/// at 50 Hz, but the shared runtime seed — replayed wholesale by the live
+/// profile switch — carried the embedded host's 10 Hz. Switching profile on the
+/// CLI therefore dropped the cadence to a fifth, silently, with the only symptom
+/// being Studio's meters going choppy.
+#[test]
+fn cadences_fall_back_to_the_host_default() {
+    let layout = SpeakerLayout::preset("7.1.4").unwrap();
+    let renderer = SpatialRenderer::new(
+        layout,
+        48_000,
+        1,
+        1,
+        0.0,
+        2.0,
+        VbapTableMode::Cartesian {
+            x_size: 9,
+            y_size: 9,
+            z_size: 5,
+            z_neg_size: 5,
+        },
+        false,
+        false,
+        DistanceModel::Linear,
+        false,
+        1.0,
+        1.0,
+        0.0,
+        1.0,
+        false,
+        [1.0, 2.0, 0.5],
+        2.0,
+        0.5,
+        0.0,
+        0.0,
+        false,
+        false,
+        false,
+        1.0,
+        1.0,
+        PreferredEvaluationMode::PrecomputedCartesian,
+        LiveEvaluationMode::PrecomputedCartesian,
+        9,
+        9,
+        5,
+        5,
+    )
+    .unwrap();
+    let control = renderer.renderer_control();
+
+    // An embedded host declares a slower cadence, then seeds from a config
+    // that says nothing about it.
+    control.set_cadence_defaults_hz(10.0, 10.0);
+    control.seed_cadences_from_config(None, None);
+    assert_eq!(control.meter_rate_hz(), 10.0);
+    assert_eq!(control.diag_rate_hz(), 10.0);
+
+    // A host that wants faster monitoring keeps it across a re-seed — this is
+    // the assertion that used to fail, because the re-seed carried 10 Hz.
+    control.set_cadence_defaults_hz(50.0, 50.0);
+    control.seed_cadences_from_config(None, None);
+    assert_eq!(control.meter_rate_hz(), 50.0);
+    assert_eq!(control.diag_rate_hz(), 50.0);
+
+    // A config that does declare a cadence still wins over the host default.
+    control.seed_cadences_from_config(Some(25.0), Some(4.0));
+    assert_eq!(control.meter_rate_hz(), 25.0);
+    assert_eq!(control.diag_rate_hz(), 4.0);
+
+    // And the declared default survives a config-driven seed, so the *next*
+    // profile switch still lands on the host's value rather than the last
+    // config's.
+    control.seed_cadences_from_config(None, None);
+    assert_eq!(control.meter_rate_hz(), 50.0);
+    assert_eq!(control.diag_rate_hz(), 50.0);
+}

--- a/omniphony-renderer/src/cli/decode/bootstrap.rs
+++ b/omniphony-renderer/src/cli/decode/bootstrap.rs
@@ -15,6 +15,13 @@ use renderer::metering::AudioMeter;
 use renderer::speaker_layout::SpeakerLayout;
 use std::sync::Arc;
 
+/// Monitoring cadences this host falls back to when the config declares none.
+///
+/// Higher than the embedded host's: this is the renderer Studio talks to, and
+/// the meters and diag plots are only as smooth as this rate.
+const CLI_METER_RATE_HZ: f32 = 50.0;
+const CLI_DIAG_RATE_HZ: f32 = 50.0;
+
 #[cfg(target_os = "windows")]
 fn list_available_output_devices(_backend: OutputBackend) -> Vec<OutputDeviceOption> {
     audio_output::list_asio_devices()
@@ -405,19 +412,15 @@ fn init_osc_runtime(
             .clamp(0.0, 1.0);
         ctrl.live.write().drc_weight = drc_weight;
 
-        // Monitoring cadences: seed RendererControl from config (CLI default
-        // 50 Hz). Renderer is the source of truth — OSC-adjustable + persisted.
-        ctrl.set_meter_rate_hz(
-            render_cfg
-                .as_ref()
-                .and_then(|cfg| cfg.meter_rate)
-                .unwrap_or(50.0),
-        );
-        ctrl.set_diag_rate_hz(
-            render_cfg
-                .as_ref()
-                .and_then(|cfg| cfg.diag_rate)
-                .unwrap_or(50.0),
+        // Monitoring cadences. This host publishes faster than the embedded
+        // one: it is what Studio's meters and diag plots read. Recorded on the
+        // control first so a later profile switch, which replays the shared
+        // runtime seed, falls back to this value and not the embedded host's.
+        // Renderer is the source of truth — OSC-adjustable + persisted.
+        ctrl.set_cadence_defaults_hz(CLI_METER_RATE_HZ, CLI_DIAG_RATE_HZ);
+        ctrl.seed_cadences_from_config(
+            render_cfg.as_ref().and_then(|cfg| cfg.meter_rate),
+            render_cfg.as_ref().and_then(|cfg| cfg.diag_rate),
         );
 
         ctrl.set_requested_ramp_mode(args.ramp_mode.into());

--- a/omniphony-renderer/src/cli/decode/spatial_metadata.rs
+++ b/omniphony-renderer/src/cli/decode/spatial_metadata.rs
@@ -110,17 +110,26 @@ impl<'a> SpatialMetadataCoordinator<'a> {
         };
         let coordinate_format = self.spatial.coordinate_format;
 
+        // Cached whether or not anyone is listening, mirroring the embedded
+        // host: names are declared sparsely, typically once at the start of a
+        // stream, so a Studio attaching mid-playback would otherwise show an
+        // object list that stays unnamed until the next declaration — which
+        // for most content never comes.
+        for upd in meta.name_updates.iter() {
+            if self.spatial.object_names.get(&upd.id).map(String::as_str) != Some(upd.name.as_str())
+            {
+                self.spatial
+                    .object_names
+                    .insert(upd.id, upd.name.to_string());
+            }
+        }
+
         if self
             .osc_sender
             .as_ref()
             .is_some_and(|sender| sender.has_osc_clients())
         {
             let osc_sender = self.osc_sender.as_mut().expect("osc_sender present");
-            for upd in meta.name_updates.iter() {
-                self.spatial
-                    .object_names
-                    .insert(upd.id, upd.name.to_string());
-            }
             let mut objects: Vec<ObjectMeta> = self
                 .spatial_renderer
                 .and_then(|renderer| {


### PR DESCRIPTION
Three unrelated symptoms with one shape: something the engine host and the CLI host each decided for themselves, where only one of them was right. These came out of the perf/capitalisation review; the larger `FrameRenderer` extraction it also proposed is **not** here — see the note at the bottom.

## 1. Monitoring cadence — the one real bug

The CLI booted its meters and diag plots at 50 Hz. But `seed_runtime_state_from_render_config`, which the **live profile switch replays wholesale**, carried the embedded host's 10 Hz.

So: switch profile on a CLI session and Studio's meters silently drop to a fifth of their rate. The only symptom is choppy meters — nothing logs, nothing fails.

The fallback can't live in the shared seed, because the seed doesn't know which host it's serving: the profile switch runs inside the OSC dispatcher. Each host now records its own default on the control at boot (`set_cadence_defaults_hz`), and the seed resolves against that (`seed_cadences_from_config`). The literals become one named constant per host, next to a note on why they differ — the embedded host publishes for an in-process overlay and may be on constrained hardware; the CLI publishes for Studio.

## 2. Object names lost on the CLI

Names were cached *inside* the `has_osc_clients()` gate ([spatial_metadata.rs:113](../blob/main/omniphony-renderer/src/cli/decode/spatial_metadata.rs#L113)). Object names are declared sparsely — typically once at the start of a stream — so a Studio attaching mid-playback got an object list that stayed unnamed until the next declaration, which for most content never comes.

The engine already caches unconditionally, with a comment saying exactly why. Same here now.

## 3. Bridge presentation ignored by the engine

`engine.rs` hard-coded `"best"`, so `render.presentation` was silently inoperative for everything played through mpv, while the CLI honoured it. It now reads the config key like the CLI.

One deliberate difference: it **warns** rather than failing. The CLI bails when the bridge rejects a presentation; this host is a decoder inside a player, and refusing to start would drop playback entirely where falling back to the bridge's own default still plays.

## Tests

The cadence fix is pinned at both levels it can break:

- the control resolves the fallback from the host default, and a config value still wins over it (`renderer`);
- the shared seed carries no cadence of its own (`orender_engine`).

I checked the second one actually catches the bug rather than just passing: against the old code it fails with `left: 10.0, right: 50.0`.

Fixes 2 and 3 are wiring changes verified by reading and by the compiler — testing them would mean standing up a metadata coordinator and a loaded bridge respectively, which costs more than it pins.

## Risk

603 workspace tests pass, fmt clean. Nothing here is verified by ear, but only #3 can affect audio, and only for a config that sets `render.presentation` to something other than the default — in which case mpv now decodes what was asked for instead of quietly ignoring it.

## On the `FrameRenderer` extraction

The review proposed extracting a host-agnostic frame renderer (~450 lines). Having looked again, that plan is stale: #265 already extracted the channel-object stages and #266 the bed planning — the two genuinely shared pieces. What's left in `render_frame` versus `write_audio_samples` is mostly host-specific orchestration that diverges for good reasons (writing to a sink vs returning a buffer, passthrough semantics, meter latency args, threading). Moving it would add indirection without removing real duplication, on the audio render path, unverifiable by ear in CI. Discussed and deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)