### PR TITLE
Pool the embedded host's output buffers

### DIFF
--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -97,6 +97,15 @@ pub struct Engine {
     // ── reusable scratch ──
     frame_events: Vec<SpatialChannelEvent>,
     pcm_f32_buf: Vec<f32>,
+    /// Spare sample buffers for [`RenderedAudio`], returned by
+    /// [`Engine::recycle`] once the host has copied them out.
+    ///
+    /// The buffers cannot simply live here, because every block of one packet is
+    /// alive at the same time — the host copies them in one pass and may stop
+    /// early on a layout change. So they are lent out and handed back. A host
+    /// that never recycles allocates exactly as before; it is an optimisation,
+    /// not a contract.
+    output_pool: Vec<Vec<f32>>,
 
     /// Optional OSC live-control server (kept alive here; its Drop stops the
     /// listener thread when the engine is dropped).
@@ -262,6 +271,7 @@ impl Engine {
             applied_drc_mode: String::new(),
             frame_events: Vec::new(),
             pcm_f32_buf: Vec::new(),
+            output_pool: Vec::new(),
             osc: None,
             audio_meter: None,
             object_names: HashMap::new(),
@@ -831,6 +841,26 @@ impl Engine {
         self.process(data, RInputTransport::Raw, 0)
     }
 
+    /// Hand the sample buffers of a consumed [`process`](Self::process) result
+    /// back for reuse.
+    ///
+    /// Optional: dropping the blocks instead is correct, just one allocation per
+    /// block per packet. Call it once the samples have been copied out — the
+    /// buffers are recycled as-is, so anything still reading them is reading a
+    /// buffer the next frame will overwrite.
+    ///
+    /// Bounded, because a host is free to call this with more blocks than it
+    /// ever renders at once and the pool would otherwise only ever grow.
+    pub fn recycle(&mut self, chunks: Vec<RenderedAudio>) {
+        const MAX_POOLED: usize = 16;
+        for chunk in chunks {
+            if self.output_pool.len() >= MAX_POOLED {
+                break;
+            }
+            self.output_pool.push(chunk.samples);
+        }
+    }
+
     fn render_frame(
         &mut self,
         frame: &RDecodedFrame,
@@ -1030,8 +1060,11 @@ impl Engine {
                 virtual_bed::BedPlanKind::HostPassthrough | virtual_bed::BedPlanKind::Silence => {
                     self.frame_events.clear();
                     let n_channels = self.renderer.output_channel_count() as u32;
+                    let mut samples = self.output_pool.pop().unwrap_or_default();
+                    samples.clear();
+                    samples.resize(sample_count * n_channels as usize, 0.0);
                     return Ok(Some(RenderedAudio {
-                        samples: vec![0.0; sample_count * n_channels as usize],
+                        samples,
                         n_channels,
                         n_frames: sample_count,
                         sample_pos: sample_pos_at_start,
@@ -1223,11 +1256,12 @@ impl Engine {
         }
 
         let render_started = std::time::Instant::now();
+        let donated = self.output_pool.pop().unwrap_or_default();
         let rendered = self.renderer.render_frame(
             render_pcm,
             render_channels,
             &self.frame_events,
-            Vec::new(),
+            donated,
             want_metering,
         )?;
         let render_time_ms = render_started.elapsed().as_secs_f32() * 1000.0;

--- a/omniphony-renderer/orender_ffi/src/lib.rs
+++ b/omniphony-renderer/orender_ffi/src/lib.rs
@@ -673,6 +673,9 @@ pub unsafe extern "C" fn orender_process(
             if !out_frames.is_null() {
                 *out_frames = 0;
             }
+            // Nothing was copied, but the buffers are still worth keeping: the
+            // caller is about to retry with a larger `out` and render again.
+            engine.recycle(chunks);
             return 1; // buffer too small; caller retries larger
         }
 
@@ -695,6 +698,10 @@ pub unsafe extern "C" fn orender_process(
             n_channels = chunk.n_channels;
             first_sample_pos.get_or_insert(chunk.sample_pos);
         }
+        // Copied out (or deliberately skipped, on a layout change): the sample
+        // buffers go back to the engine to be filled again next packet, instead
+        // of being freed and reallocated ~1200 times a second.
+        engine.recycle(chunks);
 
         if !out_frames.is_null() {
             *out_frames = total_frames;

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -2351,3 +2351,87 @@ fn cadences_fall_back_to_the_host_default() {
     assert_eq!(control.meter_rate_hz(), 50.0);
     assert_eq!(control.diag_rate_hz(), 50.0);
 }
+
+/// A donated buffer is cleared and resized, so handing back a *used* one is
+/// identical to handing over a fresh one.
+///
+/// The embedded host relies on this to pool its output buffers instead of
+/// allocating one per rendered block. If `render_frame` ever appended to the
+/// donated buffer rather than clearing it, or trusted its existing length, the
+/// symptom would be stale audio from two frames ago rather than a crash — so it
+/// is worth pinning rather than assuming.
+#[test]
+fn a_recycled_output_buffer_renders_identically_to_a_fresh_one() {
+    fn build() -> SpatialRenderer {
+        SpatialRenderer::new(
+            SpeakerLayout::preset("7.1.4").unwrap(),
+            48_000,
+            1,
+            1,
+            0.0,
+            2.0,
+            VbapTableMode::Cartesian {
+                x_size: 9,
+                y_size: 9,
+                z_size: 5,
+                z_neg_size: 5,
+            },
+            false,
+            false,
+            DistanceModel::Linear,
+            false,
+            1.0,
+            1.0,
+            0.0,
+            1.0,
+            false,
+            [1.0, 2.0, 0.5],
+            2.0,
+            0.5,
+            0.0,
+            0.0,
+            false,
+            false,
+            false,
+            1.0,
+            1.0,
+            PreferredEvaluationMode::PrecomputedCartesian,
+            LiveEvaluationMode::PrecomputedCartesian,
+            9,
+            9,
+            5,
+            5,
+        )
+        .unwrap()
+    }
+
+    let pcm: Vec<f32> = (0..40).map(|i| (i * 7 % 13) as f32 / 13.0 - 0.5).collect();
+    let event = vec![SpatialChannelEvent {
+        channel_idx: 0,
+        is_bed: false,
+        gain_db: Some(0),
+        ramp_length: Some(40),
+        size: Some([0.0, 0.0, 0.0]),
+        position: Some([0.3, -0.2, 0.4]),
+        sample_pos: Some(0),
+    }];
+
+    let fresh = build()
+        .render_frame(&pcm, 1, &event, Vec::new(), false)
+        .unwrap();
+
+    // Deliberately hostile: non-zero content, and a length that is both wrong
+    // and longer than what this frame needs.
+    let dirty = vec![-7.5f32; fresh.samples.len() * 3 + 11];
+    let recycled = build().render_frame(&pcm, 1, &event, dirty, false).unwrap();
+
+    assert_eq!(
+        recycled.samples.len(),
+        fresh.samples.len(),
+        "the donated buffer must be resized to this frame, not left long"
+    );
+    assert_eq!(
+        recycled.samples, fresh.samples,
+        "no sample of the previous contents may survive into the render"
+    );
+}


### PR DESCRIPTION
`Engine::render_frame` passed `Vec::new()` as the renderer's output buffer, so every rendered block allocated one and freed it as soon as the FFI had copied it out — about 1200 times a second on TrueHD. The CLI host has always donated and recovered its buffer; this was the mpv host doing exactly what that parameter exists to avoid.

## How big is it, honestly

Measured, per rendered block (40 samples × 12 channels):

| | per block |
|---|---|
| fresh `Vec` | 30 ns |
| pooled | 12 ns |

That is **0.02 ms per second of audio**. It is not a speedup and that is not the reason to do it.

What it actually removes is ~1200 allocate/free pairs per second from the steady state — the kind of churn that matters on a constrained allocator and over hours of continuous playback, not on a desktop glibc. If you were hoping for a number like #266's, this isn't one; it's hygiene, and it brings the two hosts in line.

## Shape

The buffers can't simply live in the engine: every block of one packet is alive at the same time, because the host copies them in a single pass and may stop early on a layout change. So they're lent out with the block and handed back by `recycle` once copied.

- **Optional** — a host that drops the blocks instead allocates exactly as before. It's an optimisation, not a contract.
- **Bounded** — a caller that hands back more blocks than it renders can't grow the pool without limit.
- The FFI recycles on **both** exits, including the buffer-too-small path, where the caller is about to retry and render the same packet again.

The silence path allocated too (`vec![0.0; …]`); it takes a pooled buffer now as well.

## Test

One test, pinning the contract the pool rests on: `render_frame` clears and resizes the buffer it's given, so a used one renders identically to a fresh one. It hands over a buffer that is both dirty (`-7.5` throughout) and the wrong length (3× too long), because if that ever regressed the symptom would be **stale audio from an earlier frame**, not a crash — silent corruption is worth a test in a way that a panic isn't.

I verified the clear-and-resize contract in both arms of `render_frame` (binaural and speaker) rather than assuming it from the CLI's use.

## Risk

602 workspace tests pass, fmt clean. No conflict with #268 (checked with `git merge-tree`).

Not verified by ear. The realistic failure mode if I've got this wrong is stale samples leaking between blocks in the mpv path — audible immediately as glitching, not subtle. Worth one playback through mpv before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)