### PR TITLE
Name every OSC address in the contract, and enforce it

### DIFF
--- a/omniphony-renderer/host_audio/src/lib.rs
+++ b/omniphony-renderer/host_audio/src/lib.rs
@@ -28,6 +28,7 @@ use runtime_control::osc::{
     parse_json_string_arg, parse_nonnegative_f32_arg, parse_nonnegative_u32_arg,
     parse_positive_f32_arg, parse_positive_u32_arg, parse_string_arg,
 };
+use runtime_control::osc_contract;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -237,7 +238,7 @@ fn push_audio_domain_broadcasts(
     include_logical_apply: bool,
 ) {
     effects.broadcasts.push(BroadcastUpdate {
-        addr: "/omniphony/state/audio".to_string(),
+        addr: osc_contract::STATE_AUDIO.to_string(),
         value: BroadcastValue::String(build_audio_state_json(audio)),
     });
     if include_logical_apply {
@@ -251,7 +252,7 @@ fn push_input_domain_broadcasts(
     include_logical_apply: bool,
 ) {
     effects.broadcasts.push(BroadcastUpdate {
-        addr: "/omniphony/state/input".to_string(),
+        addr: osc_contract::STATE_INPUT.to_string(),
         value: BroadcastValue::String(build_input_state_json(input)),
     });
     if include_logical_apply {
@@ -288,7 +289,7 @@ impl HostControlHandler for HostAudio {
         let mut effects = ControlEffects::default();
 
         // ── /control/config/audio (batch apply) ──
-        if addr == "/omniphony/control/config/audio" {
+        if addr == osc_contract::CONTROL_CONFIG_AUDIO {
             let patch = parse_json_string_arg::<AudioConfigPatch>(msg.args.first());
             if let Some(patch) = patch {
                 if let Some(output_device) = patch.output_device {
@@ -430,13 +431,13 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/config/audio/apply" {
+        if addr == osc_contract::CONTROL_CONFIG_AUDIO_APPLY {
             push_audio_domain_broadcasts(&mut effects, audio, false);
             effects.log_message = Some("OSC: audio config apply".to_string());
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/config/input" {
+        if addr == osc_contract::CONTROL_CONFIG_INPUT {
             let patch = parse_json_string_arg::<InputConfigPatch>(msg.args.first());
             if let Some(patch) = patch {
                 if let Some(mode) = patch.mode {
@@ -502,7 +503,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/config/input/apply" {
+        if addr == osc_contract::CONTROL_CONFIG_INPUT_APPLY {
             input.request_apply();
             effects.mark_dirty = true;
             push_input_domain_broadcasts(&mut effects, input, false);
@@ -510,10 +511,10 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/audio/output_devices/refresh" {
+        if addr == osc_contract::CONTROL_AUDIO_OUTPUT_DEVICES_REFRESH {
             if let Some(devices) = audio.refresh_available_output_devices() {
                 effects.broadcasts.push(BroadcastUpdate {
-                    addr: "/omniphony/state/audio".to_string(),
+                    addr: osc_contract::STATE_AUDIO.to_string(),
                     value: BroadcastValue::String(build_audio_state_json(audio)),
                 });
                 effects.log_message = Some(format!(
@@ -524,7 +525,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/audio/output_device" {
+        if addr == osc_contract::CONTROL_AUDIO_OUTPUT_DEVICE {
             let requested = msg.args.first().and_then(|arg| match arg {
                 OscType::String(s) => {
                     let trimmed = s.trim();
@@ -541,25 +542,25 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/audio/output_backend" {
+        if addr == osc_contract::CONTROL_AUDIO_OUTPUT_BACKEND {
             audio.set_requested_output_backend(trim_to_opt(parse_string_arg(msg.args.first())));
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/audio/output_file" {
+        if addr == osc_contract::CONTROL_AUDIO_OUTPUT_FILE {
             audio.set_requested_output_file(trim_to_opt(parse_string_arg(msg.args.first())));
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/audio/output_file_format" {
+        if addr == osc_contract::CONTROL_AUDIO_OUTPUT_FILE_FORMAT {
             audio.set_requested_output_file_format(trim_to_opt(parse_string_arg(msg.args.first())));
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/mode" {
+        if addr == osc_contract::CONTROL_INPUT_MODE {
             let requested = parse_string_arg(msg.args.first()).and_then(|value| {
                 match value.to_ascii_lowercase().as_str() {
                     "bridge" | "pipe_bridge" => Some(InputMode::Bridge),
@@ -579,7 +580,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/backend" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_BACKEND {
             let requested = parse_string_arg(msg.args.first()).and_then(|value| {
                 match value.to_ascii_lowercase().as_str() {
                     "pipewire" => Some(InputBackend::Pipewire),
@@ -594,21 +595,21 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/node" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_NODE {
             let requested = parse_string_arg(msg.args.first());
             input.set_requested_node_name(requested);
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/description" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_DESCRIPTION {
             let requested = parse_string_arg(msg.args.first());
             input.set_requested_node_description(requested);
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/layout" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_LAYOUT {
             let requested = parse_string_arg(msg.args.first()).map(PathBuf::from);
             input.set_requested_layout_path(requested);
             input.set_requested_current_layout(None);
@@ -616,14 +617,14 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/layout_import" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_LAYOUT_IMPORT {
             let requested = parse_input_layout_arg(msg.args.first());
             input.set_requested_current_layout(requested);
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/channels" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_CHANNELS {
             let requested = match msg.args.first() {
                 Some(OscType::Int(i)) if *i > 0 => Some(*i as u16),
                 Some(OscType::Float(f)) if *f > 0.0 => Some(*f as u16),
@@ -636,7 +637,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/sample_rate" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_SAMPLE_RATE {
             if let Some(requested) = parse_positive_u32_arg(msg.args.first()) {
                 input.set_requested_sample_rate_hz(Some(requested));
                 effects.mark_dirty = true;
@@ -644,7 +645,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/format" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_FORMAT {
             let requested = parse_string_arg(msg.args.first()).and_then(|value| {
                 match value.to_ascii_lowercase().as_str() {
                     "f32" => Some(InputSampleFormat::F32),
@@ -659,7 +660,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/map" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_MAP {
             let requested = parse_string_arg(msg.args.first()).and_then(|value| {
                 match value.to_ascii_lowercase().as_str() {
                     "7.1-fixed" => Some(InputMapMode::SevenOneFixed),
@@ -673,7 +674,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/lfe_mode" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_LFE_MODE {
             let requested = parse_string_arg(msg.args.first()).and_then(|value| {
                 match value.to_ascii_lowercase().as_str() {
                     "object" => Some(InputLfeMode::Object),
@@ -689,7 +690,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/live/clock_mode" {
+        if addr == osc_contract::CONTROL_INPUT_LIVE_CLOCK_MODE {
             let requested = parse_string_arg(msg.args.first()).and_then(|value| {
                 match value.to_ascii_lowercase().as_str() {
                     "dac" => Some(InputClockMode::Dac),
@@ -705,14 +706,14 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/input/apply" {
+        if addr == osc_contract::CONTROL_INPUT_APPLY {
             input.request_apply();
             effects.mark_dirty = true;
             effects.log_message = Some("OSC: input apply requested".to_string());
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/audio/sample_rate" {
+        if addr == osc_contract::CONTROL_AUDIO_SAMPLE_RATE {
             let requested_hz = match msg.args.first() {
                 Some(OscType::Int(i)) if *i > 0 => Some(*i as u32),
                 Some(OscType::Float(f)) if *f > 0.0 => Some(*f as u32),
@@ -723,7 +724,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING {
             if let Some(enabled) = parse_bool_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling(enabled);
                 effects.mark_dirty = true;
@@ -731,7 +732,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/enable_far_mode" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_ENABLE_FAR_MODE {
             if let Some(enabled) = parse_bool_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_enable_far_mode(enabled);
                 effects.mark_dirty = true;
@@ -739,7 +740,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/force_silence_in_far_mode" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_FORCE_SILENCE_IN_FAR_MODE {
             if let Some(enabled) = parse_bool_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_force_silence_in_far_mode(enabled);
                 effects.mark_dirty = true;
@@ -747,8 +748,8 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/hard_recover_high_in_far_mode"
-            || addr == "/omniphony/control/adaptive_resampling/hard_recover_in_far_mode"
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_HARD_RECOVER_HIGH_IN_FAR_MODE
+            || addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_HARD_RECOVER_IN_FAR_MODE
         {
             if let Some(enabled) = parse_bool_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_hard_recover_high_in_far_mode(enabled);
@@ -757,7 +758,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/hard_recover_low_in_far_mode" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_HARD_RECOVER_LOW_IN_FAR_MODE {
             if let Some(enabled) = parse_bool_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_hard_recover_low_in_far_mode(enabled);
                 effects.mark_dirty = true;
@@ -765,7 +766,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/far_mode_return_fade_in_ms" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_FAR_MODE_RETURN_FADE_IN_MS {
             if let Some(value) = parse_nonnegative_u32_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_far_mode_return_fade_in_ms(value);
                 effects.mark_dirty = true;
@@ -773,7 +774,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/kp_near" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_KP_NEAR {
             if let Some(value) = parse_positive_f32_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_kp_near(value);
                 effects.mark_dirty = true;
@@ -781,7 +782,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/ki" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_KI {
             if let Some(value) = parse_nonnegative_f32_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_ki(value);
                 effects.mark_dirty = true;
@@ -789,7 +790,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/integral_discharge_ratio" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_INTEGRAL_DISCHARGE_RATIO {
             if let Some(value) = parse_nonnegative_f32_arg(msg.args.first()).map(|v| v.min(1.0)) {
                 audio.set_requested_adaptive_resampling_integral_discharge_ratio(value);
                 effects.mark_dirty = true;
@@ -797,7 +798,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/max_adjust" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_MAX_ADJUST {
             if let Some(value) = parse_positive_f32_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_max_adjust(value);
                 effects.mark_dirty = true;
@@ -805,7 +806,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/update_interval_callbacks" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_UPDATE_INTERVAL_CALLBACKS {
             if let Some(value) = parse_positive_u32_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_update_interval_callbacks(value);
                 effects.mark_dirty = true;
@@ -813,8 +814,8 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/high_recover_entry_margin_ms"
-            || addr == "/omniphony/control/adaptive_resampling/near_far_threshold_ms"
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_HIGH_RECOVER_ENTRY_MARGIN_MS
+            || addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_NEAR_FAR_THRESHOLD_MS
         {
             if let Some(value) = parse_positive_u32_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_high_recover_entry_margin_ms(value);
@@ -823,7 +824,7 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/pause" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_PAUSE {
             if let Some(paused) = parse_bool_arg(msg.args.first()) {
                 audio.set_requested_adaptive_resampling_paused(paused);
                 effects.mark_dirty = true;
@@ -831,13 +832,13 @@ impl HostControlHandler for HostAudio {
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/adaptive_resampling/reset_ratio" {
+        if addr == osc_contract::CONTROL_ADAPTIVE_RESAMPLING_RESET_RATIO {
             audio.request_ratio_reset();
             effects.mark_dirty = true;
             return Some(effects);
         }
 
-        if addr == "/omniphony/control/latency_target" {
+        if addr == osc_contract::CONTROL_LATENCY_TARGET {
             if let Some(latency_ms) = parse_positive_u32_arg(msg.args.first()) {
                 audio.set_requested_latency_target_ms(Some(latency_ms));
                 effects.mark_dirty = true;
@@ -857,7 +858,7 @@ impl HostControlHandler for HostAudio {
         // /state/audio: full output-device + adaptive-resampling state.
         let requested = audio.requested_snapshot();
         messages.push(OscPacket::Message(OscMessage {
-            addr: "/omniphony/state/audio".to_string(),
+            addr: osc_contract::STATE_AUDIO.to_string(),
             args: vec![OscType::String(
                 json!({
                     "outputDevices": audio.available_output_devices(),
@@ -908,7 +909,7 @@ impl HostControlHandler for HostAudio {
         let requested = input.requested_snapshot();
         let applied = input.applied_snapshot();
         messages.push(OscPacket::Message(OscMessage {
-            addr: "/omniphony/state/input".to_string(),
+            addr: osc_contract::STATE_INPUT.to_string(),
             args: vec![OscType::String(
                 json!({
                     "mode": input_mode_name(requested.mode),

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -27,6 +27,7 @@ use self::transport::{
     flush_pending_logs, resolve_register_addr, send_buffered_logs_to_client, send_metering_state,
     send_raw_filtered,
 };
+use runtime_control::osc_contract;
 
 /// Timeout after which a registered client (one that must heartbeat) is considered dead.
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -102,7 +103,7 @@ fn send_resume_to_standby() {
 /// Point-to-point reply address: a standby-capable instance answers a
 /// `yield_port` with this, carrying the dynamic UDP port (Int) on which it will
 /// listen for `/omniphony/control/resume`. Both sides live in this crate.
-pub(crate) const STANDBY_RESUME_REPLY: &str = "/omniphony/yield/resume_port";
+pub(crate) const STANDBY_RESUME_REPLY: &str = osc_contract::YIELD_RESUME_PORT;
 
 /// Dynamic resume socket allocated by the yield handler when this instance is
 /// asked to stand by. The render loop's standby path takes it to listen for
@@ -557,7 +558,7 @@ impl OscSender {
                         if let Some(speaker_idx) = ctrl.take_clip_pending() {
                             if let Ok(bytes) =
                                 rosc::encoder::encode(&OscPacket::Message(OscMessage {
-                                    addr: "/omniphony/state/clip".to_string(),
+                                    addr: osc_contract::STATE_CLIP.to_string(),
                                     args: vec![rosc::OscType::Int(speaker_idx as i32)],
                                 }))
                             {
@@ -569,7 +570,7 @@ impl OscSender {
                         Ok((len, src)) => {
                             match rosc::decoder::decode_udp(&buf[..len]) {
                                 Ok((_, OscPacket::Message(msg)))
-                                    if msg.addr == "/omniphony/register" =>
+                                    if msg.addr == osc_contract::REGISTER =>
                                 {
                                     let client = resolve_register_addr(src, &msg.args);
                                     let (is_new, metering_enabled) = clients.register(client);
@@ -594,15 +595,15 @@ impl OscSender {
                                     send_metering_state(&socket, client, metering_enabled);
                                 }
                                 Ok((_, OscPacket::Message(msg)))
-                                    if msg.addr == "/omniphony/heartbeat" =>
+                                    if msg.addr == osc_contract::HEARTBEAT =>
                                 {
                                     let client = resolve_register_addr(src, &msg.args);
                                     let is_known = clients.heartbeat(client);
                                     let reply_addr = if is_known {
                                         log::trace!("OSC heartbeat/ack → {}", client);
-                                        "/omniphony/heartbeat/ack"
+                                        osc_contract::HEARTBEAT_ACK
                                     } else {
-                                        "/omniphony/heartbeat/unknown"
+                                        osc_contract::HEARTBEAT_UNKNOWN
                                     };
                                     // Echo this instance's epoch so the client can
                                     // detect a producer swap behind the same port.
@@ -996,7 +997,7 @@ fn maybe_broadcast_head_pose(
     transport::broadcast_ffff(
         socket,
         clients,
-        "/omniphony/state/head_pose",
+        osc_contract::STATE_HEAD_POSE,
         pose.w as f32,
         pose.x as f32,
         pose.y as f32,

--- a/omniphony-renderer/orender_engine/src/osc/export.rs
+++ b/omniphony-renderer/orender_engine/src/osc/export.rs
@@ -8,6 +8,7 @@ use runtime_control::HostControlHandler;
 
 use super::client_registry::OscClientRegistry;
 use super::transport::{broadcast_int, broadcast_string, send_raw};
+use runtime_control::osc_contract;
 
 /// Compose the live-state snapshot bundle: core messages (renderer/layout/
 /// speakers/loudness/DRC/monitoring/objects) + the host handler's extra
@@ -31,16 +32,16 @@ pub(crate) fn build_live_state_bundle(
     // lives in this crate), so any host-registered out-of-tree generators are
     // included.
     messages.push(OscPacket::Message(OscMessage {
-        addr: "/omniphony/state/object_generators".to_string(),
+        addr: osc_contract::STATE_OBJECT_GENERATORS.to_string(),
         args: vec![OscType::String(control.object_generators_schema())],
     }));
     // Declared phantom-extraction param schema, so Studio builds its sliders.
     messages.push(OscPacket::Message(OscMessage {
-        addr: "/omniphony/state/phantom".to_string(),
+        addr: osc_contract::STATE_PHANTOM.to_string(),
         args: vec![OscType::String(control.phantom_schema())],
     }));
     messages.push(OscPacket::Message(OscMessage {
-        addr: "/omniphony/state/snapshot_complete".to_string(),
+        addr: osc_contract::STATE_SNAPSHOT_COMPLETE.to_string(),
         args: vec![OscType::Int(1)],
     }));
     let bundle = OscPacket::Bundle(OscBundle {
@@ -62,10 +63,10 @@ pub(crate) fn save_live_config(
     let host_ref: Option<&dyn HostControlHandler> = host.map(|h| h.as_ref());
     // Clear any previous save error so the UI returns to a clean state for
     // this attempt (mirrors what we do at the start of a recompute).
-    broadcast_string(socket, clients, "/omniphony/state/config/save_error", "");
+    broadcast_string(socket, clients, osc_contract::STATE_CONFIG_SAVE_ERROR, "");
     match runtime_control::persist::save_live_config(control, host_ref) {
         Ok(result) => {
-            broadcast_int(socket, clients, "/omniphony/state/config/saved", 1);
+            broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 1);
             let state_bytes = build_live_state_bundle(control, host);
             send_raw(socket, clients, &state_bytes);
             log::info!("OSC: config saved to {}", result.path.display());
@@ -80,7 +81,7 @@ pub(crate) fn save_live_config(
             broadcast_string(
                 socket,
                 clients,
-                "/omniphony/state/config/save_error",
+                osc_contract::STATE_CONFIG_SAVE_ERROR,
                 &message,
             );
         }

--- a/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
@@ -3,6 +3,7 @@ use rosc::{OscMessage, OscPacket, OscType};
 use std::sync::atomic::Ordering;
 
 use super::{ObjectMeta, ObjectSnapshot, OscSender};
+use runtime_control::osc_contract;
 
 impl OscSender {
     pub fn send_object_position(&self, object_id: u32, x: f32, y: f32, z: f32) -> Result<()> {
@@ -17,7 +18,7 @@ impl OscSender {
 
     pub fn send_bed_config(&self, channel_count: u32) -> Result<()> {
         let msg = OscMessage {
-            addr: "/omniphony/bed/config".to_string(),
+            addr: osc_contract::BED_CONFIG.to_string(),
             args: vec![OscType::Int(channel_count as i32)],
         };
         let bytes = rosc::encoder::encode(&OscPacket::Message(msg))?;
@@ -27,7 +28,7 @@ impl OscSender {
 
     pub fn send_timestamp(&self, sample_pos: u64, seconds: f64) -> Result<()> {
         let msg = OscMessage {
-            addr: "/omniphony/timestamp".to_string(),
+            addr: osc_contract::TIMESTAMP.to_string(),
             args: vec![OscType::Long(sample_pos as i64), OscType::Double(seconds)],
         };
         let bytes = rosc::encoder::encode(&OscPacket::Message(msg))?;
@@ -43,7 +44,7 @@ impl OscSender {
         objects: &[ObjectMeta],
     ) -> Result<()> {
         let frame_msg = OscMessage {
-            addr: "/omniphony/spatial/frame".to_string(),
+            addr: osc_contract::SPATIAL_FRAME.to_string(),
             args: vec![
                 OscType::Long(sample_pos as i64),
                 OscType::Long(self.content_generation as i64),

--- a/omniphony-renderer/orender_engine/src/osc/recompute.rs
+++ b/omniphony-renderer/orender_engine/src/osc/recompute.rs
@@ -8,6 +8,7 @@ use runtime_control::snapshot::{build_renderer_state_json, build_speakers_state_
 use super::client_registry::OscClientRegistry;
 use super::gaintable::GaintableCache;
 use super::transport::{broadcast_int, broadcast_string, send_update_to_client};
+use runtime_control::osc_contract;
 
 pub(crate) fn trigger_layout_recompute(
     control: &Arc<RendererControl>,
@@ -19,7 +20,7 @@ pub(crate) fn trigger_layout_recompute(
         log::warn!(
             "OSC apply: speaker positions cannot be updated — requested backend rebuild could not be prepared"
         );
-        broadcast_int(socket, clients, "/omniphony/state/speakers/recomputing", 0);
+        broadcast_int(socket, clients, osc_contract::STATE_SPEAKERS_RECOMPUTING, 0);
         return;
     }
 
@@ -34,7 +35,7 @@ pub(crate) fn trigger_layout_recompute(
             .recompute_pending
             .store(true, std::sync::atomic::Ordering::Relaxed);
         log::info!("OSC apply: recompute already in progress, queueing a follow-up rebuild");
-        broadcast_int(socket, clients, "/omniphony/state/speakers/recomputing", 1);
+        broadcast_int(socket, clients, osc_contract::STATE_SPEAKERS_RECOMPUTING, 1);
         return;
     }
 
@@ -42,7 +43,7 @@ pub(crate) fn trigger_layout_recompute(
         Some(plan) => plan,
         None => {
             log::warn!("OSC apply: failed to prepare render backend recompute plan");
-            broadcast_int(socket, clients, "/omniphony/state/speakers/recomputing", 0);
+            broadcast_int(socket, clients, osc_contract::STATE_SPEAKERS_RECOMPUTING, 0);
             return;
         }
     };
@@ -50,11 +51,11 @@ pub(crate) fn trigger_layout_recompute(
     control
         .recomputing
         .store(true, std::sync::atomic::Ordering::Relaxed);
-    broadcast_int(socket, clients, "/omniphony/state/speakers/recomputing", 1);
+    broadcast_int(socket, clients, osc_contract::STATE_SPEAKERS_RECOMPUTING, 1);
     broadcast_string(
         socket,
         clients,
-        "/omniphony/state/speakers/recompute_error",
+        osc_contract::STATE_SPEAKERS_RECOMPUTE_ERROR,
         "",
     );
 
@@ -136,25 +137,25 @@ pub(crate) fn trigger_layout_recompute(
                     broadcast_string(
                         &socket_clone,
                         &clients_clone,
-                        "/omniphony/state/renderer",
+                        osc_contract::STATE_RENDERER,
                         &renderer_state_json,
                     );
                     broadcast_string(
                         &socket_clone,
                         &clients_clone,
-                        "/omniphony/state/layout",
+                        osc_contract::STATE_LAYOUT,
                         &layout_json,
                     );
                     broadcast_string(
                         &socket_clone,
                         &clients_clone,
-                        "/omniphony/state/speakers",
+                        osc_contract::STATE_SPEAKERS,
                         &speakers_state_json,
                     );
                     broadcast_int(
                         &socket_clone,
                         &clients_clone,
-                        "/omniphony/state/speakers/recomputing",
+                        osc_contract::STATE_SPEAKERS_RECOMPUTING,
                         0,
                     );
                     // The precomputed gain table changed with the new topology.
@@ -212,13 +213,13 @@ pub(crate) fn trigger_layout_recompute(
                     broadcast_string(
                         &socket_clone,
                         &clients_clone,
-                        "/omniphony/state/speakers/recompute_error",
+                        osc_contract::STATE_SPEAKERS_RECOMPUTE_ERROR,
                         &message,
                     );
                     broadcast_int(
                         &socket_clone,
                         &clients_clone,
-                        "/omniphony/state/speakers/recomputing",
+                        osc_contract::STATE_SPEAKERS_RECOMPUTING,
                         0,
                     );
                     // Same follow-up as the success path: a request queued

--- a/omniphony-renderer/orender_engine/src/osc/state_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/state_emit.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 
 use super::OscSender;
 use super::export::build_live_state_bundle;
+use runtime_control::osc_contract;
 impl OscSender {
     pub fn send_live_state_bundle(&self) -> Result<()> {
         let control = match self.control {
@@ -34,7 +35,7 @@ impl OscSender {
             "gain": gain_linear
         })
         .to_string();
-        super::transport::broadcast_string(socket, clients, "/omniphony/state/loudness", &payload);
+        super::transport::broadcast_string(socket, clients, osc_contract::STATE_LOUDNESS, &payload);
     }
 
     /// Publish the diag schema and/or values bundle to subscribed clients.
@@ -49,13 +50,13 @@ impl OscSender {
         let mut messages = Vec::with_capacity(2);
         if let Some(json) = diag_schema_json {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/diag_schema".to_string(),
+                addr: osc_contract::STATE_DIAG_SCHEMA.to_string(),
                 args: vec![OscType::String(json)],
             }));
         }
         if let Some(json) = diag_values_json {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/diag_values".to_string(),
+                addr: osc_contract::STATE_DIAG_VALUES.to_string(),
                 args: vec![OscType::String(json)],
             }));
         }
@@ -133,109 +134,109 @@ impl OscSender {
             .or(latency_target_ms)
         {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency".to_string(),
+                addr: osc_contract::STATE_LATENCY.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = decode_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/decode_time_ms".to_string(),
+                addr: osc_contract::STATE_DECODE_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = render_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/render_time_ms".to_string(),
+                addr: osc_contract::STATE_RENDER_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = crossover_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/crossover_time_ms".to_string(),
+                addr: osc_contract::STATE_CROSSOVER_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = write_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/write_time_ms".to_string(),
+                addr: osc_contract::STATE_WRITE_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = frame_duration_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/frame_duration_ms".to_string(),
+                addr: osc_contract::STATE_FRAME_DURATION_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = latency_instant_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_instant".to_string(),
+                addr: osc_contract::STATE_LATENCY_INSTANT.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_control_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_control".to_string(),
+                addr: osc_contract::STATE_LATENCY_CONTROL.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_smoothed_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_smoothed".to_string(),
+                addr: osc_contract::STATE_LATENCY_SMOOTHED.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_target_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_target".to_string(),
+                addr: osc_contract::STATE_LATENCY_TARGET.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_downstream_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_downstream".to_string(),
+                addr: osc_contract::STATE_LATENCY_DOWNSTREAM.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_avail_input_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_avail_input".to_string(),
+                addr: osc_contract::STATE_LATENCY_AVAIL_INPUT.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_output_fifo_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_output_fifo".to_string(),
+                addr: osc_contract::STATE_LATENCY_OUTPUT_FIFO.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ms) = latency_resampler_pending_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/latency_resampler_pending".to_string(),
+                addr: osc_contract::STATE_LATENCY_RESAMPLER_PENDING.to_string(),
                 args: vec![OscType::Float(ms)],
             }));
         }
         if let Some(ratio) = resample_ratio {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/resample_ratio".to_string(),
+                addr: osc_contract::STATE_RESAMPLE_RATIO.to_string(),
                 args: vec![OscType::Float(ratio)],
             }));
         }
         if let Some(band) = adaptive_band {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/adaptive_resampling/band".to_string(),
+                addr: osc_contract::STATE_ADAPTIVE_RESAMPLING_BAND.to_string(),
                 args: vec![OscType::String(band.to_string())],
             }));
         }
         if let Some(state) = adaptive_state {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/adaptive_resampling/state".to_string(),
+                addr: osc_contract::STATE_ADAPTIVE_RESAMPLING_STATE.to_string(),
                 args: vec![OscType::String(state.to_string())],
             }));
         }
         if let Some(gain) = drc_gain {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/meter/drc_gain".to_string(),
+                addr: osc_contract::METER_DRC_GAIN.to_string(),
                 args: vec![OscType::Float(gain)],
             }));
         }
@@ -293,7 +294,7 @@ impl OscSender {
             // other can only draw something half true.
             let (peak, rms) = object_test_level.unwrap_or((-100.0, -100.0));
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/object_test/position".to_string(),
+                addr: osc_contract::STATE_OBJECT_TEST_POSITION.to_string(),
                 args: vec![
                     OscType::Float(x),
                     OscType::Float(y),
@@ -304,7 +305,7 @@ impl OscSender {
             }));
         }
         messages.push(OscPacket::Message(OscMessage {
-            addr: "/omniphony/meter/master".to_string(),
+            addr: osc_contract::METER_MASTER.to_string(),
             args: vec![
                 OscType::Float(snapshot.master_peak),
                 OscType::Float(snapshot.master_rms),
@@ -333,19 +334,19 @@ impl OscSender {
         let mut messages = Vec::new();
         if let Some(ms) = decode_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/decode_time_ms".to_string(),
+                addr: osc_contract::STATE_DECODE_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = render_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/render_time_ms".to_string(),
+                addr: osc_contract::STATE_RENDER_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }
         if let Some(ms) = write_time_ms {
             messages.push(OscPacket::Message(OscMessage {
-                addr: "/omniphony/state/write_time_ms".to_string(),
+                addr: osc_contract::STATE_WRITE_TIME_MS.to_string(),
                 args: vec![OscType::Float(ms.max(0.0))],
             }));
         }

--- a/omniphony-renderer/orender_engine/src/osc/transport.rs
+++ b/omniphony-renderer/orender_engine/src/osc/transport.rs
@@ -4,6 +4,7 @@ use rosc::{OscMessage, OscPacket, OscType};
 use runtime_control::osc::{BroadcastUpdate, BroadcastValue};
 
 use super::client_registry::OscClientRegistry;
+use runtime_control::osc_contract;
 
 pub(crate) fn broadcast_float(
     socket: &UdpSocket,
@@ -109,7 +110,7 @@ pub(crate) fn broadcast_blob(
 
 pub(crate) fn encode_log_record(record: &sys::live_log::BufferedLogRecord) -> Option<Vec<u8>> {
     let packet = OscPacket::Message(OscMessage {
-        addr: "/omniphony/log".to_string(),
+        addr: osc_contract::LOG.to_string(),
         args: vec![
             OscType::Long(record.seq as i64),
             OscType::String(record.level.clone()),
@@ -167,7 +168,7 @@ pub(crate) fn send_raw_filtered<F>(
 
 pub(crate) fn send_metering_state(socket: &UdpSocket, client: SocketAddr, enabled: bool) {
     let packet = OscPacket::Message(OscMessage {
-        addr: "/omniphony/state/osc/metering".to_string(),
+        addr: osc_contract::STATE_OSC_METERING.to_string(),
         args: vec![OscType::Int(if enabled { 1 } else { 0 })],
     });
     if let Ok(bytes) = rosc::encoder::encode(&packet) {
@@ -179,7 +180,7 @@ pub(crate) fn send_metering_state(socket: &UdpSocket, client: SocketAddr, enable
 
 pub(crate) fn send_diag_state(socket: &UdpSocket, client: SocketAddr, enabled: bool) {
     let packet = OscPacket::Message(OscMessage {
-        addr: "/omniphony/state/osc/diag".to_string(),
+        addr: osc_contract::STATE_OSC_DIAG.to_string(),
         args: vec![OscType::Int(if enabled { 1 } else { 0 })],
     });
     if let Ok(bytes) = rosc::encoder::encode(&packet) {

--- a/omniphony-renderer/runtime_control/src/command.rs
+++ b/omniphony-renderer/runtime_control/src/command.rs
@@ -1,3 +1,4 @@
+use crate::osc_contract;
 use log::LevelFilter;
 use rosc::{OscMessage, OscType};
 
@@ -29,12 +30,12 @@ pub fn parse_runtime_log_level(value: &str) -> Option<LevelFilter> {
 
 pub fn parse_process_command(msg: &OscMessage) -> Option<RuntimeCommand> {
     match msg.addr.as_str() {
-        "/omniphony/control/save_config" => Some(RuntimeCommand::SaveConfig),
-        "/omniphony/control/reload_config" => Some(RuntimeCommand::ReloadConfig),
-        "/omniphony/control/quit" => Some(RuntimeCommand::Quit),
-        "/omniphony/control/yield_port" => Some(RuntimeCommand::YieldPort),
-        "/omniphony/control/resume" => Some(RuntimeCommand::Resume),
-        "/omniphony/control/log_level" => msg.args.first().and_then(|arg| match arg {
+        osc_contract::CONTROL_SAVE_CONFIG => Some(RuntimeCommand::SaveConfig),
+        osc_contract::CONTROL_RELOAD_CONFIG => Some(RuntimeCommand::ReloadConfig),
+        osc_contract::CONTROL_QUIT => Some(RuntimeCommand::Quit),
+        osc_contract::CONTROL_YIELD_PORT => Some(RuntimeCommand::YieldPort),
+        osc_contract::CONTROL_RESUME => Some(RuntimeCommand::Resume),
+        osc_contract::CONTROL_LOG_LEVEL => msg.args.first().and_then(|arg| match arg {
             OscType::String(s) => parse_runtime_log_level(s).map(RuntimeCommand::SetLogLevel),
             _ => None,
         }),
@@ -56,13 +57,13 @@ mod tests {
     #[test]
     fn yield_port_maps_to_runtime_command() {
         assert!(matches!(
-            parse_process_command(&msg(crate::osc_contract::CONTROL_YIELD_PORT)),
+            parse_process_command(&msg(osc_contract::CONTROL_YIELD_PORT)),
             Some(RuntimeCommand::YieldPort)
         ));
         assert!(matches!(
-            parse_process_command(&msg(crate::osc_contract::CONTROL_QUIT)),
+            parse_process_command(&msg(osc_contract::CONTROL_QUIT)),
             Some(RuntimeCommand::Quit)
         ));
-        assert!(parse_process_command(&msg("/omniphony/control/unknown")).is_none());
+        assert!(parse_process_command(&msg(osc_contract::CONTROL_UNKNOWN)).is_none());
     }
 }

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -1,4 +1,5 @@
 use crate::context::RuntimeControlContext;
+use crate::osc_contract;
 use renderer::live_params::LiveEvaluationMode;
 use renderer::render_backend::canonical_builtin_backend_id;
 use rosc::{OscMessage, OscType};
@@ -214,7 +215,7 @@ pub fn gaintable_chunk_broadcasts(
         })
         .to_string();
         out.push(BroadcastUpdate {
-            addr: "/omniphony/state/debug/speaker_gaintable/meta".to_string(),
+            addr: osc_contract::STATE_DEBUG_SPEAKER_GAINTABLE_META.to_string(),
             value: BroadcastValue::String(meta),
         });
     }
@@ -226,7 +227,7 @@ pub fn gaintable_chunk_broadcasts(
         blob.extend_from_slice(&(ci as u32).to_le_bytes());
         blob.extend_from_slice(&bytes[start..end]);
         out.push(BroadcastUpdate {
-            addr: "/omniphony/state/debug/speaker_gaintable/chunk".to_string(),
+            addr: osc_contract::STATE_DEBUG_SPEAKER_GAINTABLE_CHUNK.to_string(),
             value: BroadcastValue::Blob(blob),
         });
     }
@@ -556,7 +557,7 @@ pub fn apply_simple_osc_control(
     let addr = msg.addr.as_str();
     let mut effects = ControlEffects::default();
 
-    if addr == "/omniphony/control/config/layout" {
+    if addr == osc_contract::CONTROL_CONFIG_LAYOUT {
         let patch = parse_json_string_arg::<LayoutConfigPatch>(msg.args.first());
         if let Some(patch) = patch {
             let mut changed = false;
@@ -700,14 +701,14 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/config/layout/apply" {
+    if addr == osc_contract::CONTROL_CONFIG_LAYOUT_APPLY {
         effects.mark_dirty = true;
         effects.trigger_layout_recompute = true;
         effects.log_message = Some("OSC: layout config apply".to_string());
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/config/speakers" {
+    if addr == osc_contract::CONTROL_CONFIG_SPEAKERS {
         let patch = parse_json_string_arg::<SpeakersConfigPatch>(msg.args.first());
         if let Some(patch) = patch {
             let mut changed = false;
@@ -753,7 +754,7 @@ pub fn apply_simple_osc_control(
     // (orender_engine::osc::dispatch) against RendererControl — the single
     // source of truth for both, persisted to config.
 
-    if addr == "/omniphony/control/render_backend" {
+    if addr == osc_contract::CONTROL_RENDER_BACKEND {
         // Accept built-in ids/aliases (e.g. "distance") and any registered backend
         // id (e.g. a contributor's "example"), so the dropdown can offer them all.
         let requested_id = parse_string_arg(msg.args.first()).and_then(|value| {
@@ -773,7 +774,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/output_mode" {
+    if addr == osc_contract::CONTROL_OUTPUT_MODE {
         // Switch between the classic speaker (VBAP) path and the independent
         // binaural (headphone) stage. No topology recompute: the binaural path
         // does not use the speaker topology.
@@ -790,7 +791,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == crate::osc_contract::CONTROL_SPEAKER_TEST {
+    if addr == osc_contract::CONTROL_SPEAKER_TEST {
         // Start/stop the per-speaker test signal. A negative index stops: the
         // client owns the trigger policy (hold, fixed burst, toggle), so the
         // renderer only ever sees "play this" or "stop".
@@ -835,7 +836,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == crate::osc_contract::CONTROL_OBJECT_TEST {
+    if addr == osc_contract::CONTROL_OBJECT_TEST {
         // Start/move/stop the object test. Studio sends one of these per pointer
         // move while dragging, so the common case is a position update on an
         // already-running test: keep it allocation-free and let the renderer
@@ -915,7 +916,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == crate::osc_contract::CONTROL_OBJECT_TEST_ROTATION {
+    if addr == osc_contract::CONTROL_OBJECT_TEST_ROTATION {
         let Some(axis_name) = parse_string_arg(msg.args.first()) else {
             log::warn!("OSC {addr}: expected [axis, radius, period, azimuth, elevation]");
             return Some(effects);
@@ -966,7 +967,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == crate::osc_contract::CONTROL_OBJECT_TEST_CLIP {
+    if addr == osc_contract::CONTROL_OBJECT_TEST_CLIP {
         // Choosing the file the `clip` signal plays. Everything expensive
         // happens here, on the control thread: read, downmix, resample,
         // normalise. The render path gets an array and an index.
@@ -1018,13 +1019,13 @@ pub fn apply_simple_osc_control(
             }
         };
         effects.broadcasts.push(BroadcastUpdate {
-            addr: crate::osc_contract::STATE_OBJECT_TEST_CLIP.to_string(),
+            addr: osc_contract::STATE_OBJECT_TEST_CLIP.to_string(),
             value: BroadcastValue::String(state),
         });
         return Some(effects);
     }
 
-    if addr == crate::osc_contract::CONTROL_SPEAKER_TEST_IDLE_FEED {
+    if addr == osc_contract::CONTROL_SPEAKER_TEST_IDLE_FEED {
         // Arm/disarm the idle feed that keeps the output chain warm while the
         // client's test pane is open. Arming always bumps the generation (even
         // when already armed) so the decode loop refreshes its keepalive
@@ -1049,7 +1050,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural_mode" {
+    if addr == osc_contract::CONTROL_BINAURAL_MODE {
         // Switch the binaural stage between per-object HRTF ("direct") and the
         // virtual-speaker cascade ("cascaded"). No topology recompute: the
         // cascade stage builds its own virtual topology lazily on the render
@@ -1067,7 +1068,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/ear_gain" {
+    if addr == osc_contract::CONTROL_BINAURAL_EAR_GAIN {
         // Headphone L/R output gain: [ear_idx (0|1), linear_gain]. Dedicated
         // params — the ears no longer ride the first two per-speaker slots
         // (those drive the virtual FL/FR in cascaded mode).
@@ -1087,7 +1088,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/ear_mute" {
+    if addr == osc_contract::CONTROL_BINAURAL_EAR_MUTE {
         // Headphone L/R mute: [ear_idx (0|1), 0|1].
         let idx = parse_nonnegative_u32_arg(msg.args.first());
         let mute = parse_bool_arg(msg.args.get(1));
@@ -1103,7 +1104,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/orientation" {
+    if addr == osc_contract::CONTROL_HEAD_ORIENTATION {
         // Static head pose from Euler degrees [yaw, pitch, roll]. The live
         // head-tracking input (SensorsOSC) lands in M2; this lets Studio / tests
         // drive the pose directly. No topology rebuild (binaural is topology-free).
@@ -1117,7 +1118,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/quat" {
+    if addr == osc_contract::CONTROL_HEAD_QUAT {
         // Static head pose from a raw quaternion [w, x, y, z].
         let w = parse_f32_arg(msg.args.first()).unwrap_or(1.0);
         let x = parse_f32_arg(msg.args.get(1)).unwrap_or(0.0);
@@ -1130,7 +1131,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/hrir_source" {
+    if addr == osc_contract::CONTROL_BINAURAL_HRIR_SOURCE {
         // "synthetic" | "saf"/"kemar" | "sofa:<path>" | "pinna[:<size>:<depth>]".
         // No topology rebuild; the render thread rebuilds the HRIR grid lazily
         // when the source changes.
@@ -1151,7 +1152,7 @@ pub fn apply_simple_osc_control(
     // For setups where Studio does not share a filesystem with the renderer:
     // begin [s name, i total_bytes] → chunk [i seq, b data]* → end [i chunks].
     // The file lands in <config dir>/hrtf/ and is activated on completion.
-    if addr == "/omniphony/control/binaural/hrtf_upload/begin" {
+    if addr == osc_contract::CONTROL_BINAURAL_HRTF_UPLOAD_BEGIN {
         let name = parse_string_arg(msg.args.first()).unwrap_or_default();
         let total = match msg.args.get(1) {
             Some(rosc::OscType::Int(i)) if *i > 0 => *i as usize,
@@ -1180,7 +1181,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/hrtf_upload/chunk" {
+    if addr == osc_contract::CONTROL_BINAURAL_HRTF_UPLOAD_CHUNK {
         let seq = match msg.args.first() {
             Some(rosc::OscType::Int(i)) if *i >= 0 => *i as u32,
             _ => return Some(effects),
@@ -1206,7 +1207,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/hrtf_upload/end" {
+    if addr == osc_contract::CONTROL_BINAURAL_HRTF_UPLOAD_END {
         let chunks = match msg.args.first() {
             Some(rosc::OscType::Int(i)) if *i >= 0 => *i as u32,
             _ => 0,
@@ -1249,7 +1250,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/unit_scale" {
+    if addr == osc_contract::CONTROL_BINAURAL_UNIT_SCALE {
         // Metres per ADM unit (isotropic distance scale for the binaural stage).
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             if v.is_finite() && v > 0.0 {
@@ -1262,7 +1263,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/head_radius" {
+    if addr == osc_contract::CONTROL_BINAURAL_HEAD_RADIUS {
         // Effective head radius (m) for the ITD model — half the inter-ear
         // distance. Human range is roughly 6–12 cm.
         if let Some(v) = parse_f32_arg(msg.args.first()) {
@@ -1276,7 +1277,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/reflections/enabled" {
+    if addr == osc_contract::CONTROL_BINAURAL_REFLECTIONS_ENABLED {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().binaural.reflections.enabled = v;
             effects.mark_dirty = true;
@@ -1285,7 +1286,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/reflections/level" {
+    if addr == osc_contract::CONTROL_BINAURAL_REFLECTIONS_LEVEL {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             if v.is_finite() {
                 ctx.renderer.live.write().binaural.reflections.level = v.clamp(0.0, 1.0);
@@ -1296,9 +1297,9 @@ pub fn apply_simple_osc_control(
     }
 
     if let Some(axis) = match addr {
-        "/omniphony/control/binaural/reflections/room_width" => Some(0usize),
-        "/omniphony/control/binaural/reflections/room_depth" => Some(1),
-        "/omniphony/control/binaural/reflections/room_height" => Some(2),
+        osc_contract::CONTROL_BINAURAL_REFLECTIONS_ROOM_WIDTH => Some(0usize),
+        osc_contract::CONTROL_BINAURAL_REFLECTIONS_ROOM_DEPTH => Some(1),
+        osc_contract::CONTROL_BINAURAL_REFLECTIONS_ROOM_HEIGHT => Some(2),
         _ => None,
     } {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
@@ -1314,7 +1315,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/reverb/enabled" {
+    if addr == osc_contract::CONTROL_BINAURAL_REVERB_ENABLED {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().binaural.reverb.enabled = v;
             effects.mark_dirty = true;
@@ -1323,7 +1324,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/reverb/level" {
+    if addr == osc_contract::CONTROL_BINAURAL_REVERB_LEVEL {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             if v.is_finite() {
                 ctx.renderer.live.write().binaural.reverb.level = v.clamp(0.0, 1.0);
@@ -1333,7 +1334,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/reverb/rt60" {
+    if addr == osc_contract::CONTROL_BINAURAL_REVERB_RT60 {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             if v.is_finite() && v > 0.0 {
                 ctx.renderer.live.write().binaural.reverb.rt60_s = v.clamp(0.1, 3.0);
@@ -1343,7 +1344,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/reverb/predelay" {
+    if addr == osc_contract::CONTROL_BINAURAL_REVERB_PREDELAY {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             if v.is_finite() && v >= 0.0 {
                 ctx.renderer.live.write().binaural.reverb.predelay_ms = v.clamp(0.0, 100.0);
@@ -1353,7 +1354,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/binaural/air_absorption" {
+    if addr == osc_contract::CONTROL_BINAURAL_AIR_ABSORPTION {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().binaural.air_absorption = v;
             effects.mark_dirty = true;
@@ -1362,7 +1363,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/recenter" {
+    if addr == osc_contract::CONTROL_HEAD_RECENTER {
         // Capture the current raw tracker orientation as "forward" and snap the
         // rendered pose to identity so the scene faces straight ahead.
         let mut live = ctx.renderer.live.write();
@@ -1376,7 +1377,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/tracking/address" {
+    if addr == osc_contract::CONTROL_HEAD_TRACKING_ADDRESS {
         // Empty string disables tracking.
         let raw = parse_string_arg(msg.args.first()).unwrap_or_default();
         let mut live = ctx.renderer.live.write();
@@ -1390,7 +1391,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/tracking/format" {
+    if addr == osc_contract::CONTROL_HEAD_TRACKING_FORMAT {
         if let Some(fmt) = parse_string_arg(msg.args.first())
             .and_then(|s| renderer::binaural::HeadTrackingFormat::from_str(&s))
         {
@@ -1401,7 +1402,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/tracking/smoothing" {
+    if addr == osc_contract::CONTROL_HEAD_TRACKING_SMOOTHING {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             ctx.renderer.live.write().binaural.tracking.smoothing = v.clamp(0.0, 0.999);
             effects.mark_dirty = true;
@@ -1409,7 +1410,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/head/tracking/invert" {
+    if addr == osc_contract::CONTROL_HEAD_TRACKING_INVERT {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().binaural.tracking.invert = v;
             effects.mark_dirty = true;
@@ -1417,7 +1418,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/render_backend/restore" {
+    if addr == osc_contract::CONTROL_RENDER_BACKEND_RESTORE {
         effects.log_message = Some(
             "OSC: render_backend/restore is no longer supported after removing from_file"
                 .to_string(),
@@ -1432,7 +1433,7 @@ pub fn apply_simple_osc_control(
     // barycenter tab) even though it is not the active selection. Values are
     // stored generically (no typed field per backend) and read at the next
     // topology rebuild via the schema.
-    if addr == "/omniphony/control/backend/param" {
+    if addr == osc_contract::CONTROL_BACKEND_PARAM {
         let (target, key, value_arg) = if msg.args.len() >= 3 {
             (
                 parse_string_arg(msg.args.first()),
@@ -1485,7 +1486,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/render_evaluation_mode" {
+    if addr == osc_contract::CONTROL_RENDER_EVALUATION_MODE {
         let requested = parse_string_arg(msg.args.first())
             .and_then(|value| LiveEvaluationMode::from_str(&value));
         if let Some(requested) = requested {
@@ -1512,13 +1513,13 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/render_evaluation_mode/from_file" {
+    if addr == osc_contract::CONTROL_RENDER_EVALUATION_MODE_FROM_FILE {
         effects.log_message =
             Some("OSC: render_evaluation_mode/from_file is no longer supported".to_string());
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/input/drc_mode" {
+    if addr == osc_contract::CONTROL_INPUT_DRC_MODE {
         let requested = parse_string_arg(msg.args.first());
         if let Some(requested) = requested {
             let mut live = ctx.renderer.live.write();
@@ -1531,7 +1532,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/input/drc_weight" {
+    if addr == osc_contract::CONTROL_INPUT_DRC_WEIGHT {
         if let Some(value) = parse_f32_arg(msg.args.first()) {
             let clamped = value.clamp(0.0, 1.0);
             let mut live = ctx.renderer.live.write();
@@ -1544,7 +1545,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/ramp_mode" {
+    if addr == osc_contract::CONTROL_RAMP_MODE {
         let Some(mode) = msg.args.first().and_then(|arg| match arg {
             OscType::String(s) => renderer::live_params::RampMode::from_str(s),
             _ => None,
@@ -1558,7 +1559,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/layout/radius_m" {
+    if addr == osc_contract::CONTROL_LAYOUT_RADIUS_M {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.01)) {
             ctx.renderer
                 .with_editable_layout(|layout| layout.radius_m = v);
@@ -1568,7 +1569,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/gain" {
+    if addr == osc_contract::CONTROL_GAIN {
         if let Some(gain) = parse_f32_arg(msg.args.first()) {
             ctx.renderer.live.write().master_gain = gain;
             effects.mark_dirty = true;
@@ -1582,7 +1583,7 @@ pub fn apply_simple_osc_control(
     // working; the canonical path is `/omniphony/control/backend/param`. All of
     // them trigger a topology rebuild (the values are baked, not per-request).
     macro_rules! spread_param_with_recompute {
-        ($path:literal, $key:literal) => {
+        ($path:expr, $key:literal) => {
             if addr == $path {
                 if let Some(value) = parse_f32_arg(msg.args.first()) {
                     ctx.renderer.set_backend_param(
@@ -1598,18 +1599,18 @@ pub fn apply_simple_osc_control(
         };
     }
 
-    spread_param_with_recompute!("/omniphony/control/spread/min", "spread_min");
-    spread_param_with_recompute!("/omniphony/control/spread/max", "spread_max");
+    spread_param_with_recompute!(osc_contract::CONTROL_SPREAD_MIN, "spread_min");
+    spread_param_with_recompute!(osc_contract::CONTROL_SPREAD_MAX, "spread_max");
     spread_param_with_recompute!(
-        "/omniphony/control/spread/distance_range",
+        osc_contract::CONTROL_SPREAD_DISTANCE_RANGE,
         "spread_distance_range"
     );
     spread_param_with_recompute!(
-        "/omniphony/control/spread/distance_curve",
+        osc_contract::CONTROL_SPREAD_DISTANCE_CURVE,
         "spread_distance_curve"
     );
 
-    if addr == "/omniphony/control/spread/from_distance" {
+    if addr == osc_contract::CONTROL_SPREAD_FROM_DISTANCE {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.set_backend_param(
                 "vbap",
@@ -1622,7 +1623,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/spread/size_to_spread_mode" {
+    if addr == osc_contract::CONTROL_SPREAD_SIZE_TO_SPREAD_MODE {
         if let Some(OscType::String(s)) = msg.args.first() {
             if let Some(mode) = renderer::render_backend::SizeToSpreadMode::from_str(
                 s.trim().to_ascii_lowercase().as_str(),
@@ -1641,7 +1642,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/auto_gain" {
+    if addr == osc_contract::CONTROL_AUTO_GAIN {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().auto_gain = v;
             effects.mark_dirty = true;
@@ -1650,7 +1651,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/auto_gain_ceiling" {
+    if addr == osc_contract::CONTROL_AUTO_GAIN_CEILING {
         if let Some(v) = parse_f32_arg(msg.args.first()) {
             // dBFS target; clamp to a sane range (ceiling at or below 0 dBFS).
             ctx.renderer.live.write().auto_gain_ceiling_db = v.clamp(-12.0, 0.0);
@@ -1670,19 +1671,19 @@ pub fn apply_simple_osc_control(
             let state_addr = match rest {
                 "x_size" => {
                     ctx.renderer.live.write().evaluation.cartesian.x_size = size;
-                    Some("/omniphony/state/render_evaluation/cartesian/x_size")
+                    Some(osc_contract::STATE_RENDER_EVALUATION_CARTESIAN_X_SIZE)
                 }
                 "y_size" => {
                     ctx.renderer.live.write().evaluation.cartesian.y_size = size;
-                    Some("/omniphony/state/render_evaluation/cartesian/y_size")
+                    Some(osc_contract::STATE_RENDER_EVALUATION_CARTESIAN_Y_SIZE)
                 }
                 "z_size" => {
                     ctx.renderer.live.write().evaluation.cartesian.z_size = size;
-                    Some("/omniphony/state/render_evaluation/cartesian/z_size")
+                    Some(osc_contract::STATE_RENDER_EVALUATION_CARTESIAN_Z_SIZE)
                 }
                 "z_neg_size" => {
                     ctx.renderer.live.write().evaluation.cartesian.z_neg_size = size;
-                    Some("/omniphony/state/render_evaluation/cartesian/z_neg_size")
+                    Some(osc_contract::STATE_RENDER_EVALUATION_CARTESIAN_Z_NEG_SIZE)
                 }
                 _ => None,
             };
@@ -1701,7 +1702,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/render_evaluation/position_interpolation" {
+    if addr == osc_contract::CONTROL_RENDER_EVALUATION_POSITION_INTERPOLATION {
         if let Some(enabled) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().evaluation.position_interpolation = enabled;
             // No layout recompute: this flag only selects nearest-cell vs
@@ -1711,14 +1712,14 @@ pub fn apply_simple_osc_control(
             // the whole grid here just produced an identical table.
             effects.mark_dirty = true;
             effects.broadcasts.push(BroadcastUpdate {
-                addr: "/omniphony/state/render_evaluation/position_interpolation".to_string(),
+                addr: osc_contract::STATE_RENDER_EVALUATION_POSITION_INTERPOLATION.to_string(),
                 value: BroadcastValue::Int(if enabled { 1 } else { 0 }),
             });
         }
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/render_evaluation/object_size_intervals" {
+    if addr == osc_contract::CONTROL_RENDER_EVALUATION_OBJECT_SIZE_INTERVALS {
         let intervals = match msg.args.first() {
             Some(OscType::Int(i)) => Some((*i).max(0) as usize),
             Some(OscType::Float(f)) => Some(f.round().max(0.0) as usize),
@@ -1732,7 +1733,7 @@ pub fn apply_simple_osc_control(
             // tables, reuse the backend geometry.
             effects.evaluation_only = true;
             effects.broadcasts.push(BroadcastUpdate {
-                addr: "/omniphony/state/render_evaluation/object_size_intervals".to_string(),
+                addr: osc_contract::STATE_RENDER_EVALUATION_OBJECT_SIZE_INTERVALS.to_string(),
                 value: BroadcastValue::Int(intervals as i32),
             });
         }
@@ -1751,11 +1752,11 @@ pub fn apply_simple_osc_control(
                     let state_addr = match rest {
                         "azimuth_resolution" => {
                             ctx.renderer.live.write().evaluation.polar.azimuth_values = res;
-                            Some("/omniphony/state/render_evaluation/polar/azimuth_resolution")
+                            Some(osc_contract::STATE_RENDER_EVALUATION_POLAR_AZIMUTH_RESOLUTION)
                         }
                         "elevation_resolution" => {
                             ctx.renderer.live.write().evaluation.polar.elevation_values = res;
-                            Some("/omniphony/state/render_evaluation/polar/elevation_resolution")
+                            Some(osc_contract::STATE_RENDER_EVALUATION_POLAR_ELEVATION_RESOLUTION)
                         }
                         _ => None,
                     };
@@ -1783,7 +1784,7 @@ pub fn apply_simple_osc_control(
                     effects.trigger_layout_recompute = true;
                     effects.evaluation_only = true;
                     effects.broadcasts.push(BroadcastUpdate {
-                        addr: "/omniphony/state/render_evaluation/polar/distance_res".to_string(),
+                        addr: osc_contract::STATE_RENDER_EVALUATION_POLAR_DISTANCE_RES.to_string(),
                         value: BroadcastValue::Int(res),
                     });
                 }
@@ -1800,7 +1801,7 @@ pub fn apply_simple_osc_control(
                     effects.trigger_layout_recompute = true;
                     effects.evaluation_only = true;
                     effects.broadcasts.push(BroadcastUpdate {
-                        addr: "/omniphony/state/render_evaluation/polar/distance_max".to_string(),
+                        addr: osc_contract::STATE_RENDER_EVALUATION_POLAR_DISTANCE_MAX.to_string(),
                         value: BroadcastValue::Float(max_v),
                     });
                 }
@@ -1810,7 +1811,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/loudness" {
+    if addr == osc_contract::CONTROL_LOUDNESS {
         if let Some(v) = parse_bool_arg(msg.args.first()) {
             ctx.renderer.live.write().use_loudness = v;
             effects.mark_dirty = true;
@@ -1818,7 +1819,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/distance_model" {
+    if addr == osc_contract::CONTROL_DISTANCE_MODEL {
         if let Some(OscType::String(model)) = msg.args.first() {
             if let Ok(model) = model.parse::<renderer::spatial_vbap::DistanceModel>() {
                 ctx.renderer.live.write().distance_model = model;
@@ -1829,7 +1830,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/distance_model_metric" {
+    if addr == osc_contract::CONTROL_DISTANCE_MODEL_METRIC {
         if let Some(OscType::String(metric)) = msg.args.first() {
             if let Ok(metric) = metric.parse::<renderer::spatial_vbap::DistanceMetric>() {
                 ctx.renderer.live.write().distance_model_metric = metric;
@@ -1918,7 +1919,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/room_ratio" {
+    if addr == osc_contract::CONTROL_ROOM_RATIO {
         if msg.args.len() >= 3 {
             let w = parse_f32_arg(msg.args.first());
             let l = parse_f32_arg(msg.args.get(1));
@@ -1933,7 +1934,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/room_ratio_rear" {
+    if addr == osc_contract::CONTROL_ROOM_RATIO_REAR {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.01)) {
             ctx.renderer.live.write().room_ratio_rear = v;
             effects.mark_dirty = true;
@@ -1943,7 +1944,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/room_ratio_lower" {
+    if addr == osc_contract::CONTROL_ROOM_RATIO_LOWER {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.max(0.01)) {
             ctx.renderer.live.write().room_ratio_lower = v;
             effects.mark_dirty = true;
@@ -1953,7 +1954,7 @@ pub fn apply_simple_osc_control(
         return Some(effects);
     }
 
-    if addr == "/omniphony/control/room_ratio_center_blend" {
+    if addr == osc_contract::CONTROL_ROOM_RATIO_CENTER_BLEND {
         if let Some(v) = parse_f32_arg(msg.args.first()).map(|f| f.clamp(0.0, 1.0)) {
             ctx.renderer.live.write().room_ratio_center_blend = v;
             effects.mark_dirty = true;
@@ -2013,7 +2014,7 @@ pub fn apply_simple_osc_control(
         }
     }
 
-    if let Some(rest) = addr.strip_prefix("/omniphony/control/object/") {
+    if let Some(rest) = addr.strip_prefix(osc_contract::CONTROL_OBJECT_PREFIX) {
         if let Some(idx_str) = rest.strip_suffix("/mute") {
             if let Ok(idx) = idx_str.parse::<usize>() {
                 if let Some(muted) = parse_bool_arg(msg.args.first()) {

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -3,10 +3,16 @@
 //! The engine is driven and observed entirely over OSC: clients send
 //! `/omniphony/control/…` messages and receive `/omniphony/state/…` updates.
 //! Those address strings are the wire contract between the engine and every
-//! client (Omniphony Studio, alternative front-ends, automation). Historically
-//! they were bare string literals scattered across the dispatcher and the
-//! producers; this module names them once so the Rust side references symbols
-//! instead of magic strings, and so the surface is discoverable in one place.
+//! client (Omniphony Studio, alternative front-ends, automation). They were
+//! once bare string literals scattered across the dispatcher and the producers;
+//! this module names them once so the Rust side references symbols instead of
+//! magic strings, and so the surface is discoverable in one place.
+//!
+//! "Single source of truth" is enforced, not just asserted: a test walks the
+//! OSC-facing sources and fails on any address spelled out rather than named
+//! here. The reason it is worth a test is that the failure mode is invisible —
+//! a mistyped literal compiles, matches nothing, and the control it belongs to
+//! simply stops working, with no error anywhere.
 //!
 //! The human-readable companion — direction, argument types and semantics for
 //! every address — lives in `docs/osc-control-contract.md`. Keep the two in
@@ -82,6 +88,32 @@ pub const CONTROL_BACKEND_FILE_GET: &str = "/omniphony/control/backend/file/get"
 pub const CONTROL_BACKEND_FILE_LIST: &str = "/omniphony/control/backend/file/list";
 pub const CONTROL_BACKEND_FILE_PUT: &str = "/omniphony/control/backend/file/put";
 pub const CONTROL_BACKEND_PARAM: &str = "/omniphony/control/backend/param";
+pub const CONTROL_BINAURAL_AIR_ABSORPTION: &str = "/omniphony/control/binaural/air_absorption";
+pub const CONTROL_BINAURAL_EAR_GAIN: &str = "/omniphony/control/binaural/ear_gain";
+pub const CONTROL_BINAURAL_EAR_MUTE: &str = "/omniphony/control/binaural/ear_mute";
+pub const CONTROL_BINAURAL_HEAD_RADIUS: &str = "/omniphony/control/binaural/head_radius";
+pub const CONTROL_BINAURAL_HRIR_SOURCE: &str = "/omniphony/control/binaural/hrir_source";
+pub const CONTROL_BINAURAL_HRTF_UPLOAD_BEGIN: &str =
+    "/omniphony/control/binaural/hrtf_upload/begin";
+pub const CONTROL_BINAURAL_HRTF_UPLOAD_CHUNK: &str =
+    "/omniphony/control/binaural/hrtf_upload/chunk";
+pub const CONTROL_BINAURAL_HRTF_UPLOAD_END: &str = "/omniphony/control/binaural/hrtf_upload/end";
+pub const CONTROL_BINAURAL_MODE: &str = "/omniphony/control/binaural_mode";
+pub const CONTROL_BINAURAL_REFLECTIONS_ENABLED: &str =
+    "/omniphony/control/binaural/reflections/enabled";
+pub const CONTROL_BINAURAL_REFLECTIONS_LEVEL: &str =
+    "/omniphony/control/binaural/reflections/level";
+pub const CONTROL_BINAURAL_REFLECTIONS_ROOM_DEPTH: &str =
+    "/omniphony/control/binaural/reflections/room_depth";
+pub const CONTROL_BINAURAL_REFLECTIONS_ROOM_HEIGHT: &str =
+    "/omniphony/control/binaural/reflections/room_height";
+pub const CONTROL_BINAURAL_REFLECTIONS_ROOM_WIDTH: &str =
+    "/omniphony/control/binaural/reflections/room_width";
+pub const CONTROL_BINAURAL_REVERB_ENABLED: &str = "/omniphony/control/binaural/reverb/enabled";
+pub const CONTROL_BINAURAL_REVERB_LEVEL: &str = "/omniphony/control/binaural/reverb/level";
+pub const CONTROL_BINAURAL_REVERB_PREDELAY: &str = "/omniphony/control/binaural/reverb/predelay";
+pub const CONTROL_BINAURAL_REVERB_RT60: &str = "/omniphony/control/binaural/reverb/rt60";
+pub const CONTROL_BINAURAL_UNIT_SCALE: &str = "/omniphony/control/binaural/unit_scale";
 pub const CONTROL_CONFIG_AUDIO: &str = "/omniphony/control/config/audio";
 pub const CONTROL_CONFIG_AUDIO_APPLY: &str = "/omniphony/control/config/audio/apply";
 pub const CONTROL_CONFIG_INPUT: &str = "/omniphony/control/config/input";
@@ -100,6 +132,13 @@ pub const CONTROL_DIAG_RATE_HZ: &str = "/omniphony/control/diag/rate_hz";
 pub const CONTROL_DISTANCE_MODEL: &str = "/omniphony/control/distance_model";
 pub const CONTROL_DISTANCE_MODEL_METRIC: &str = "/omniphony/control/distance_model_metric";
 pub const CONTROL_GAIN: &str = "/omniphony/control/gain";
+pub const CONTROL_HEAD_ORIENTATION: &str = "/omniphony/control/head/orientation";
+pub const CONTROL_HEAD_QUAT: &str = "/omniphony/control/head/quat";
+pub const CONTROL_HEAD_RECENTER: &str = "/omniphony/control/head/recenter";
+pub const CONTROL_HEAD_TRACKING_ADDRESS: &str = "/omniphony/control/head/tracking/address";
+pub const CONTROL_HEAD_TRACKING_FORMAT: &str = "/omniphony/control/head/tracking/format";
+pub const CONTROL_HEAD_TRACKING_INVERT: &str = "/omniphony/control/head/tracking/invert";
+pub const CONTROL_HEAD_TRACKING_SMOOTHING: &str = "/omniphony/control/head/tracking/smoothing";
 pub const CONTROL_INPUT_APPLY: &str = "/omniphony/control/input/apply";
 pub const CONTROL_INPUT_DRC_MODE: &str = "/omniphony/control/input/drc_mode";
 pub const CONTROL_INPUT_DRC_WEIGHT: &str = "/omniphony/control/input/drc_weight";
@@ -116,18 +155,22 @@ pub const CONTROL_INPUT_LIVE_NODE: &str = "/omniphony/control/input/live/node";
 pub const CONTROL_INPUT_LIVE_SAMPLE_RATE: &str = "/omniphony/control/input/live/sample_rate";
 pub const CONTROL_INPUT_MODE: &str = "/omniphony/control/input/mode";
 pub const CONTROL_INPUT_REFRESH: &str = "/omniphony/control/input/refresh";
+pub const CONTROL_LATENCY_TARGET: &str = "/omniphony/control/latency_target";
 pub const CONTROL_LAYOUT_EXPORT: &str = "/omniphony/control/layout/export";
 pub const CONTROL_LAYOUT_RADIUS_M: &str = "/omniphony/control/layout/radius_m";
 pub const CONTROL_LOG_LEVEL: &str = "/omniphony/control/log_level";
 pub const CONTROL_LOUDNESS: &str = "/omniphony/control/loudness";
 pub const CONTROL_METERING: &str = "/omniphony/control/metering";
 pub const CONTROL_METERING_RATE_HZ: &str = "/omniphony/control/metering/rate_hz";
+pub const CONTROL_OUTPUT_MODE: &str = "/omniphony/control/output_mode";
 pub const CONTROL_OVERLAY_ENABLED: &str = "/omniphony/control/overlay/enabled";
 pub const CONTROL_OVERLAY_HEATMAP_BANDS: &str = "/omniphony/control/overlay/heatmap_bands";
 pub const CONTROL_OVERLAY_HEATMAP_COLORMAP: &str = "/omniphony/control/overlay/heatmap_colormap";
 pub const CONTROL_OVERLAY_HEATMAP_CUSTOM_STOPS: &str =
     "/omniphony/control/overlay/heatmap_custom_stops";
 pub const CONTROL_OVERLAY_HEATMAP_ENABLED: &str = "/omniphony/control/overlay/heatmap_enabled";
+pub const CONTROL_RENDER_EVALUATION_OBJECT_SIZE_INTERVALS: &str =
+    "/omniphony/control/render_evaluation/object_size_intervals";
 /// Enables/disables every renderer-synthesized-object stage without clearing
 /// the configured phantom/height selections.
 pub const CONTROL_SYNTHETIC_OBJECTS: &str = "/omniphony/control/synthetic_objects";
@@ -149,6 +192,7 @@ pub const CONTROL_SURROUND_PLACEMENT: &str = "/omniphony/control/surround_placem
 /// How output channels map to device ports: `by_index` (positionless — port N =
 /// layout speaker N) or `by_name` (positional). Persisted to config.
 pub const CONTROL_OUTPUT_CHANNEL_MAPPING: &str = "/omniphony/control/output_channel_mapping";
+pub const CONTROL_UNKNOWN: &str = "/omniphony/control/unknown";
 /// Set the parametrable virtual bed for channel content. Argument is a YAML
 /// `SpeakerLayout` (one entry per channel label, `spatialize` = virtual/direct);
 /// an empty string resets to the built-in canonical poses (LFE direct).
@@ -341,6 +385,7 @@ pub const STATE_DECODE_TIME_MS: &str = "/omniphony/state/decode_time_ms";
 pub const STATE_DIAG_SCHEMA: &str = "/omniphony/state/diag_schema";
 pub const STATE_DIAG_VALUES: &str = "/omniphony/state/diag_values";
 pub const STATE_FRAME_DURATION_MS: &str = "/omniphony/state/frame_duration_ms";
+pub const STATE_HEAD_POSE: &str = "/omniphony/state/head_pose";
 pub const STATE_INPUT: &str = "/omniphony/state/input";
 pub const STATE_INPUT_PIPE: &str = "/omniphony/state/input_pipe";
 pub const STATE_LATENCY: &str = "/omniphony/state/latency";
@@ -351,13 +396,17 @@ pub const STATE_LATENCY_INSTANT: &str = "/omniphony/state/latency_instant";
 pub const STATE_LATENCY_OUTPUT_FIFO: &str = "/omniphony/state/latency_output_fifo";
 pub const STATE_LATENCY_RESAMPLER_PENDING: &str = "/omniphony/state/latency_resampler_pending";
 pub const STATE_LATENCY_SMOOTHED: &str = "/omniphony/state/latency_smoothed";
+pub const STATE_LATENCY_TARGET: &str = "/omniphony/state/latency_target";
 pub const STATE_LAYOUT: &str = "/omniphony/state/layout";
 pub const STATE_LOG_LEVEL: &str = "/omniphony/state/log_level";
 pub const STATE_LOUDNESS: &str = "/omniphony/state/loudness";
 pub const STATE_MONITORING: &str = "/omniphony/state/monitoring";
+pub const STATE_OBJECT_GENERATORS: &str = "/omniphony/state/object_generators";
+pub const STATE_OBJECT_TEST_POSITION: &str = "/omniphony/state/object_test/position";
 /// Schema of the declared live options (`renderer::options` registry rows),
 /// as a JSON string. Same pattern as `/state/object_generators` / `/state/phantom`.
 pub const STATE_OPTIONS_SCHEMA: &str = "/omniphony/state/options_schema";
+pub const STATE_PHANTOM: &str = "/omniphony/state/phantom";
 /// Named config profiles view as JSON: `{"active": "...", "names": ["..."]}`.
 /// Broadcast in the state snapshot and after every profile mutation.
 pub const STATE_PROFILES: &str = "/omniphony/state/profiles";
@@ -379,6 +428,8 @@ pub const STATE_RENDER_EVALUATION_CARTESIAN_Z_NEG_SIZE: &str =
     "/omniphony/state/render_evaluation/cartesian/z_neg_size";
 pub const STATE_RENDER_EVALUATION_CARTESIAN_Z_SIZE: &str =
     "/omniphony/state/render_evaluation/cartesian/z_size";
+pub const STATE_RENDER_EVALUATION_OBJECT_SIZE_INTERVALS: &str =
+    "/omniphony/state/render_evaluation/object_size_intervals";
 pub const STATE_RENDER_EVALUATION_POLAR_AZIMUTH_RESOLUTION: &str =
     "/omniphony/state/render_evaluation/polar/azimuth_resolution";
 pub const STATE_RENDER_EVALUATION_POLAR_DISTANCE_MAX: &str =
@@ -400,6 +451,24 @@ pub const STATE_SPEAKERS_RECOMPUTE_ERROR: &str = "/omniphony/state/speakers/reco
 pub const STATE_SPEAKERS_RECOMPUTING: &str = "/omniphony/state/speakers/recomputing";
 pub const STATE_VBAP_ALLOW_NEGATIVE_Z: &str = "/omniphony/state/vbap/allow_negative_z";
 pub const STATE_WRITE_TIME_MS: &str = "/omniphony/state/write_time_ms";
+
+// ── Session handshake and high-rate streams ─────────────────────────────────
+//
+// Everything under `/omniphony/` that is neither a control nor a state address:
+// the client/engine handshake, the log relay, and the per-frame streams whose
+// rate makes them their own family (objects, meters, timestamps).
+
+pub const BED_CONFIG: &str = "/omniphony/bed/config";
+pub const HEARTBEAT: &str = "/omniphony/heartbeat";
+pub const HEARTBEAT_ACK: &str = "/omniphony/heartbeat/ack";
+pub const HEARTBEAT_UNKNOWN: &str = "/omniphony/heartbeat/unknown";
+pub const LOG: &str = "/omniphony/log";
+pub const METER_DRC_GAIN: &str = "/omniphony/meter/drc_gain";
+pub const METER_MASTER: &str = "/omniphony/meter/master";
+pub const REGISTER: &str = "/omniphony/register";
+pub const SPATIAL_FRAME: &str = "/omniphony/spatial/frame";
+pub const TIMESTAMP: &str = "/omniphony/timestamp";
+pub const YIELD_RESUME_PORT: &str = "/omniphony/yield/resume_port";
 
 // ── Address catalogues (handy for clients / tests) ──────────────────────────
 
@@ -522,6 +591,36 @@ pub const ALL_CONTROL: &[&str] = &[
     CONTROL_SPREAD_MIN,
     CONTROL_SPREAD_SIZE_TO_SPREAD_MODE,
     CONTROL_YIELD_PORT,
+    CONTROL_BINAURAL_AIR_ABSORPTION,
+    CONTROL_BINAURAL_EAR_GAIN,
+    CONTROL_BINAURAL_EAR_MUTE,
+    CONTROL_BINAURAL_HEAD_RADIUS,
+    CONTROL_BINAURAL_HRIR_SOURCE,
+    CONTROL_BINAURAL_HRTF_UPLOAD_BEGIN,
+    CONTROL_BINAURAL_HRTF_UPLOAD_CHUNK,
+    CONTROL_BINAURAL_HRTF_UPLOAD_END,
+    CONTROL_BINAURAL_MODE,
+    CONTROL_BINAURAL_REFLECTIONS_ENABLED,
+    CONTROL_BINAURAL_REFLECTIONS_LEVEL,
+    CONTROL_BINAURAL_REFLECTIONS_ROOM_DEPTH,
+    CONTROL_BINAURAL_REFLECTIONS_ROOM_HEIGHT,
+    CONTROL_BINAURAL_REFLECTIONS_ROOM_WIDTH,
+    CONTROL_BINAURAL_REVERB_ENABLED,
+    CONTROL_BINAURAL_REVERB_LEVEL,
+    CONTROL_BINAURAL_REVERB_PREDELAY,
+    CONTROL_BINAURAL_REVERB_RT60,
+    CONTROL_BINAURAL_UNIT_SCALE,
+    CONTROL_HEAD_ORIENTATION,
+    CONTROL_HEAD_QUAT,
+    CONTROL_HEAD_RECENTER,
+    CONTROL_HEAD_TRACKING_ADDRESS,
+    CONTROL_HEAD_TRACKING_FORMAT,
+    CONTROL_HEAD_TRACKING_INVERT,
+    CONTROL_HEAD_TRACKING_SMOOTHING,
+    CONTROL_LATENCY_TARGET,
+    CONTROL_OUTPUT_MODE,
+    CONTROL_RENDER_EVALUATION_OBJECT_SIZE_INTERVALS,
+    CONTROL_UNKNOWN,
 ];
 
 pub const ALL_STATE: &[&str] = &[
@@ -592,6 +691,32 @@ pub const ALL_STATE: &[&str] = &[
     STATE_SPEAKERS_RECOMPUTING,
     STATE_VBAP_ALLOW_NEGATIVE_Z,
     STATE_WRITE_TIME_MS,
+    STATE_HEAD_POSE,
+    STATE_LATENCY_TARGET,
+    STATE_OBJECT_GENERATORS,
+    STATE_OBJECT_TEST_POSITION,
+    STATE_PHANTOM,
+    STATE_RENDER_EVALUATION_OBJECT_SIZE_INTERVALS,
+];
+
+/// Session handshake and high-rate stream addresses: everything under
+/// `/omniphony/` that is neither `control/` nor `state/`.
+///
+/// Catalogued for the same reason as the other two — so the guard tests below
+/// see the whole wire surface, not just the part that happens to be named after
+/// a direction.
+pub const ALL_SESSION: &[&str] = &[
+    BED_CONFIG,
+    HEARTBEAT,
+    HEARTBEAT_ACK,
+    HEARTBEAT_UNKNOWN,
+    LOG,
+    METER_DRC_GAIN,
+    METER_MASTER,
+    REGISTER,
+    SPATIAL_FRAME,
+    TIMESTAMP,
+    YIELD_RESUME_PORT,
 ];
 
 #[cfg(test)]
@@ -620,13 +745,90 @@ mod tests {
     }
 
     #[test]
+    fn session_consts_are_neither_control_nor_state() {
+        for &a in ALL_SESSION {
+            assert!(
+                a.starts_with("/omniphony/"),
+                "not an omniphony address: {a}"
+            );
+            assert!(
+                !a.starts_with("/omniphony/control/") && !a.starts_with("/omniphony/state/"),
+                "belongs in ALL_CONTROL or ALL_STATE, not here: {a}"
+            );
+        }
+    }
+
+    #[test]
     fn no_duplicate_addresses() {
         // A duplicated value would mean two names collide on one wire address,
         // or a typo merged two addresses — both are contract bugs.
         let mut seen = HashSet::new();
-        for &a in ALL_CONTROL.iter().chain(ALL_STATE) {
+        for &a in ALL_CONTROL.iter().chain(ALL_STATE).chain(ALL_SESSION) {
             assert!(seen.insert(a), "duplicate OSC address in contract: {a}");
         }
+    }
+
+    /// The OSC-facing sources must name addresses, not spell them.
+    ///
+    /// This module claims to be the single source of truth, but nothing used to
+    /// enforce it: a bare literal compiles just as well as a constant, and a
+    /// typo in one produces an address that silently never matches — no error,
+    /// no log, just a control that does nothing. So the claim is checked.
+    ///
+    /// Two forms are still spelled out, because they are not addresses: family
+    /// prefixes matched with `starts_with`, and `format!` templates with a
+    /// dynamic tail (`/omniphony/meter/object/{}`). Both would need a different
+    /// shape in the contract than a `&str` constant; until they get one, they
+    /// are listed here rather than silently tolerated.
+    #[test]
+    fn osc_sources_reference_the_contract_instead_of_spelling_addresses() {
+        use std::path::Path;
+
+        // Relative to this crate's root, so the guard follows the files.
+        const SOURCES: &[&str] = &[
+            "src/osc.rs",
+            "src/command.rs",
+            "../host_audio/src/lib.rs",
+            "../orender_engine/src/osc.rs",
+            "../orender_engine/src/osc/dispatch.rs",
+            "../orender_engine/src/osc/transport.rs",
+            "../orender_engine/src/osc/export.rs",
+            "../orender_engine/src/osc/recompute.rs",
+            "../orender_engine/src/osc/state_emit.rs",
+            "../orender_engine/src/osc/metadata_emit.rs",
+            "../orender_engine/src/osc/profiles.rs",
+        ];
+
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut offenders = Vec::new();
+        for rel in SOURCES {
+            let path = root.join(rel);
+            let src = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("guard is stale: cannot read {}: {e}", path.display()));
+            for (n, line) in src.lines().enumerate() {
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                let mut rest = line;
+                while let Some(i) = rest.find("\"/omniphony/") {
+                    let after = &rest[i + 1..];
+                    let Some(end) = after.find('"') else { break };
+                    let addr = &after[..end];
+                    // A prefix is matched with `starts_with`; a template is
+                    // filled in by `format!`. Neither is a whole address.
+                    if !addr.ends_with('/') && !addr.contains('{') {
+                        offenders.push(format!("{}:{}: {addr}", rel, n + 1));
+                    }
+                    rest = &after[end..];
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "OSC addresses spelled out instead of referencing this module \
+             (add a constant here and use it):\n  {}",
+            offenders.join("\n  ")
+        );
     }
 
     #[test]


### PR DESCRIPTION
`osc_contract` opens by calling itself the single source of truth for the wire addresses. It wasn't one.

- **178 addresses** were still spelled out as literals across the dispatcher's fallback layer (`runtime_control/osc.rs`: 70), the host-audio handler (45), and the state producers (~50).
- **47 had no constant at all** — including the *entire* binaural and head-tracking control families, the register/heartbeat handshake, and the object/meter/timestamp streams. The catalogues and their duplicate guard could only see the part that had been declared.

## Why it's worth doing

The failure mode is invisible. A mistyped literal **compiles**. It matches nothing. The control it belongs to stops working and nothing says so — no error, no log, just a dead address. Two places writing the same address, one as a constant and one by hand, is the same hazard with an extra step.

## What changed

- 47 new constants: 30 `CONTROL_*`, 6 `STATE_*`, and 11 that are neither — the handshake, the log relay and the per-frame streams. Those get their own catalogue (`ALL_SESSION`) and a guard asserting they're under `/omniphony/` but *not* control or state, so they can't silently drift into the wrong family.
- All 178 sites migrated to reference them.

## Verified, not trusted

The migration was mechanical, so the check is too. Resolving every source file's addresses — literals **plus constants expanded to their values** — gives byte-identical multisets before and after:

```
>>> address sets IDENTICAL across 11 files (274 occurrences)
```

No address changed value. (My first run reported a diff on `/omniphony/log`; that turned out to be my checker's regex requiring 4+ characters and the constant being named `LOG`. Worth mentioning because it's the kind of thing that could equally have hidden a real diff.)

## The claim is now a test

`osc_sources_reference_the_contract_instead_of_spelling_addresses` walks the OSC-facing sources and fails on any spelled-out address, naming file and line:

```
OSC addresses spelled out instead of referencing this module (add a constant here and use it):
  ../orender_engine/src/osc/export.rs:40: /omniphony/state/phantom
```

I confirmed it fails that way by reintroducing one literal, rather than assuming a green test means a working guard.

**Two forms stay literal**, deliberately: family prefixes matched with `starts_with` (5), and `format!` templates with a dynamic tail like `/omniphony/meter/object/{}` (10). Neither is a whole address, and both need a different shape in the contract than a `&str` constant — a prefix constant or a small builder fn. Until they get one they're listed in the test rather than silently tolerated. That's the obvious follow-up.

## Risk

603 workspace tests pass, fmt clean. No behavioural change: this is a rename of string constants, proven equivalent by the address-set check. One macro took `$path:literal` and now takes `$path:expr`, which is what let it accept a constant.

Not verified by ear, and it doesn't need to be — but a Studio click-through would confirm the binaural and head-tracking panels still drive the engine, since those families are the ones that had no constants before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)