### PR TITLE
One answer to "what counts as a number" in the OSC layer

### DIFF
--- a/omniphony-renderer/host_audio/src/lib.rs
+++ b/omniphony-renderer/host_audio/src/lib.rs
@@ -625,11 +625,7 @@ impl HostControlHandler for HostAudio {
         }
 
         if addr == osc_contract::CONTROL_INPUT_LIVE_CHANNELS {
-            let requested = match msg.args.first() {
-                Some(OscType::Int(i)) if *i > 0 => Some(*i as u16),
-                Some(OscType::Float(f)) if *f > 0.0 => Some(*f as u16),
-                _ => None,
-            };
+            let requested = parse_positive_u32_arg(msg.args.first()).map(|v| v as u16);
             if let Some(requested) = requested {
                 input.set_requested_channels(Some(requested));
                 effects.mark_dirty = true;
@@ -714,11 +710,7 @@ impl HostControlHandler for HostAudio {
         }
 
         if addr == osc_contract::CONTROL_AUDIO_SAMPLE_RATE {
-            let requested_hz = match msg.args.first() {
-                Some(OscType::Int(i)) if *i > 0 => Some(*i as u32),
-                Some(OscType::Float(f)) if *f > 0.0 => Some(*f as u32),
-                _ => None,
-            };
+            let requested_hz = parse_positive_u32_arg(msg.args.first());
             audio.set_requested_output_sample_rate(requested_hz);
             effects.mark_dirty = true;
             return Some(effects);

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -910,16 +910,13 @@ impl Drop for OscSender {
     }
 }
 
-/// Numeric OSC args → `f32`, accepting the common scalar types a sensor app may
-/// emit (float, double, int).
+/// Numeric OSC args → `f32`, dropping anything that is not a number.
+///
+/// Sensor apps pick their own tag for the same reading, so this goes through
+/// the shared parser rather than deciding again which tags count.
 fn collect_f32(args: &[rosc::OscType]) -> Vec<f32> {
     args.iter()
-        .filter_map(|a| match a {
-            rosc::OscType::Float(f) => Some(*f),
-            rosc::OscType::Double(d) => Some(*d as f32),
-            rosc::OscType::Int(i) => Some(*i as f32),
-            _ => None,
-        })
+        .filter_map(|a| runtime_control::osc::parse_f32_arg(Some(a)))
         .collect()
 }
 

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -14,6 +14,9 @@ use runtime_control::osc::{
     BroadcastUpdate, BroadcastValue, ControlEffects, apply_simple_osc_control,
     gaintable_chunk_broadcasts,
 };
+use runtime_control::osc::{
+    parse_bool_arg, parse_f32_arg, parse_nonnegative_u32_arg, parse_positive_u32_arg,
+};
 use runtime_control::osc_contract;
 
 use super::client_registry::OscClientRegistry;
@@ -48,7 +51,7 @@ pub(crate) fn handle_control_message(
     // CLI and embedded engine read them, they persist to config, and they are
     // broadcast in the live-state bundle. Changing them marks the config dirty.
     if addr == osc_contract::CONTROL_METERING_RATE_HZ {
-        if let Some(hz) = first_rate_hz_arg(msg) {
+        if let Some(hz) = parse_f32_arg(msg.args.first()) {
             control.set_meter_rate_hz(hz);
             control.mark_dirty();
             broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
@@ -57,7 +60,7 @@ pub(crate) fn handle_control_message(
         return;
     }
     if addr == osc_contract::CONTROL_DIAG_RATE_HZ {
-        if let Some(hz) = first_rate_hz_arg(msg) {
+        if let Some(hz) = parse_f32_arg(msg.args.first()) {
             control.set_diag_rate_hz(hz);
             control.mark_dirty();
             broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
@@ -100,11 +103,9 @@ pub(crate) fn handle_control_message(
             Some(OscType::String(s)) => s.trim().to_ascii_lowercase(),
             _ => return,
         };
-        let value = match msg.args.get(1) {
-            Some(OscType::Float(f)) => *f,
-            Some(OscType::Double(d)) => *d as f32,
-            Some(OscType::Int(i)) => *i as f32,
-            _ => return,
+        let value = match parse_f32_arg(msg.args.get(1)) {
+            Some(v) => v,
+            None => return,
         };
         if key.is_empty() || !value.is_finite() {
             return;
@@ -131,11 +132,9 @@ pub(crate) fn handle_control_message(
             Some(OscType::String(s)) => s.trim().to_ascii_lowercase(),
             _ => return,
         };
-        let value = match msg.args.get(1) {
-            Some(OscType::Float(f)) => *f,
-            Some(OscType::Double(d)) => *d as f32,
-            Some(OscType::Int(i)) => *i as f32,
-            _ => return,
+        let value = match parse_f32_arg(msg.args.get(1)) {
+            Some(v) => v,
+            None => return,
         };
         if key.is_empty() || !value.is_finite() {
             return;
@@ -181,41 +180,33 @@ pub(crate) fn handle_control_message(
     // (it no longer transports overlay frames). These are transient view
     // preferences — not persisted, so no `mark_dirty`.
     if addr == osc_contract::CONTROL_OVERLAY_ENABLED {
-        let enabled = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            Some(OscType::Bool(b)) => *b,
-            _ => return,
+        let enabled = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
         crate::overlay::set_enabled(enabled);
         return;
     }
     if addr == osc_contract::CONTROL_OVERLAY_LABELS {
-        let enabled = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            Some(OscType::Bool(b)) => *b,
-            _ => return,
+        let enabled = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
         crate::overlay::set_labels_enabled(enabled);
         return;
     }
     if addr == osc_contract::CONTROL_OVERLAY_OBJECTS {
-        let visible = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            Some(OscType::Bool(b)) => *b,
-            _ => return,
+        let visible = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
         crate::overlay::set_objects_visible(visible);
         return;
     }
     if addr == osc_contract::CONTROL_OVERLAY_HEATMAP_ENABLED {
-        let enabled = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            Some(OscType::Bool(b)) => *b,
-            _ => return,
+        let enabled = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
         crate::overlay::set_heatmap_enabled(enabled);
         return;
@@ -239,45 +230,33 @@ pub(crate) fn handle_control_message(
         return;
     }
     if addr == osc_contract::CONTROL_OVERLAY_HEATMAP_BANDS {
-        let count = match msg.args.first() {
-            Some(OscType::Int(i)) if *i > 0 => *i as usize,
-            Some(OscType::Float(f)) if *f > 0.0 => *f as usize,
-            _ => return,
+        let count = match parse_positive_u32_arg(msg.args.first()) {
+            Some(v) => v as usize,
+            None => return,
         };
         crate::overlay::set_heatmap_bands(count);
         return;
     }
     if addr == osc_contract::CONTROL_OVERLAY_HEATMAP_COLORMAP {
-        let idx = match msg.args.first() {
-            Some(OscType::Int(i)) if *i >= 0 => *i as usize,
-            Some(OscType::Float(f)) if *f >= 0.0 => *f as usize,
-            _ => return,
+        let idx = match parse_nonnegative_u32_arg(msg.args.first()) {
+            Some(v) => v as usize,
+            None => return,
         };
         crate::overlay::set_heatmap_colormap(idx);
         return;
     }
     if addr == osc_contract::CONTROL_OVERLAY_TRAILS {
         // Args mirror Studio's former wire fields: enabled, ttl_ms, mode, teleport.
-        let enabled = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            Some(OscType::Bool(b)) => *b,
-            _ => return,
+        let enabled = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
-        let ttl_ms = match msg.args.get(1) {
-            Some(OscType::Int(i)) if *i >= 0 => *i as u32,
-            Some(OscType::Float(f)) if *f >= 0.0 => *f as u32,
-            _ => 7000,
-        };
+        let ttl_ms = parse_nonnegative_u32_arg(msg.args.get(1)).unwrap_or(7000);
         let diffuse = matches!(
             msg.args.get(2),
             Some(OscType::String(s)) if s.eq_ignore_ascii_case("diffuse")
         );
-        let teleport = match msg.args.get(3) {
-            Some(OscType::Float(f)) => *f as f64,
-            Some(OscType::Int(i)) => *i as f64,
-            _ => 0.0,
-        };
+        let teleport = parse_f32_arg(msg.args.get(3)).unwrap_or(0.0) as f64;
         crate::overlay::set_trail_config(enabled, ttl_ms, diffuse, teleport);
         return;
     }
@@ -309,10 +288,7 @@ pub(crate) fn handle_control_message(
     // every topology rebuild while subscribed (see `recompute.rs`). Args:
     // [Int have_version, Int speaker_index].
     if addr == osc_contract::CONTROL_DEBUG_SPEAKER_GAINTABLE_SUBSCRIBE {
-        let have_version = match msg.args.first() {
-            Some(OscType::Int(i)) if *i >= 0 => Some(*i as u32),
-            _ => None,
-        };
+        let have_version = parse_nonnegative_u32_arg(msg.args.first());
         // A negative index selects an all-speaker derived field, not an error:
         // the global heatmaps subscribe through the same path as a per-speaker
         // one. Known sentinels pass through; an unknown negative falls back to
@@ -388,10 +364,9 @@ pub(crate) fn handle_control_message(
     }
 
     if addr == osc_contract::CONTROL_METERING {
-        let enabled = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            _ => return,
+        let enabled = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
         let client = resolve_register_addr(src, &[]);
         if clients.set_metering(client, enabled) {
@@ -401,11 +376,9 @@ pub(crate) fn handle_control_message(
     }
 
     if addr == osc_contract::CONTROL_DIAG_ENABLED {
-        let enabled = match msg.args.first() {
-            Some(OscType::Int(i)) => *i != 0,
-            Some(OscType::Float(f)) => *f != 0.0,
-            Some(OscType::Bool(b)) => *b,
-            _ => return,
+        let enabled = match parse_bool_arg(msg.args.first()) {
+            Some(v) => v,
+            None => return,
         };
         let client = resolve_register_addr(src, &[]);
         if clients.set_diag(client, enabled) {
@@ -670,14 +643,6 @@ pub(crate) fn handle_control_message(
     }
 }
 
-fn first_rate_hz_arg(msg: &OscMessage) -> Option<f32> {
-    msg.args.first().and_then(|arg| match arg {
-        OscType::Float(v) => Some(*v),
-        OscType::Int(v) => Some(*v as f32),
-        _ => None,
-    })
-}
-
 fn set_dirty(control: &Arc<RendererControl>, socket: &UdpSocket, clients: &OscClientRegistry) {
     control.mark_dirty();
     broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
@@ -690,6 +655,7 @@ fn raw_option_value(arg: Option<&OscType>) -> Option<renderer::options::RawOptio
     match arg? {
         OscType::String(s) => Some(RawOptionValue::Str(s)),
         OscType::Int(i) => Some(RawOptionValue::Number(*i as f64)),
+        OscType::Long(l) => Some(RawOptionValue::Number(*l as f64)),
         OscType::Float(f) => Some(RawOptionValue::Number(*f as f64)),
         OscType::Double(d) => Some(RawOptionValue::Number(*d)),
         OscType::Bool(b) => Some(RawOptionValue::Bool(*b)),

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -234,52 +234,54 @@ pub fn gaintable_chunk_broadcasts(
     out
 }
 
-pub fn parse_bool_arg(arg: Option<&OscType>) -> Option<bool> {
+/// Any OSC numeric argument, as `f64`.
+///
+/// OSC has four numeric tags — `i`, `h`, `f`, `d` — and the *sender* picks one,
+/// not the receiver: Studio's sliders send `f`, a scripted client sends `i` for
+/// the same control, and most Python bindings turn `1.0` into `d`. Which tag
+/// arrived says nothing about what was meant, so the parsers below read the
+/// value and treat the tag as a transport detail.
+///
+/// This is the one place that decides what counts as a number. Handlers used to
+/// answer that question inline and disagreed with each other, so whether a
+/// control accepted your message depended on which address you sent it to — and
+/// a rejected message was dropped in silence, with no error and no log.
+fn numeric(arg: &OscType) -> Option<f64> {
     match arg {
-        Some(OscType::Int(i)) => Some(*i != 0),
-        Some(OscType::Float(f)) => Some(*f != 0.0),
+        OscType::Int(i) => Some(*i as f64),
+        OscType::Long(l) => Some(*l as f64),
+        OscType::Float(f) => Some(*f as f64),
+        OscType::Double(d) => Some(*d),
         _ => None,
+    }
+}
+
+/// A boolean argument: the `T`/`F` tags, or any number read as zero/non-zero.
+pub fn parse_bool_arg(arg: Option<&OscType>) -> Option<bool> {
+    match arg? {
+        OscType::Bool(b) => Some(*b),
+        other => numeric(other).map(|v| v != 0.0),
     }
 }
 
 pub fn parse_positive_u32_arg(arg: Option<&OscType>) -> Option<u32> {
-    match arg {
-        Some(OscType::Int(i)) if *i > 0 => Some(*i as u32),
-        Some(OscType::Float(f)) if *f > 0.0 => Some(*f as u32),
-        _ => None,
-    }
+    numeric(arg?).filter(|v| *v > 0.0).map(|v| v as u32)
 }
 
 pub fn parse_nonnegative_u32_arg(arg: Option<&OscType>) -> Option<u32> {
-    match arg {
-        Some(OscType::Int(i)) if *i >= 0 => Some(*i as u32),
-        Some(OscType::Float(f)) if *f >= 0.0 => Some(*f as u32),
-        _ => None,
-    }
+    numeric(arg?).filter(|v| *v >= 0.0).map(|v| v as u32)
 }
 
 pub fn parse_positive_f32_arg(arg: Option<&OscType>) -> Option<f32> {
-    match arg {
-        Some(OscType::Float(f)) if *f > 0.0 => Some(*f),
-        Some(OscType::Int(i)) if *i > 0 => Some(*i as f32),
-        _ => None,
-    }
+    numeric(arg?).filter(|v| *v > 0.0).map(|v| v as f32)
 }
 
 pub fn parse_nonnegative_f32_arg(arg: Option<&OscType>) -> Option<f32> {
-    match arg {
-        Some(OscType::Float(f)) if *f >= 0.0 => Some(*f),
-        Some(OscType::Int(i)) if *i >= 0 => Some(*i as f32),
-        _ => None,
-    }
+    numeric(arg?).filter(|v| *v >= 0.0).map(|v| v as f32)
 }
 
 pub fn parse_f32_arg(arg: Option<&OscType>) -> Option<f32> {
-    match arg {
-        Some(OscType::Float(f)) => Some(*f),
-        Some(OscType::Int(i)) => Some(*i as f32),
-        _ => None,
-    }
+    numeric(arg?).map(|v| v as f32)
 }
 
 pub fn parse_string_arg(arg: Option<&OscType>) -> Option<String> {
@@ -2103,5 +2105,96 @@ mod freq_cutoff_clear_tests {
             &speaker_patch(r#"{"id":0,"spatialize":true}"#),
         );
         assert_eq!(speaker.freq_low, Some(120.0));
+    }
+
+    /// Every OSC numeric tag must reach the same value.
+    ///
+    /// The sender picks the tag: Studio sends `f`, a scripted client sends `i`,
+    /// most Python bindings turn `1.0` into `d`. Before these parsers agreed,
+    /// which of those a control accepted depended on the address you sent it
+    /// to, and the ones it did not accept were dropped without a word.
+    #[test]
+    fn every_numeric_tag_parses_to_the_same_value() {
+        let tags = [
+            OscType::Int(3),
+            OscType::Long(3),
+            OscType::Float(3.0),
+            OscType::Double(3.0),
+        ];
+        for tag in &tags {
+            assert_eq!(parse_f32_arg(Some(tag)), Some(3.0), "{tag:?}");
+            assert_eq!(parse_positive_f32_arg(Some(tag)), Some(3.0), "{tag:?}");
+            assert_eq!(parse_nonnegative_f32_arg(Some(tag)), Some(3.0), "{tag:?}");
+            assert_eq!(parse_positive_u32_arg(Some(tag)), Some(3), "{tag:?}");
+            assert_eq!(parse_nonnegative_u32_arg(Some(tag)), Some(3), "{tag:?}");
+            assert_eq!(parse_bool_arg(Some(tag)), Some(true), "{tag:?}");
+        }
+    }
+
+    /// A `T`/`F` argument is the natural way to send a toggle, and it used to
+    /// work on some addresses and be silently ignored on others.
+    #[test]
+    fn bool_tags_and_numbers_both_read_as_booleans() {
+        assert_eq!(parse_bool_arg(Some(&OscType::Bool(true))), Some(true));
+        assert_eq!(parse_bool_arg(Some(&OscType::Bool(false))), Some(false));
+        for zero in [
+            OscType::Int(0),
+            OscType::Long(0),
+            OscType::Float(0.0),
+            OscType::Double(0.0),
+        ] {
+            assert_eq!(parse_bool_arg(Some(&zero)), Some(false), "{zero:?}");
+        }
+        assert_eq!(parse_bool_arg(Some(&OscType::Float(-1.0))), Some(true));
+    }
+
+    /// Widening must not have swallowed the sign filters.
+    #[test]
+    fn sign_filters_still_reject_out_of_range_values() {
+        for negative in [OscType::Int(-1), OscType::Double(-0.5)] {
+            assert_eq!(
+                parse_positive_u32_arg(Some(&negative)),
+                None,
+                "{negative:?}"
+            );
+            assert_eq!(
+                parse_positive_f32_arg(Some(&negative)),
+                None,
+                "{negative:?}"
+            );
+            assert_eq!(
+                parse_nonnegative_u32_arg(Some(&negative)),
+                None,
+                "{negative:?}"
+            );
+        }
+        assert_eq!(parse_positive_u32_arg(Some(&OscType::Int(0))), None);
+        assert_eq!(parse_nonnegative_u32_arg(Some(&OscType::Int(0))), Some(0));
+        // NaN is not a value any of these should accept.
+        assert_eq!(
+            parse_positive_f32_arg(Some(&OscType::Float(f32::NAN))),
+            None
+        );
+        assert_eq!(
+            parse_nonnegative_f32_arg(Some(&OscType::Float(f32::NAN))),
+            None
+        );
+    }
+
+    /// Widening the numeric tags must not turn non-numbers into numbers.
+    #[test]
+    fn non_numeric_arguments_are_still_rejected() {
+        for junk in [
+            OscType::String("7".to_string()),
+            OscType::Blob(vec![1, 2, 3]),
+            OscType::Nil,
+            OscType::Char('7'),
+        ] {
+            assert_eq!(parse_f32_arg(Some(&junk)), None, "{junk:?}");
+            assert_eq!(parse_bool_arg(Some(&junk)), None, "{junk:?}");
+            assert_eq!(parse_positive_u32_arg(Some(&junk)), None, "{junk:?}");
+        }
+        assert_eq!(parse_f32_arg(None), None);
+        assert_eq!(parse_bool_arg(None), None);
     }
 }


### PR DESCRIPTION
OSC has four numeric tags — `i`, `h`, `f`, `d` — and **the sender picks one, not the receiver**. Studio's sliders send `f`; a scripted client sends `i` for the same control; most Python bindings turn `1.0` into `d`. Which tag arrived says nothing about what was meant.

Handlers answered that question inline, and disagreed with each other. So whether a control accepted your message depended on the address you sent it to:

| you send | works on | silently ignored on |
|---|---|---|
| `T`/`F` toggle | `/control/overlay/enabled`, `/control/diag/enabled` | `/control/auto_gain`, `/control/loudness`, `/control/metering` |
| `d` (double) | `/control/option`, `/control/backend/param` | `/control/gain` |
| `i` (integer) | most things | `/control/speaker_test` level, object-test axes — replaced by the default |

**Ignored means silently.** No error, no log, no reply — the control simply does nothing, and the client has no way to tell.

## The fix

One private `numeric()` decides what counts as a number, accepting all four tags; the sign filters and the boolean reading layer on top. Every handler goes through the shared parsers. `parse_bool_arg` also takes the `T`/`F` tags — the natural way to send a toggle, and the one shape it rejected.

**Strictly widening.** Nothing that parsed before stops parsing. The sign filters and non-numeric rejection are unchanged: NaN still fails both filters, and a numeric *string* is still not a number.

The dispatcher used **none** of the shared helpers before this and now uses them throughout:

- 16 inline coercions replaced
- `first_rate_hz_arg` deleted — a character-for-character copy of `parse_f32_arg`
- `collect_f32` in the head-tracking path routed through the same place

`raw_option_value` stays a `match`, deliberately: it maps onto a *typed* value that the options registry validates per kind, so it has to keep String/Number/Bool apart rather than coerce them. It only gains the missing `h` arm.

## Tests

Four tests covering the widening **and its limits**: every numeric tag reaching the same value, `T`/`F` and numbers both reading as booleans, sign filters and NaN still rejected, non-numbers still refused.

I checked they catch the actual bug rather than just passing — against the old `parse_bool_arg` they fail on `Bool(true)` and `Long(3)`:

```
assertion `left == right` failed: Long(3)
  left: None
 right: Some(true)
```

## Risk

610 workspace tests pass, fmt clean.

Behaviour changes only in the widening direction, so the realistic failure mode isn't a broken control — it's a control that now responds to a message it used to drop. Worth knowing if any client relies on sending a `d` to an address expecting it to be ignored; I found no such caller in-tree, and it would be a strange thing to rely on.

Not verified by ear. A Studio click-through would confirm nothing regressed on the addresses that already worked; the interesting part — the tags that used to be dropped — needs a scripted OSC client to exercise, which is exactly the audience this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
