### PR TITLE
Give the pacer FIFO one consumer, and the ring one producer

### DIFF
--- a/omniphony-renderer/audio_input/src/pipewire.rs
+++ b/omniphony-renderer/audio_input/src/pipewire.rs
@@ -898,7 +898,7 @@ where
             // until pacer_fifo is primed.
             if user_data.channels > 0 && user_data.rate_hz > 0 {
                 if let Some(pacer) = input_control_for_process.output_pacer() {
-                    if pacer.enabled.load(Ordering::Relaxed) {
+                    if pacer.enabled {
                         let in_subframes = byte_len as u64
                             / (user_data.channels as u64 * user_data.bytes_per_sample as u64);
                         let drain_samples = (in_subframes

--- a/omniphony-renderer/audio_output/src/adaptive_runtime.rs
+++ b/omniphony-renderer/audio_output/src/adaptive_runtime.rs
@@ -745,6 +745,122 @@ pub fn compute_hard_recover_high_plan(
     }
 }
 
+/// Loop-invariant context for [`far_mode_step`].
+pub struct FarModeStepCtx<'a> {
+    pub adaptive_config: &'a crate::AdaptiveResamplingConfig,
+    pub channel_count: usize,
+    pub input_sample_rate: u32,
+    pub output_sample_rate: u32,
+    /// Published runtime-state code, for the diag plot.
+    pub runtime_state_code: &'a std::sync::atomic::AtomicU8,
+    pub latency: LatencyMetricTargets<'a>,
+}
+
+/// The per-callback figures the far-mode step works from.
+pub struct FarModeStepInputs {
+    pub is_far_band: bool,
+    pub control_available: usize,
+    pub smoothed_control_available: usize,
+    pub target_buffer_fill: usize,
+    pub callback_input_domain_samples: usize,
+    /// The ratio this path works in: the resampler's effective ratio, or `1.0`
+    /// when samples are copied straight through.
+    pub resample_ratio: f64,
+    /// The pacer's fixed contribution, folded into the *displayed* latency only.
+    pub pacer_buffer_samples: usize,
+    pub graph_latency_ms: f32,
+}
+
+/// Run the far-mode state machine for one callback, publish the runtime-state
+/// code, and store the latency the metrics display.
+///
+/// The resampler path and the direct-copy path differ only in the ratio they
+/// work in, but each used to carry its own copy of this, and the copies had
+/// drifted apart:
+///
+/// * the resampler copy recovered the low-recover trim by converting the
+///   decision's *output* figure back through the ratio. That round trip —
+///   `align(round(input × ratio))` on the way out, `round(output / ratio)` on
+///   the way back — does not return the input figure the state machine actually
+///   decided once the ratio is far enough from 1. Both now read
+///   `low_recover_trim_input_samples`, which is the authoritative one: the
+///   output figure is derived from it, not the reverse.
+/// * the displayed-latency store had been kept identical by hand.
+///
+/// It only skewed the *displayed* latency, never what was consumed — but it is
+/// exactly the shape of bug that gets fixed on one path and left on the other.
+pub fn far_mode_step(
+    state: &mut AdaptiveRuntimeState,
+    ctx: &FarModeStepCtx<'_>,
+    inputs: FarModeStepInputs,
+) -> FarModeDecision {
+    let decision = update_far_mode_state(
+        state,
+        ctx.adaptive_config,
+        inputs.is_far_band,
+        inputs.control_available,
+        inputs.smoothed_control_available,
+        inputs.target_buffer_fill,
+        inputs.callback_input_domain_samples,
+        inputs.resample_ratio,
+        ctx.channel_count,
+        ctx.input_sample_rate,
+        ctx.output_sample_rate,
+    );
+    ctx.runtime_state_code.store(
+        crate::adaptive_runtime_state_code(adaptive_runtime_state_name(
+            state.low_recover_phase,
+            decision.hard_recover_high,
+        )),
+        Ordering::Relaxed,
+    );
+
+    // What the buffer level will be once this callback's action has been
+    // applied — the servo reasons about the outcome, not the reading.
+    let mut projected = inputs.control_available;
+    if decision.recovery_reacquire_pending && decision.mute_far_output {
+        projected = projected.saturating_sub(inputs.callback_input_domain_samples);
+    } else if decision.hard_recover_high {
+        let plan = compute_hard_recover_high_plan(
+            inputs.callback_input_domain_samples,
+            inputs.control_available,
+            inputs.target_buffer_fill,
+            inputs.resample_ratio,
+            ctx.channel_count,
+        );
+        projected = projected.saturating_sub(plan.desired_consume_input_samples);
+    } else if decision.hold_low_recover {
+        let muted_consume_input_samples =
+            if decision.mute_far_output && decision.consume_while_muted {
+                inputs.callback_input_domain_samples
+            } else {
+                0
+            };
+        projected = projected.saturating_sub(
+            decision
+                .low_recover_trim_input_samples
+                .saturating_add(muted_consume_input_samples),
+        );
+    }
+
+    // Fold in the pacer's fixed contribution so the displayed control/measured
+    // latency reflects the true end-to-end delay and stays comparable to the
+    // target. The servo keeps using the pacer-excluded figure for its own
+    // decisions.
+    store_latency_metrics_from_control_available(
+        projected.saturating_add(inputs.pacer_buffer_samples),
+        ctx.channel_count,
+        ctx.input_sample_rate,
+        inputs.graph_latency_ms,
+        LatencyMetricTargets {
+            measured_latency_ms_bits: ctx.latency.measured_latency_ms_bits,
+            control_latency_ms_bits: ctx.latency.control_latency_ms_bits,
+        },
+    );
+
+    decision
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -855,6 +971,115 @@ mod tests {
         s.controller_state.accumulated_drift = -7.0;
         reset_controller_integrator(&mut s);
         assert_eq!(s.controller_state.accumulated_drift, 0.0);
+    }
+
+    // ── far_mode_step: the step both output paths share ──────────────────
+
+    fn step_ctx<'a>(
+        cfg: &'a crate::AdaptiveResamplingConfig,
+        code: &'a std::sync::atomic::AtomicU8,
+        measured: &'a Arc<AtomicU32>,
+        control: &'a Arc<AtomicU32>,
+    ) -> FarModeStepCtx<'a> {
+        FarModeStepCtx {
+            adaptive_config: cfg,
+            channel_count: 8,
+            input_sample_rate: 48_000,
+            output_sample_rate: 48_000,
+            runtime_state_code: code,
+            latency: LatencyMetricTargets {
+                measured_latency_ms_bits: measured,
+                control_latency_ms_bits: control,
+            },
+        }
+    }
+
+    fn step_inputs(control_available: usize, ratio: f64) -> FarModeStepInputs {
+        FarModeStepInputs {
+            is_far_band: false,
+            control_available,
+            smoothed_control_available: control_available,
+            target_buffer_fill: 48_000,
+            callback_input_domain_samples: 1024,
+            resample_ratio: ratio,
+            pacer_buffer_samples: 0,
+            graph_latency_ms: 0.0,
+        }
+    }
+
+    /// The step publishes the runtime-state code the diag plot reads, which
+    /// both output paths used to store by hand.
+    #[test]
+    fn far_mode_step_publishes_the_runtime_state_code() {
+        let cfg = crate::AdaptiveResamplingConfig::default();
+        let code = std::sync::atomic::AtomicU8::new(u8::MAX);
+        let (m, c) = (Arc::new(AtomicU32::new(0)), Arc::new(AtomicU32::new(0)));
+        let mut state = AdaptiveRuntimeState::new(1.0);
+
+        far_mode_step(
+            &mut state,
+            &step_ctx(&cfg, &code, &m, &c),
+            step_inputs(48_000, 1.0),
+        );
+        assert_eq!(
+            code.load(Ordering::Relaxed),
+            crate::adaptive_runtime_state_code("stable")
+        );
+    }
+
+    /// The step stores a latency for the metrics to display, and folds the
+    /// pacer's fixed contribution into it.
+    #[test]
+    fn far_mode_step_stores_the_displayed_latency_including_the_pacer() {
+        let cfg = crate::AdaptiveResamplingConfig::default();
+        let code = std::sync::atomic::AtomicU8::new(0);
+        let (m, c) = (Arc::new(AtomicU32::new(0)), Arc::new(AtomicU32::new(0)));
+
+        let mut without = AdaptiveRuntimeState::new(1.0);
+        far_mode_step(
+            &mut without,
+            &step_ctx(&cfg, &code, &m, &c),
+            step_inputs(48_000, 1.0),
+        );
+        let latency_without = f32::from_bits(c.load(Ordering::Relaxed));
+
+        let mut with = AdaptiveRuntimeState::new(1.0);
+        let mut inputs = step_inputs(48_000, 1.0);
+        inputs.pacer_buffer_samples = 48_000;
+        far_mode_step(&mut with, &step_ctx(&cfg, &code, &m, &c), inputs);
+        let latency_with = f32::from_bits(c.load(Ordering::Relaxed));
+
+        assert!(
+            latency_with > latency_without,
+            "the pacer's contribution must show in the displayed latency \
+             ({latency_with} vs {latency_without})"
+        );
+    }
+
+    /// The low-recover trim is taken in the input domain the state machine
+    /// decided, not recovered by converting its output figure back.
+    ///
+    /// The resampler path used to do the round trip — `align(round(input ×
+    /// ratio))` out, `round(output / ratio)` back — which does not return the
+    /// input figure once the ratio is far enough from 1. It only skewed the
+    /// displayed latency, but the two paths disagreed about a number the state
+    /// machine had already decided.
+    #[test]
+    fn the_low_recover_trim_does_not_round_trip_through_the_output_domain() {
+        // A ratio far enough from 1 that the round trip loses samples, and an
+        // overshoot large enough for the trim to be non-zero.
+        let ratio = 1.05_f64;
+        let plan = compute_low_recover_settle_trim_plan(60_000, 48_000, 1024, ratio, 8);
+        assert!(
+            plan.desired_consume_input_samples > 0,
+            "the fixture must actually produce a trim"
+        );
+        let round_tripped =
+            output_to_input_domain_samples(plan.desired_consume_output_samples, ratio);
+        assert_ne!(
+            round_tripped, plan.desired_consume_input_samples,
+            "fixture is only meaningful if the round trip actually loses samples"
+        );
     }
 
     #[test]

--- a/omniphony-renderer/audio_output/src/pacer.rs
+++ b/omniphony-renderer/audio_output/src/pacer.rs
@@ -42,11 +42,17 @@ pub struct PacerHandle {
     pub out_sample_rate: u32,
     /// Output channel count used to compute the per-chunk drain quantum.
     pub out_channels: u32,
-    /// Live mirror of `AdaptiveResamplingConfig::use_output_pacing`. When
-    /// `false`, the input-thread drain is a no-op and the writer pushes
-    /// directly to `ring` — i.e. legacy behaviour. Toggling this atomic is
-    /// the hot-swap mechanism for the feature flag.
-    pub enabled: Arc<AtomicBool>,
+    /// Whether pacing is in effect, from `AdaptiveResamplingConfig::
+    /// use_output_pacing`. When `false`, the drain is a no-op and the writer
+    /// pushes straight to `ring`.
+    ///
+    /// Fixed for the lifetime of the audio output, and a plain `bool` so that
+    /// it cannot be otherwise. It decides *which thread produces into `ring`* —
+    /// the drain when set, the renderer when not — and swapping producers under
+    /// a running stream is exactly what a single-producer ring forbids. Changing
+    /// it takes effect at the next output start, like the other settings that
+    /// shape the audio path rather than tune it.
+    pub enabled: bool,
     /// Diagnostic: cumulative number of samples drawn from the FIFO (real
     /// audio + zero fills). f64-encoded so the diag plot can read it like
     /// any other atomic metric.
@@ -159,7 +165,7 @@ mod tests {
             pre_roll_threshold_samples: pre_roll,
             out_sample_rate: 48_000,
             out_channels: CHANNELS,
-            enabled: Arc::new(AtomicBool::new(true)),
+            enabled: true,
             diag_drain_total: Arc::new(AtomicU64::new(0)),
             diag_underrun_total: Arc::new(AtomicU64::new(0)),
             diag_fifo_level: Arc::new(AtomicU64::new(0)),

--- a/omniphony-renderer/audio_output/src/pacer.rs
+++ b/omniphony-renderer/audio_output/src/pacer.rs
@@ -59,15 +59,33 @@ pub struct PacerHandle {
     /// Should oscillate around `pre_roll_threshold_samples` in steady state
     /// — bottoms out near zero just before each decoder AU lands.
     pub diag_fifo_level: Arc<AtomicU64>,
+    /// A flush has been asked for; [`drain`](Self::drain) empties the FIFO
+    /// before its next transfer.
+    ///
+    /// The flush is deferred rather than done where it is requested because
+    /// `drain` is the FIFO's only consumer and needs to stay that way. It used
+    /// to be popped from three threads — the drain, the OSC thread on a pacing
+    /// toggle, and the DAC callback on recovery — which the queue tolerates but
+    /// which leaves no single owner, and put an unbounded `while pop()` inside
+    /// the audio callback.
+    pub flush_requested: Arc<AtomicBool>,
 }
 
 impl PacerHandle {
-    /// Flush the FIFO and re-arm the pre-roll. Called on
-    /// `recovery_reacquire_pending` consumption or codec switch from the
-    /// DAC callback (output side); the input callback observes the
-    /// `pre_roll_complete` atomic and adapts on the next chunk.
-    pub fn flush_and_rearm(&self) {
-        while self.pacer_fifo.pop().is_some() {}
+    /// Ask for the FIFO to be flushed and the pre-roll re-armed.
+    ///
+    /// Called on `recovery_reacquire_pending` consumption or codec switch from
+    /// the DAC callback (output side), and on a pacing toggle from the OSC
+    /// thread. The work happens on the next [`drain`](Self::drain); until then
+    /// the stale samples sit in the FIFO, where nothing else reads them.
+    ///
+    /// Deferring is also what the caller wants on a toggle: flushing at the
+    /// moment pacing is switched off leaves the FIFO to refill from the
+    /// renderer before draining resumes, whereas flushing at the first drain
+    /// guarantees nothing stale reaches the ring.
+    pub fn request_flush_and_rearm(&self) {
+        self.flush_requested
+            .store(true, std::sync::atomic::Ordering::Release);
         self.pre_roll_complete
             .store(false, std::sync::atomic::Ordering::Relaxed);
     }
@@ -85,6 +103,13 @@ impl PacerHandle {
     /// drives the call.
     pub fn drain(&self, drain_samples: usize) {
         let mut underruns = 0u64;
+        // Honour a deferred flush first, so no stale sample reaches the ring.
+        // Done here because this is the FIFO's only consumer — see
+        // [`request_flush_and_rearm`](Self::request_flush_and_rearm).
+        if self.flush_requested.swap(false, Ordering::Acquire) {
+            while self.pacer_fifo.pop().is_some() {}
+            self.pre_roll_complete.store(false, Ordering::Relaxed);
+        }
         let priming = !self.pre_roll_complete.load(Ordering::Relaxed);
         if priming {
             if self.pacer_fifo.len() >= self.pre_roll_threshold_samples {
@@ -117,5 +142,107 @@ impl PacerHandle {
         }
         self.diag_fifo_level
             .store((self.pacer_fifo.len() as f64).to_bits(), Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHANNELS: u32 = 2;
+
+    fn handle(pre_roll: usize) -> PacerHandle {
+        PacerHandle {
+            pacer_fifo: Arc::new(ArrayQueue::new(4096)),
+            ring: Arc::new(ArrayQueue::new(4096)),
+            pre_roll_complete: Arc::new(AtomicBool::new(true)),
+            pre_roll_threshold_samples: pre_roll,
+            out_sample_rate: 48_000,
+            out_channels: CHANNELS,
+            enabled: Arc::new(AtomicBool::new(true)),
+            diag_drain_total: Arc::new(AtomicU64::new(0)),
+            diag_underrun_total: Arc::new(AtomicU64::new(0)),
+            diag_fifo_level: Arc::new(AtomicU64::new(0)),
+            flush_requested: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn fill(h: &PacerHandle, values: &[f32]) {
+        for &v in values {
+            h.pacer_fifo.push(v).expect("fifo has room");
+        }
+    }
+
+    fn drain_ring(h: &PacerHandle) -> Vec<f32> {
+        std::iter::from_fn(|| h.ring.pop()).collect()
+    }
+
+    /// The request only records the intent: the FIFO is the drain's to empty,
+    /// and the requester is a different thread.
+    #[test]
+    fn requesting_a_flush_does_not_touch_the_fifo() {
+        let h = handle(0);
+        fill(&h, &[1.0, 2.0, 3.0, 4.0]);
+        h.request_flush_and_rearm();
+        assert_eq!(h.pacer_fifo.len(), 4, "the requester must not consume");
+        assert!(h.flush_requested.load(Ordering::Relaxed));
+        assert!(
+            !h.pre_roll_complete.load(Ordering::Relaxed),
+            "pre-roll re-armed"
+        );
+    }
+
+    /// The deferred flush happens at the next drain, and nothing queued before
+    /// it reaches the ring — which is the whole point of flushing.
+    #[test]
+    fn the_next_drain_flushes_before_transferring() {
+        let h = handle(0);
+        fill(&h, &[1.0, 2.0, 3.0, 4.0]);
+        h.request_flush_and_rearm();
+
+        h.drain(4);
+        assert_eq!(h.pacer_fifo.len(), 0, "the drain emptied the FIFO");
+        assert!(
+            !h.flush_requested.load(Ordering::Relaxed),
+            "request consumed"
+        );
+        assert!(
+            drain_ring(&h).iter().all(|s| *s == 0.0),
+            "stale samples must not reach the ring"
+        );
+
+        // Fresh audio queued after the flush goes through normally.
+        h.pre_roll_complete.store(true, Ordering::Relaxed);
+        fill(&h, &[0.5, -0.5]);
+        h.drain(2);
+        assert_eq!(drain_ring(&h), vec![0.5, -0.5]);
+    }
+
+    /// A second drain must not re-flush: the request is consumed once.
+    #[test]
+    fn the_flush_request_is_consumed_once() {
+        let h = handle(0);
+        h.request_flush_and_rearm();
+        h.drain(0);
+        h.pre_roll_complete.store(true, Ordering::Relaxed);
+        fill(&h, &[7.0, 8.0]);
+        h.drain(2);
+        assert_eq!(
+            drain_ring(&h),
+            vec![7.0, 8.0],
+            "a stale request would have eaten these"
+        );
+    }
+
+    /// Pre-roll still gates real audio: until the FIFO is primed the drain
+    /// emits silence rather than draining the FIFO below its safety margin.
+    #[test]
+    fn pre_roll_still_holds_back_real_audio() {
+        let h = handle(8);
+        h.pre_roll_complete.store(false, Ordering::Relaxed);
+        fill(&h, &[1.0, 2.0]);
+        h.drain(2);
+        assert_eq!(drain_ring(&h), vec![0.0, 0.0], "silence while priming");
+        assert_eq!(h.pacer_fifo.len(), 2, "the FIFO was not drawn down");
     }
 }

--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -246,7 +246,7 @@ pub struct PipewireWriter {
     /// buffer the DAC consumes sees a smooth flow regardless of the
     /// decoder's burst pattern.
     pacer_fifo: Arc<ArrayQueue<f32>>,
-    pacer_enabled: Arc<AtomicBool>,
+    pacer_enabled: bool,
     /// When true, `write_samples` pushes without ever blocking and drops the
     /// overflow above the back-pressure threshold instead of waiting for the
     /// DAC to drain. Decouples the producer from the consumer clock.
@@ -434,7 +434,7 @@ impl PipewireWriter {
         // the same amount of audio. It only fills meaningfully when the
         // input-thread drain lags or is paused (eg. during pre-roll).
         let pacer_fifo = Arc::new(ArrayQueue::new(BUFFER_SIZE));
-        let pacer_enabled = Arc::new(AtomicBool::new(adaptive_config.use_output_pacing));
+        let pacer_enabled = adaptive_config.use_output_pacing;
         let backpressure_disabled = Arc::new(AtomicBool::new(adaptive_config.disable_backpressure));
         let pacer_pre_roll_complete = Arc::new(AtomicBool::new(false));
         let pacer_flush_requested = Arc::new(AtomicBool::new(false));
@@ -520,10 +520,9 @@ impl PipewireWriter {
         let input_trigger_quantum_for_thread = Arc::clone(&input_trigger_quantum_frames);
         // Pacer atomics cloned into the PipeWire thread so the DAC callback
         // can flush the FIFO and re-arm pre-roll on recovery_reacquire.
-        let pacer_fifo_for_thread = Arc::clone(&pacer_fifo);
         let pacer_pre_roll_complete_for_thread = Arc::clone(&pacer_pre_roll_complete);
         let pacer_flush_requested_for_thread = Arc::clone(&pacer_flush_requested);
-        let pacer_enabled_for_thread = Arc::clone(&pacer_enabled);
+        let pacer_enabled_for_thread = pacer_enabled;
         let pacer_pre_roll_threshold_for_thread = pacer_pre_roll_threshold_samples;
 
         // Capture before moving buffer_config into the thread closure.
@@ -580,7 +579,6 @@ impl PipewireWriter {
                 input_trigger_rate_for_thread,
                 input_trigger_quantum_for_thread,
                 input_clock_us,
-                pacer_fifo_for_thread,
                 pacer_pre_roll_complete_for_thread,
                 pacer_flush_requested_for_thread,
                 pacer_enabled_for_thread,
@@ -699,7 +697,7 @@ impl PipewireWriter {
         // backpressure on the renderer push: this guarantees the pacer
         // contributes a *fixed* latency (= pre_roll_threshold) instead of
         // drifting up to seconds of buffered audio.
-        let pacer_active = self.pacer_enabled.load(Ordering::Relaxed);
+        let pacer_active = self.pacer_enabled;
         let target_buffer: &Arc<ArrayQueue<f32>> = if pacer_active {
             &self.pacer_fifo
         } else {
@@ -851,28 +849,10 @@ impl PipewireWriter {
             pre_roll_threshold_samples: self.pacer_pre_roll_threshold_samples,
             out_sample_rate: self.sample_rate,
             out_channels: self.channel_count,
-            enabled: Arc::clone(&self.pacer_enabled),
+            enabled: self.pacer_enabled,
             diag_drain_total: Arc::clone(&self.pacer_drain_total),
             diag_underrun_total: Arc::clone(&self.pacer_underrun_total),
             diag_fifo_level: Arc::clone(&self.pacer_fifo_level),
-        }
-    }
-
-    /// Hot-swap the pacer enabled flag. Called when
-    /// `AdaptiveResamplingConfig::use_output_pacing` flips via OSC.
-    pub fn set_output_pacing_enabled(&self, enabled: bool) {
-        // On transition true → false, drain any leftover FIFO so we don't
-        // resume with stale audio on the next toggle. On false → true,
-        // re-arm pre-roll so we always grow the buffer before the input
-        // thread starts pulling real samples.
-        let was = self.pacer_enabled.swap(enabled, Ordering::Relaxed);
-        if was != enabled {
-            // Ask the drain to flush; it owns the FIFO. Deferring also means a
-            // re-enable cannot start from stale audio, which flushing here did
-            // not guarantee — the renderer refills between the toggle and the
-            // first drain.
-            self.pacer_flush_requested.store(true, Ordering::Release);
-            self.pacer_pre_roll_complete.store(false, Ordering::Relaxed);
         }
     }
 
@@ -959,9 +939,17 @@ impl PipewireWriter {
 
     /// Update adaptive resampling tuning parameters without restarting the audio thread.
     pub fn update_adaptive_config(&self, config: AdaptiveResamplingConfig) {
-        // Hot-swap the pacer enabled flag and reset its state on transition,
-        // so toggling `use_output_pacing` over OSC starts a clean pre-roll.
-        self.set_output_pacing_enabled(config.use_output_pacing);
+        // Output pacing is NOT hot-swappable: it decides which thread produces
+        // into the ring, and swapping producers under a running stream is what
+        // the single-producer invariant forbids. Say so rather than silently
+        // ignoring the request.
+        if config.use_output_pacing != self.pacer_enabled {
+            log::warn!(
+                "Output pacing is fixed for the lifetime of the audio output                  (running with {}, requested {}); the change takes effect at the                  next output start.",
+                self.pacer_enabled,
+                config.use_output_pacing
+            );
+        }
         self.set_backpressure_disabled(config.disable_backpressure);
         *self.live_adaptive_config.lock() = config;
     }
@@ -1155,10 +1143,9 @@ fn run_pipewire_loop(
     input_trigger_rate_hz: Arc<AtomicU32>,
     input_trigger_quantum_frames: Arc<AtomicU32>,
     input_clock_us: Arc<std::sync::atomic::AtomicU64>,
-    pacer_fifo: Arc<ArrayQueue<f32>>,
     pacer_pre_roll_complete: Arc<AtomicBool>,
     pacer_flush_requested: Arc<AtomicBool>,
-    pacer_enabled: Arc<AtomicBool>,
+    pacer_enabled: bool,
     pacer_pre_roll_threshold_samples: usize,
 ) -> Result<()> {
     // Determine actual output rate and resampling ratio
@@ -1489,7 +1476,7 @@ fn run_pipewire_loop(
                     // sum (ring + pacer) lands at user_target. Without this,
                     // setting latency to 500 ms would actually give
                     // 500 + pacer_capacity audible delay.
-                    let runtime_target_buffer_fill = if pacer_enabled.load(Ordering::Relaxed) {
+                    let runtime_target_buffer_fill = if pacer_enabled {
                         target_buffer_fill.saturating_sub(pacer_pre_roll_threshold_samples)
                     } else {
                         target_buffer_fill
@@ -1610,7 +1597,7 @@ fn run_pipewire_loop(
                     // keeps the total end-to-end latency at the user's
                     // configured `latency_ms` regardless of whether the
                     // pacer is active.
-                    let pacer_buffer_samples = if pacer_enabled.load(Ordering::Relaxed) {
+                    let pacer_buffer_samples = if pacer_enabled {
                         pacer_pre_roll_threshold_samples
                     } else {
                         0

--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -252,6 +252,7 @@ pub struct PipewireWriter {
     /// DAC to drain. Decouples the producer from the consumer clock.
     backpressure_disabled: Arc<AtomicBool>,
     pacer_pre_roll_complete: Arc<AtomicBool>,
+    pacer_flush_requested: Arc<AtomicBool>,
     pacer_pre_roll_threshold_samples: usize,
     pacer_drain_total: Arc<AtomicU64>,
     pacer_underrun_total: Arc<AtomicU64>,
@@ -436,6 +437,7 @@ impl PipewireWriter {
         let pacer_enabled = Arc::new(AtomicBool::new(adaptive_config.use_output_pacing));
         let backpressure_disabled = Arc::new(AtomicBool::new(adaptive_config.disable_backpressure));
         let pacer_pre_roll_complete = Arc::new(AtomicBool::new(false));
+        let pacer_flush_requested = Arc::new(AtomicBool::new(false));
         // 64 ms of audio at the output rate × channel count. Covers >1 AU
         // for both supported input codecs (~32 ms per AU) with margin.
         let pacer_pre_roll_threshold_samples =
@@ -520,6 +522,7 @@ impl PipewireWriter {
         // can flush the FIFO and re-arm pre-roll on recovery_reacquire.
         let pacer_fifo_for_thread = Arc::clone(&pacer_fifo);
         let pacer_pre_roll_complete_for_thread = Arc::clone(&pacer_pre_roll_complete);
+        let pacer_flush_requested_for_thread = Arc::clone(&pacer_flush_requested);
         let pacer_enabled_for_thread = Arc::clone(&pacer_enabled);
         let pacer_pre_roll_threshold_for_thread = pacer_pre_roll_threshold_samples;
 
@@ -579,6 +582,7 @@ impl PipewireWriter {
                 input_clock_us,
                 pacer_fifo_for_thread,
                 pacer_pre_roll_complete_for_thread,
+                pacer_flush_requested_for_thread,
                 pacer_enabled_for_thread,
                 pacer_pre_roll_threshold_for_thread,
             ) {
@@ -621,6 +625,7 @@ impl PipewireWriter {
             pacer_enabled,
             backpressure_disabled,
             pacer_pre_roll_complete,
+            pacer_flush_requested,
             pacer_pre_roll_threshold_samples,
             pacer_drain_total,
             pacer_underrun_total,
@@ -842,6 +847,7 @@ impl PipewireWriter {
             pacer_fifo: Arc::clone(&self.pacer_fifo),
             ring: Arc::clone(&self.sample_buffer),
             pre_roll_complete: Arc::clone(&self.pacer_pre_roll_complete),
+            flush_requested: Arc::clone(&self.pacer_flush_requested),
             pre_roll_threshold_samples: self.pacer_pre_roll_threshold_samples,
             out_sample_rate: self.sample_rate,
             out_channels: self.channel_count,
@@ -861,7 +867,11 @@ impl PipewireWriter {
         // thread starts pulling real samples.
         let was = self.pacer_enabled.swap(enabled, Ordering::Relaxed);
         if was != enabled {
-            while self.pacer_fifo.pop().is_some() {}
+            // Ask the drain to flush; it owns the FIFO. Deferring also means a
+            // re-enable cannot start from stale audio, which flushing here did
+            // not guarantee — the renderer refills between the toggle and the
+            // first drain.
+            self.pacer_flush_requested.store(true, Ordering::Release);
             self.pacer_pre_roll_complete.store(false, Ordering::Relaxed);
         }
     }
@@ -1147,6 +1157,7 @@ fn run_pipewire_loop(
     input_clock_us: Arc<std::sync::atomic::AtomicU64>,
     pacer_fifo: Arc<ArrayQueue<f32>>,
     pacer_pre_roll_complete: Arc<AtomicBool>,
+    pacer_flush_requested: Arc<AtomicBool>,
     pacer_enabled: Arc<AtomicBool>,
     pacer_pre_roll_threshold_samples: usize,
 ) -> Result<()> {
@@ -1947,7 +1958,7 @@ fn run_pipewire_loop(
                             // samples queued before the reacquire are stale.
                             // Re-arm pre-roll so the input thread re-primes
                             // before starting real drains.
-                            while pacer_fifo.pop().is_some() {}
+                            pacer_flush_requested.store(true, Ordering::Release);
                             pacer_pre_roll_complete.store(false, Ordering::Relaxed);
                             if far_decision.mute_far_output {
                                 if let Err(e) = resampler_fifo.ensure_output_samples(
@@ -2262,7 +2273,7 @@ fn run_pipewire_loop(
                             runtime_state.pre_bridge_offset_initialized = false;
                             runtime_state.pre_bridge_offset_accum = 0;
                             runtime_state.pre_bridge_offset_count = 0;
-                            while pacer_fifo.pop().is_some() {}
+                            pacer_flush_requested.store(true, Ordering::Release);
                             pacer_pre_roll_complete.store(false, Ordering::Relaxed);
                             if far_decision.mute_far_output {
                                 let dropped =

--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -20,16 +20,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::{
     ADAPTIVE_BAND_FAR, AdaptiveResamplingConfig, LOCAL_RESAMPLER_MAX_RELATIVE_RATIO,
     adaptive_runtime::{
-        AdaptiveRuntimeState, FarModeDecision, LatencyMetricTargets, LowRecoverPhase,
-        MAX_INTEGRAL_TERM, PRE_BRIDGE_CALIBRATION_CALLBACKS, adaptive_runtime_state_name,
+        AdaptiveRuntimeState, FarModeStepCtx, FarModeStepInputs, LatencyMetricTargets,
+        LowRecoverPhase, MAX_INTEGRAL_TERM, PRE_BRIDGE_CALIBRATION_CALLBACKS,
         compute_hard_recover_high_plan, discard_ring_samples, far_mode_band_from_latency,
-        note_refill_or_underrun, output_to_input_domain_samples, paused_rate_adjust,
+        far_mode_step, note_refill_or_underrun, output_to_input_domain_samples, paused_rate_adjust,
         postprocess_interleaved_output, reset_adaptive_runtime, run_adaptive_servo,
-        should_run_adaptive_servo, store_latency_metrics_from_control_available,
-        update_far_mode_state, update_latency_metrics, zero_pad_tail,
+        should_run_adaptive_servo, update_latency_metrics, zero_pad_tail,
     },
-    adaptive_runtime_state_code, adaptive_runtime_state_name_from_code,
-    clamp_ratio_for_local_resampler, local_resampler_ratio_bounds,
+    adaptive_runtime_state_name_from_code, clamp_ratio_for_local_resampler,
+    local_resampler_ratio_bounds,
     resampler_fifo::{RESAMPLER_CHUNK_SIZE, ResamplerFifoEngine},
     ring_buffer_io::{
         flush_ring_buffer, push_samples_drop_overflow, push_samples_with_backpressure,
@@ -1847,70 +1846,31 @@ fn run_pipewire_loop(
                         // State machine on raw: its entry/exit/settle bands are
                         // already the hysteresis; smoothing on top added phase lag
                         // that drove a slow oscillation.
-                        let far_decision = update_far_mode_state(
+                        let far_decision = far_mode_step(
                             &mut runtime_state,
-                            &adaptive_cfg,
-                            current_adaptive_band.load(Ordering::Relaxed) == ADAPTIVE_BAND_FAR,
-                            metrics.control_available,
-                            metrics.smoothed_control_available,
-                            runtime_target_buffer_fill,
-                            callback_input_domain_samples,
-                            effective_resample_ratio,
-                            channel_count as usize,
-                            sample_rate,
-                            actual_output_rate,
-                        );
-                        current_runtime_state.store(
-                            adaptive_runtime_state_code(adaptive_runtime_state_name(
-                                runtime_state.low_recover_phase,
-                                far_decision.hard_recover_high,
-                            )),
-                            Ordering::Relaxed,
-                        );
-                        let mut projected_control_available = metrics.control_available;
-                        if far_decision.recovery_reacquire_pending && far_decision.mute_far_output {
-                            projected_control_available =
-                                projected_control_available.saturating_sub(callback_input_domain_samples);
-                        } else if far_decision.hard_recover_high {
-                            let plan = compute_hard_recover_high_plan(
+                            &FarModeStepCtx {
+                                adaptive_config: &adaptive_cfg,
+                                channel_count: channel_count as usize,
+                                input_sample_rate: sample_rate,
+                                output_sample_rate: actual_output_rate,
+                                runtime_state_code: &current_runtime_state,
+                                latency: LatencyMetricTargets {
+                                    measured_latency_ms_bits: &measured_latency_ms_out,
+                                    control_latency_ms_bits: &control_latency_ms_out,
+                                },
+                            },
+                            FarModeStepInputs {
+                                is_far_band: current_adaptive_band.load(Ordering::Relaxed)
+                                    == ADAPTIVE_BAND_FAR,
+                                control_available: metrics.control_available,
+                                smoothed_control_available: metrics.smoothed_control_available,
+                                target_buffer_fill: runtime_target_buffer_fill,
                                 callback_input_domain_samples,
-                                metrics.control_available,
-                                runtime_target_buffer_fill,
-                                effective_resample_ratio,
-                                channel_count as usize,
-                            );
-                            projected_control_available = projected_control_available
-                                .saturating_sub(plan.desired_consume_input_samples);
-                        } else if far_decision.hold_low_recover {
-                            let trim_input_samples = output_to_input_domain_samples(
-                                far_decision.low_recover_trim_output_samples,
-                                effective_resample_ratio,
-                            );
-                            let muted_consume_input_samples =
-                                if far_decision.mute_far_output && far_decision.consume_while_muted {
-                                    callback_input_domain_samples
-                                } else {
-                                    0
-                                };
-                            projected_control_available = projected_control_available
-                                .saturating_sub(
-                                    trim_input_samples.saturating_add(muted_consume_input_samples),
-                                );
-                        }
-                        // Fold in the pacer's fixed contribution so the displayed
-                        // control/measured latency reflects the true end-to-end
-                        // delay and stays comparable to the target — the same
-                        // adjustment the main `display_control_available` path
-                        // applies. The servo keeps using the pacer-excluded
-                        // `projected_control_available` for its own decisions.
-                        store_latency_metrics_from_control_available(
-                            projected_control_available.saturating_add(pacer_buffer_samples),
-                            channel_count as usize,
-                            sample_rate,
-                            f32::from_bits(graph_latency_for_callback.load(Ordering::Relaxed)),
-                            LatencyMetricTargets {
-                                measured_latency_ms_bits: &measured_latency_ms_out,
-                                control_latency_ms_bits: &control_latency_ms_out,
+                                resample_ratio: effective_resample_ratio,
+                                pacer_buffer_samples,
+                                graph_latency_ms: f32::from_bits(
+                                    graph_latency_for_callback.load(Ordering::Relaxed),
+                                ),
                             },
                         );
                         if far_decision.hold_low_recover {
@@ -2186,68 +2146,33 @@ fn run_pipewire_loop(
                         let samples_to_read = frames_to_read * ch;
 
                         // State machine on raw — see resampler path.
-                        let far_decision: FarModeDecision = update_far_mode_state(
+                        // Straight copy: the ratio is 1.0, so input and output
+                        // domains coincide. Same step as the resampler path.
+                        let far_decision = far_mode_step(
                             &mut runtime_state,
-                            &adaptive_cfg,
-                            current_adaptive_band.load(Ordering::Relaxed) == ADAPTIVE_BAND_FAR,
-                            metrics.control_available,
-                            metrics.smoothed_control_available,
-                            runtime_target_buffer_fill,
-                            callback_input_domain_samples,
-                            1.0,
-                            channel_count as usize,
-                            sample_rate,
-                            actual_output_rate,
-                        );
-                        current_runtime_state.store(
-                            adaptive_runtime_state_code(adaptive_runtime_state_name(
-                                runtime_state.low_recover_phase,
-                                far_decision.hard_recover_high,
-                            )),
-                            Ordering::Relaxed,
-                        );
-                        let mut projected_control_available = metrics.control_available;
-                        if far_decision.recovery_reacquire_pending && far_decision.mute_far_output {
-                            projected_control_available =
-                                projected_control_available.saturating_sub(callback_input_domain_samples);
-                        } else if far_decision.hard_recover_high {
-                            let plan = compute_hard_recover_high_plan(
+                            &FarModeStepCtx {
+                                adaptive_config: &adaptive_cfg,
+                                channel_count: channel_count as usize,
+                                input_sample_rate: sample_rate,
+                                output_sample_rate: actual_output_rate,
+                                runtime_state_code: &current_runtime_state,
+                                latency: LatencyMetricTargets {
+                                    measured_latency_ms_bits: &measured_latency_ms_out,
+                                    control_latency_ms_bits: &control_latency_ms_out,
+                                },
+                            },
+                            FarModeStepInputs {
+                                is_far_band: current_adaptive_band.load(Ordering::Relaxed)
+                                    == ADAPTIVE_BAND_FAR,
+                                control_available: metrics.control_available,
+                                smoothed_control_available: metrics.smoothed_control_available,
+                                target_buffer_fill: runtime_target_buffer_fill,
                                 callback_input_domain_samples,
-                                metrics.control_available,
-                                runtime_target_buffer_fill,
-                                1.0,
-                                channel_count as usize,
-                            );
-                            projected_control_available = projected_control_available
-                                .saturating_sub(plan.desired_consume_input_samples);
-                        } else if far_decision.hold_low_recover {
-                            let muted_consume_input_samples =
-                                if far_decision.mute_far_output && far_decision.consume_while_muted {
-                                    callback_input_domain_samples
-                                } else {
-                                    0
-                                };
-                            projected_control_available = projected_control_available
-                                .saturating_sub(
-                                    far_decision
-                                        .low_recover_trim_input_samples
-                                        .saturating_add(muted_consume_input_samples),
-                                );
-                        }
-                        // Fold in the pacer's fixed contribution so the displayed
-                        // control/measured latency reflects the true end-to-end
-                        // delay and stays comparable to the target — the same
-                        // adjustment the main `display_control_available` path
-                        // applies. The servo keeps using the pacer-excluded
-                        // `projected_control_available` for its own decisions.
-                        store_latency_metrics_from_control_available(
-                            projected_control_available.saturating_add(pacer_buffer_samples),
-                            channel_count as usize,
-                            sample_rate,
-                            f32::from_bits(graph_latency_for_callback.load(Ordering::Relaxed)),
-                            LatencyMetricTargets {
-                                measured_latency_ms_bits: &measured_latency_ms_out,
-                                control_latency_ms_bits: &control_latency_ms_out,
+                                resample_ratio: 1.0,
+                                pacer_buffer_samples,
+                                graph_latency_ms: f32::from_bits(
+                                    graph_latency_for_callback.load(Ordering::Relaxed),
+                                ),
                             },
                         );
                         if far_decision.hold_low_recover {

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -778,7 +778,7 @@ fn spawn_pacer_drain_thread(
                     frac_frames = 0.0;
                     continue;
                 };
-                if !pacer.enabled.load(std::sync::atomic::Ordering::Relaxed)
+                if !pacer.enabled
                     || input_control.applied_snapshot().active_mode
                         != audio_input::InputMode::Bridge
                 {


### PR DESCRIPTION
Prerequisite for the SPSC ring work: make the queue topology genuinely single-producer/single-consumer, without changing the queue type. Two commits, one per half.

## 1. The pacer FIFO had three consumers

| thread | where |
|---|---|
| drain (owns it) | `PacerHandle::drain` |
| OSC control | `set_output_pacing_enabled` — `while self.pacer_fifo.pop().is_some() {}` |
| **DAC callback** | `flush_and_rearm`, on recovery-reacquire and codec switch |

`ArrayQueue` is MPMC so this was *correct*. But it left the FIFO with no owner, and it put an **unbounded `while pop()` inside the audio callback** — work whose duration depends on how much audio happens to be queued, on the one thread that must never be surprised. Worth fixing on its own merits.

Both out-of-band flushes are now a request the drain honours at the top of its next transfer. Deferring is also the *better* semantics: flushing at toggle time left the renderer free to refill before draining resumed, so "flush on transition" never actually guaranteed a clean restart. Flushing at the first drain does.

## 2. The ring had two possible producers

The renderer when pacing is off, the drain when it's on — and `use_output_pacing` flipped at runtime from OSC, two plain `Relaxed` reads, nothing ordering the handover. Toggling mid-stream let both push concurrently.

You confirmed the live toggle is diagnostic only, so pacing now takes effect **at the next output start**, like the other settings that shape the audio path rather than tune it. That avoids building a handover handshake whose on→off direction needs the drain to acknowledge before the renderer resumes, with "the drain never runs" hanging it.

The flag is a plain `bool` on the writer and in `PacerHandle`, not an atomic, so **the invariant is structural — you cannot hot-swap what is not mutable**. `set_output_pacing_enabled` is gone. A request to change pacing on a running output now logs that it applies at the next start, rather than being silently dropped.

`run_pipewire_loop` also loses its pacer-FIFO parameter: the callback no longer touches that queue at all.

## Why this was needed

A slice-based SPSC ring measures ~**9× per sample** on these transfers — cross-thread, 10.6 ns vs 1.1 ns, so ~11-16 ms per audio-second across the three crossings on x86, more on ARM32. But an SPSC ring with `UnsafeCell` is **unsound** unless each queue really has one producer and one consumer.

The audit that proposed the ring work asserted "these are all SPSC hand-offs". That was wrong, and this PR is what makes it true.

## What still isn't verified

An input-mode change (Bridge ↔ Live) also switches which drain caller is active — the pipe-bridge drain thread vs the PipeWire input callback — so both gate on `active_mode` as well as on pacing. That window is much narrower than a deliberate live toggle, and it may already be closed by the writer (and therefore the queues) being rebuilt on a mode change, but **I have not verified that**. It needs checking before the ring type changes.

## Risk

610 workspace tests pass, fmt clean. Four new tests on the deferred flush: the request doesn't consume, the next drain flushes before transferring and no stale sample reaches the ring, the request is consumed exactly once, and pre-roll still holds back real audio.

Behaviour changes: the flush timing described above, and pacing no longer being live-toggleable. Not verified by ear — the paths touched are recovery-reacquire, codec switch, and the pacing toggle, so exercising them means forcing a resync or restarting the output with pacing flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
