### PR TITLE
Share the far-mode step between both output paths

### DIFF
--- a/omniphony-renderer/audio_output/src/adaptive_runtime.rs
+++ b/omniphony-renderer/audio_output/src/adaptive_runtime.rs
@@ -745,6 +745,122 @@ pub fn compute_hard_recover_high_plan(
     }
 }
 
+/// Loop-invariant context for [`far_mode_step`].
+pub struct FarModeStepCtx<'a> {
+    pub adaptive_config: &'a crate::AdaptiveResamplingConfig,
+    pub channel_count: usize,
+    pub input_sample_rate: u32,
+    pub output_sample_rate: u32,
+    /// Published runtime-state code, for the diag plot.
+    pub runtime_state_code: &'a std::sync::atomic::AtomicU8,
+    pub latency: LatencyMetricTargets<'a>,
+}
+
+/// The per-callback figures the far-mode step works from.
+pub struct FarModeStepInputs {
+    pub is_far_band: bool,
+    pub control_available: usize,
+    pub smoothed_control_available: usize,
+    pub target_buffer_fill: usize,
+    pub callback_input_domain_samples: usize,
+    /// The ratio this path works in: the resampler's effective ratio, or `1.0`
+    /// when samples are copied straight through.
+    pub resample_ratio: f64,
+    /// The pacer's fixed contribution, folded into the *displayed* latency only.
+    pub pacer_buffer_samples: usize,
+    pub graph_latency_ms: f32,
+}
+
+/// Run the far-mode state machine for one callback, publish the runtime-state
+/// code, and store the latency the metrics display.
+///
+/// The resampler path and the direct-copy path differ only in the ratio they
+/// work in, but each used to carry its own copy of this, and the copies had
+/// drifted apart:
+///
+/// * the resampler copy recovered the low-recover trim by converting the
+///   decision's *output* figure back through the ratio. That round trip —
+///   `align(round(input × ratio))` on the way out, `round(output / ratio)` on
+///   the way back — does not return the input figure the state machine actually
+///   decided once the ratio is far enough from 1. Both now read
+///   `low_recover_trim_input_samples`, which is the authoritative one: the
+///   output figure is derived from it, not the reverse.
+/// * the displayed-latency store had been kept identical by hand.
+///
+/// It only skewed the *displayed* latency, never what was consumed — but it is
+/// exactly the shape of bug that gets fixed on one path and left on the other.
+pub fn far_mode_step(
+    state: &mut AdaptiveRuntimeState,
+    ctx: &FarModeStepCtx<'_>,
+    inputs: FarModeStepInputs,
+) -> FarModeDecision {
+    let decision = update_far_mode_state(
+        state,
+        ctx.adaptive_config,
+        inputs.is_far_band,
+        inputs.control_available,
+        inputs.smoothed_control_available,
+        inputs.target_buffer_fill,
+        inputs.callback_input_domain_samples,
+        inputs.resample_ratio,
+        ctx.channel_count,
+        ctx.input_sample_rate,
+        ctx.output_sample_rate,
+    );
+    ctx.runtime_state_code.store(
+        crate::adaptive_runtime_state_code(adaptive_runtime_state_name(
+            state.low_recover_phase,
+            decision.hard_recover_high,
+        )),
+        Ordering::Relaxed,
+    );
+
+    // What the buffer level will be once this callback's action has been
+    // applied — the servo reasons about the outcome, not the reading.
+    let mut projected = inputs.control_available;
+    if decision.recovery_reacquire_pending && decision.mute_far_output {
+        projected = projected.saturating_sub(inputs.callback_input_domain_samples);
+    } else if decision.hard_recover_high {
+        let plan = compute_hard_recover_high_plan(
+            inputs.callback_input_domain_samples,
+            inputs.control_available,
+            inputs.target_buffer_fill,
+            inputs.resample_ratio,
+            ctx.channel_count,
+        );
+        projected = projected.saturating_sub(plan.desired_consume_input_samples);
+    } else if decision.hold_low_recover {
+        let muted_consume_input_samples =
+            if decision.mute_far_output && decision.consume_while_muted {
+                inputs.callback_input_domain_samples
+            } else {
+                0
+            };
+        projected = projected.saturating_sub(
+            decision
+                .low_recover_trim_input_samples
+                .saturating_add(muted_consume_input_samples),
+        );
+    }
+
+    // Fold in the pacer's fixed contribution so the displayed control/measured
+    // latency reflects the true end-to-end delay and stays comparable to the
+    // target. The servo keeps using the pacer-excluded figure for its own
+    // decisions.
+    store_latency_metrics_from_control_available(
+        projected.saturating_add(inputs.pacer_buffer_samples),
+        ctx.channel_count,
+        ctx.input_sample_rate,
+        inputs.graph_latency_ms,
+        LatencyMetricTargets {
+            measured_latency_ms_bits: ctx.latency.measured_latency_ms_bits,
+            control_latency_ms_bits: ctx.latency.control_latency_ms_bits,
+        },
+    );
+
+    decision
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -855,6 +971,115 @@ mod tests {
         s.controller_state.accumulated_drift = -7.0;
         reset_controller_integrator(&mut s);
         assert_eq!(s.controller_state.accumulated_drift, 0.0);
+    }
+
+    // ── far_mode_step: the step both output paths share ──────────────────
+
+    fn step_ctx<'a>(
+        cfg: &'a crate::AdaptiveResamplingConfig,
+        code: &'a std::sync::atomic::AtomicU8,
+        measured: &'a Arc<AtomicU32>,
+        control: &'a Arc<AtomicU32>,
+    ) -> FarModeStepCtx<'a> {
+        FarModeStepCtx {
+            adaptive_config: cfg,
+            channel_count: 8,
+            input_sample_rate: 48_000,
+            output_sample_rate: 48_000,
+            runtime_state_code: code,
+            latency: LatencyMetricTargets {
+                measured_latency_ms_bits: measured,
+                control_latency_ms_bits: control,
+            },
+        }
+    }
+
+    fn step_inputs(control_available: usize, ratio: f64) -> FarModeStepInputs {
+        FarModeStepInputs {
+            is_far_band: false,
+            control_available,
+            smoothed_control_available: control_available,
+            target_buffer_fill: 48_000,
+            callback_input_domain_samples: 1024,
+            resample_ratio: ratio,
+            pacer_buffer_samples: 0,
+            graph_latency_ms: 0.0,
+        }
+    }
+
+    /// The step publishes the runtime-state code the diag plot reads, which
+    /// both output paths used to store by hand.
+    #[test]
+    fn far_mode_step_publishes_the_runtime_state_code() {
+        let cfg = crate::AdaptiveResamplingConfig::default();
+        let code = std::sync::atomic::AtomicU8::new(u8::MAX);
+        let (m, c) = (Arc::new(AtomicU32::new(0)), Arc::new(AtomicU32::new(0)));
+        let mut state = AdaptiveRuntimeState::new(1.0);
+
+        far_mode_step(
+            &mut state,
+            &step_ctx(&cfg, &code, &m, &c),
+            step_inputs(48_000, 1.0),
+        );
+        assert_eq!(
+            code.load(Ordering::Relaxed),
+            crate::adaptive_runtime_state_code("stable")
+        );
+    }
+
+    /// The step stores a latency for the metrics to display, and folds the
+    /// pacer's fixed contribution into it.
+    #[test]
+    fn far_mode_step_stores_the_displayed_latency_including_the_pacer() {
+        let cfg = crate::AdaptiveResamplingConfig::default();
+        let code = std::sync::atomic::AtomicU8::new(0);
+        let (m, c) = (Arc::new(AtomicU32::new(0)), Arc::new(AtomicU32::new(0)));
+
+        let mut without = AdaptiveRuntimeState::new(1.0);
+        far_mode_step(
+            &mut without,
+            &step_ctx(&cfg, &code, &m, &c),
+            step_inputs(48_000, 1.0),
+        );
+        let latency_without = f32::from_bits(c.load(Ordering::Relaxed));
+
+        let mut with = AdaptiveRuntimeState::new(1.0);
+        let mut inputs = step_inputs(48_000, 1.0);
+        inputs.pacer_buffer_samples = 48_000;
+        far_mode_step(&mut with, &step_ctx(&cfg, &code, &m, &c), inputs);
+        let latency_with = f32::from_bits(c.load(Ordering::Relaxed));
+
+        assert!(
+            latency_with > latency_without,
+            "the pacer's contribution must show in the displayed latency \
+             ({latency_with} vs {latency_without})"
+        );
+    }
+
+    /// The low-recover trim is taken in the input domain the state machine
+    /// decided, not recovered by converting its output figure back.
+    ///
+    /// The resampler path used to do the round trip — `align(round(input ×
+    /// ratio))` out, `round(output / ratio)` back — which does not return the
+    /// input figure once the ratio is far enough from 1. It only skewed the
+    /// displayed latency, but the two paths disagreed about a number the state
+    /// machine had already decided.
+    #[test]
+    fn the_low_recover_trim_does_not_round_trip_through_the_output_domain() {
+        // A ratio far enough from 1 that the round trip loses samples, and an
+        // overshoot large enough for the trim to be non-zero.
+        let ratio = 1.05_f64;
+        let plan = compute_low_recover_settle_trim_plan(60_000, 48_000, 1024, ratio, 8);
+        assert!(
+            plan.desired_consume_input_samples > 0,
+            "the fixture must actually produce a trim"
+        );
+        let round_tripped =
+            output_to_input_domain_samples(plan.desired_consume_output_samples, ratio);
+        assert_ne!(
+            round_tripped, plan.desired_consume_input_samples,
+            "fixture is only meaningful if the round trip actually loses samples"
+        );
     }
 
     #[test]

--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -20,16 +20,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::{
     ADAPTIVE_BAND_FAR, AdaptiveResamplingConfig, LOCAL_RESAMPLER_MAX_RELATIVE_RATIO,
     adaptive_runtime::{
-        AdaptiveRuntimeState, FarModeDecision, LatencyMetricTargets, LowRecoverPhase,
-        MAX_INTEGRAL_TERM, PRE_BRIDGE_CALIBRATION_CALLBACKS, adaptive_runtime_state_name,
+        AdaptiveRuntimeState, FarModeStepCtx, FarModeStepInputs, LatencyMetricTargets,
+        LowRecoverPhase, MAX_INTEGRAL_TERM, PRE_BRIDGE_CALIBRATION_CALLBACKS,
         compute_hard_recover_high_plan, discard_ring_samples, far_mode_band_from_latency,
-        note_refill_or_underrun, output_to_input_domain_samples, paused_rate_adjust,
+        far_mode_step, note_refill_or_underrun, output_to_input_domain_samples, paused_rate_adjust,
         postprocess_interleaved_output, reset_adaptive_runtime, run_adaptive_servo,
-        should_run_adaptive_servo, store_latency_metrics_from_control_available,
-        update_far_mode_state, update_latency_metrics, zero_pad_tail,
+        should_run_adaptive_servo, update_latency_metrics, zero_pad_tail,
     },
-    adaptive_runtime_state_code, adaptive_runtime_state_name_from_code,
-    clamp_ratio_for_local_resampler, local_resampler_ratio_bounds,
+    adaptive_runtime_state_name_from_code, clamp_ratio_for_local_resampler,
+    local_resampler_ratio_bounds,
     resampler_fifo::{RESAMPLER_CHUNK_SIZE, ResamplerFifoEngine},
     ring_buffer_io::{
         flush_ring_buffer, push_samples_drop_overflow, push_samples_with_backpressure,
@@ -1847,70 +1846,31 @@ fn run_pipewire_loop(
                         // State machine on raw: its entry/exit/settle bands are
                         // already the hysteresis; smoothing on top added phase lag
                         // that drove a slow oscillation.
-                        let far_decision = update_far_mode_state(
+                        let far_decision = far_mode_step(
                             &mut runtime_state,
-                            &adaptive_cfg,
-                            current_adaptive_band.load(Ordering::Relaxed) == ADAPTIVE_BAND_FAR,
-                            metrics.control_available,
-                            metrics.smoothed_control_available,
-                            runtime_target_buffer_fill,
-                            callback_input_domain_samples,
-                            effective_resample_ratio,
-                            channel_count as usize,
-                            sample_rate,
-                            actual_output_rate,
-                        );
-                        current_runtime_state.store(
-                            adaptive_runtime_state_code(adaptive_runtime_state_name(
-                                runtime_state.low_recover_phase,
-                                far_decision.hard_recover_high,
-                            )),
-                            Ordering::Relaxed,
-                        );
-                        let mut projected_control_available = metrics.control_available;
-                        if far_decision.recovery_reacquire_pending && far_decision.mute_far_output {
-                            projected_control_available =
-                                projected_control_available.saturating_sub(callback_input_domain_samples);
-                        } else if far_decision.hard_recover_high {
-                            let plan = compute_hard_recover_high_plan(
+                            &FarModeStepCtx {
+                                adaptive_config: &adaptive_cfg,
+                                channel_count: channel_count as usize,
+                                input_sample_rate: sample_rate,
+                                output_sample_rate: actual_output_rate,
+                                runtime_state_code: &current_runtime_state,
+                                latency: LatencyMetricTargets {
+                                    measured_latency_ms_bits: &measured_latency_ms_out,
+                                    control_latency_ms_bits: &control_latency_ms_out,
+                                },
+                            },
+                            FarModeStepInputs {
+                                is_far_band: current_adaptive_band.load(Ordering::Relaxed)
+                                    == ADAPTIVE_BAND_FAR,
+                                control_available: metrics.control_available,
+                                smoothed_control_available: metrics.smoothed_control_available,
+                                target_buffer_fill: runtime_target_buffer_fill,
                                 callback_input_domain_samples,
-                                metrics.control_available,
-                                runtime_target_buffer_fill,
-                                effective_resample_ratio,
-                                channel_count as usize,
-                            );
-                            projected_control_available = projected_control_available
-                                .saturating_sub(plan.desired_consume_input_samples);
-                        } else if far_decision.hold_low_recover {
-                            let trim_input_samples = output_to_input_domain_samples(
-                                far_decision.low_recover_trim_output_samples,
-                                effective_resample_ratio,
-                            );
-                            let muted_consume_input_samples =
-                                if far_decision.mute_far_output && far_decision.consume_while_muted {
-                                    callback_input_domain_samples
-                                } else {
-                                    0
-                                };
-                            projected_control_available = projected_control_available
-                                .saturating_sub(
-                                    trim_input_samples.saturating_add(muted_consume_input_samples),
-                                );
-                        }
-                        // Fold in the pacer's fixed contribution so the displayed
-                        // control/measured latency reflects the true end-to-end
-                        // delay and stays comparable to the target — the same
-                        // adjustment the main `display_control_available` path
-                        // applies. The servo keeps using the pacer-excluded
-                        // `projected_control_available` for its own decisions.
-                        store_latency_metrics_from_control_available(
-                            projected_control_available.saturating_add(pacer_buffer_samples),
-                            channel_count as usize,
-                            sample_rate,
-                            f32::from_bits(graph_latency_for_callback.load(Ordering::Relaxed)),
-                            LatencyMetricTargets {
-                                measured_latency_ms_bits: &measured_latency_ms_out,
-                                control_latency_ms_bits: &control_latency_ms_out,
+                                resample_ratio: effective_resample_ratio,
+                                pacer_buffer_samples,
+                                graph_latency_ms: f32::from_bits(
+                                    graph_latency_for_callback.load(Ordering::Relaxed),
+                                ),
                             },
                         );
                         if far_decision.hold_low_recover {
@@ -2186,68 +2146,33 @@ fn run_pipewire_loop(
                         let samples_to_read = frames_to_read * ch;
 
                         // State machine on raw — see resampler path.
-                        let far_decision: FarModeDecision = update_far_mode_state(
+                        // Straight copy: the ratio is 1.0, so input and output
+                        // domains coincide. Same step as the resampler path.
+                        let far_decision = far_mode_step(
                             &mut runtime_state,
-                            &adaptive_cfg,
-                            current_adaptive_band.load(Ordering::Relaxed) == ADAPTIVE_BAND_FAR,
-                            metrics.control_available,
-                            metrics.smoothed_control_available,
-                            runtime_target_buffer_fill,
-                            callback_input_domain_samples,
-                            1.0,
-                            channel_count as usize,
-                            sample_rate,
-                            actual_output_rate,
-                        );
-                        current_runtime_state.store(
-                            adaptive_runtime_state_code(adaptive_runtime_state_name(
-                                runtime_state.low_recover_phase,
-                                far_decision.hard_recover_high,
-                            )),
-                            Ordering::Relaxed,
-                        );
-                        let mut projected_control_available = metrics.control_available;
-                        if far_decision.recovery_reacquire_pending && far_decision.mute_far_output {
-                            projected_control_available =
-                                projected_control_available.saturating_sub(callback_input_domain_samples);
-                        } else if far_decision.hard_recover_high {
-                            let plan = compute_hard_recover_high_plan(
+                            &FarModeStepCtx {
+                                adaptive_config: &adaptive_cfg,
+                                channel_count: channel_count as usize,
+                                input_sample_rate: sample_rate,
+                                output_sample_rate: actual_output_rate,
+                                runtime_state_code: &current_runtime_state,
+                                latency: LatencyMetricTargets {
+                                    measured_latency_ms_bits: &measured_latency_ms_out,
+                                    control_latency_ms_bits: &control_latency_ms_out,
+                                },
+                            },
+                            FarModeStepInputs {
+                                is_far_band: current_adaptive_band.load(Ordering::Relaxed)
+                                    == ADAPTIVE_BAND_FAR,
+                                control_available: metrics.control_available,
+                                smoothed_control_available: metrics.smoothed_control_available,
+                                target_buffer_fill: runtime_target_buffer_fill,
                                 callback_input_domain_samples,
-                                metrics.control_available,
-                                runtime_target_buffer_fill,
-                                1.0,
-                                channel_count as usize,
-                            );
-                            projected_control_available = projected_control_available
-                                .saturating_sub(plan.desired_consume_input_samples);
-                        } else if far_decision.hold_low_recover {
-                            let muted_consume_input_samples =
-                                if far_decision.mute_far_output && far_decision.consume_while_muted {
-                                    callback_input_domain_samples
-                                } else {
-                                    0
-                                };
-                            projected_control_available = projected_control_available
-                                .saturating_sub(
-                                    far_decision
-                                        .low_recover_trim_input_samples
-                                        .saturating_add(muted_consume_input_samples),
-                                );
-                        }
-                        // Fold in the pacer's fixed contribution so the displayed
-                        // control/measured latency reflects the true end-to-end
-                        // delay and stays comparable to the target — the same
-                        // adjustment the main `display_control_available` path
-                        // applies. The servo keeps using the pacer-excluded
-                        // `projected_control_available` for its own decisions.
-                        store_latency_metrics_from_control_available(
-                            projected_control_available.saturating_add(pacer_buffer_samples),
-                            channel_count as usize,
-                            sample_rate,
-                            f32::from_bits(graph_latency_for_callback.load(Ordering::Relaxed)),
-                            LatencyMetricTargets {
-                                measured_latency_ms_bits: &measured_latency_ms_out,
-                                control_latency_ms_bits: &control_latency_ms_out,
+                                resample_ratio: 1.0,
+                                pacer_buffer_samples,
+                                graph_latency_ms: f32::from_bits(
+                                    graph_latency_for_callback.load(Ordering::Relaxed),
+                                ),
                             },
                         );
                         if far_decision.hold_low_recover {


### PR DESCRIPTION
> **Stacked on #272** (`refactor/pacer-single-consumer`), which touches the same closure. Review or merge that one first; this branch will rebase cleanly onto main afterwards.

The resampler path and the direct-copy path each carried their own copy of the far-mode step — run the state machine, publish the runtime-state code, project the buffer level, store the displayed latency. Roughly **60 lines, twice**, differing only in the ratio they work in.

That's the shape of thing that gets fixed on one path and left on the other. Which is exactly what had happened.

## The drift

The resampler copy recovered the low-recover trim by converting the decision's *output* figure back through the ratio:

```
align(round(input × ratio))    on the way out
round(output / ratio)          on the way back
```

Two roundings and a frame alignment in between — that round trip does not return the input figure the state machine decided, once the ratio is far enough from 1.

`FarModeDecision` already carries `low_recover_trim_input_samples`, which is the **authoritative** one: the output figure is derived from it, not the reverse. The direct path already used it. Both do now.

Only the *displayed* latency was affected, never what was actually consumed — so this is a metrics inaccuracy, not an audio bug. But the two paths disagreed about a number that had already been decided for them, and neither of them needed to be doing the arithmetic.

## Where it lives

`far_mode_step` goes in `adaptive_runtime`, next to the state machine it drives and in the module that exists to hold the callback's pure logic — which is also the best-tested corner of this crate, so it gets tests:

- the runtime-state code the diag plot reads is published;
- the pacer's fixed contribution reaches the displayed latency;
- and, with a ratio of 1.05 and a real overshoot, **the round trip does lose samples** — the fixture asserts that, so the fix is provably not cosmetic.

Two context structs rather than a 15-argument function, so no `#[allow(clippy::too_many_arguments)]`.

## Scope

The process closure goes from **1068 to 994 lines**. Still far too long — this is the *duplication* half of the problem, not the decomposition half. The remaining split (telemetry struct, callback state struct, FFI shims) is a separate and larger change; this one is contained enough to review by reading the diff.

## Risk

613 workspace tests pass, fmt clean. Behaviour changes in exactly one place: the resampler path's displayed low-recover latency now matches what the state machine decided instead of a lossy reconstruction of it. Not verified by ear, and it can't be — the change is to a diagnostic figure, visible in Studio's latency plot during a low-recover episode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
