### PR TITLE
fix(binaural): pinna model rendered the whole left hemisphere as rear

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/hrir.rs
+++ b/omniphony-renderer/renderer/src/binaural/hrir.rs
@@ -168,8 +168,15 @@ impl HrirProvider for ParametricPinnaHrir {
         // delay spread — hence the notch pattern — collapses behind the head:
         // that is the front/back cue. (8) is validated for the frontal half
         // space only; the rear is our extrapolation.
+        //
+        // `abs`, not a [0, 1] clamp: the formula assumes a signed azimuth in
+        // [-180°, 180°], but the grid feeds [0°, 360°), where cos(az/2) goes
+        // negative over the whole left hemisphere. Clamping that to 0 rendered
+        // the entire left side with the collapsed "behind the head" notch
+        // pattern (audibly brighter on the left); |cos(az/2)| is the same even,
+        // 360°-periodic function under both conventions.
         let az = az_deg.to_radians();
-        let front = (0.5 * az).cos().clamp(0.0, 1.0);
+        let front = (0.5 * az).cos().abs();
         let el_term = (90.0 - el_deg).to_radians(); // 0 overhead, grows downward
         let fs_scale = sample_rate as f32 / Self::REF_FS;
         let mut taus = [0.0f32; 5];
@@ -646,6 +653,60 @@ mod tests {
             max_diff < 0.05,
             "fractional-delay discontinuity: {max_diff}"
         );
+    }
+
+    /// Left/right mirror symmetry: every *modelled* provider (synthetic, pinna,
+    /// PRTF) has no ear-specific data, so rendering the mirrored direction must
+    /// swap the ears exactly: `render(az).left == render(-az).right`. Measured
+    /// sets (SAF/SOFA) are exempt — real ears are not symmetric. The grid feeds
+    /// azimuths in [0°, 360°), so the mirror of `az` is `360 - az`; a provider
+    /// that assumes signed azimuths breaks precisely on that convention (heard
+    /// as a brighter left hemisphere with `pinna`).
+    #[test]
+    fn modelled_providers_are_left_right_symmetric() {
+        let providers: Vec<(&str, Box<dyn HrirProvider>)> = vec![
+            ("synthetic", Box::new(SyntheticHrir)),
+            (
+                "pinna",
+                Box::new(ParametricPinnaHrir {
+                    d: ParametricPinnaHrir::D_PB_NH,
+                    depth: 1.0,
+                }),
+            ),
+            (
+                "prtf",
+                Box::new(crate::binaural::prtf::SpagnolPrtfHrir {
+                    depth: 1.0,
+                    freq_scale: 1.0,
+                }),
+            ),
+        ];
+        for (name, p) in &providers {
+            for el in [-30.0f32, 0.0, 30.0] {
+                for az in [10.0f32, 30.0, 90.0, 150.0] {
+                    let a = p.render(az, el, 48_000);
+                    let b = p.render(360.0 - az, el, 48_000);
+                    let d_lr: f32 = a
+                        .left
+                        .iter()
+                        .zip(b.right.iter())
+                        .map(|(x, y)| (x - y) * (x - y))
+                        .sum();
+                    let d_rl: f32 = a
+                        .right
+                        .iter()
+                        .zip(b.left.iter())
+                        .map(|(x, y)| (x - y) * (x - y))
+                        .sum();
+                    assert!(
+                        d_lr < 1e-8 && d_rl < 1e-8,
+                        "{name}: az {az}/{} el {el} not mirror-symmetric \
+                         (L↔R sumsq {d_lr:e} / {d_rl:e})",
+                        360.0 - az
+                    );
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Rotating a pink-noise source around the Z axis with `hrir_source = pinna`, the left half of the circle sounds audibly **brighter** than the right one. The model has no ear-specific data, so it has no business being asymmetric.

`ParametricPinnaHrir::render` computes Brown & Duda's front/back factor as `cos(az/2).clamp(0.0, 1.0)`. Equation (8) assumes a **signed** azimuth in [-180°, 180°], where `cos(az/2)` is naturally 1 ahead, 0 behind and even in `az`. But `HrirSet::new` builds the grid over **[0°, 360°)**: across the entire left hemisphere (az 180-360°) `cos(az/2)` is negative, and the clamp flattened it to 0.

The consequence is not a subtle level error — a zero front factor is exactly the "directly behind the head" case, where the echo-delay spread collapses to its `B_n` minimum. The whole left side was therefore rendered with the rear comb pattern, whose notches sit at higher frequencies: the brightness the listener heard.

Fix: use `|cos(az/2)|`, which is the same even, 360°-periodic function under both azimuth conventions.

## The sanity check

Added `modelled_providers_are_left_right_symmetric`: for every *modelled* provider (`synthetic`, `pinna`, `prtf`), `render(az).left` must equal `render(360 - az).right` exactly, swept across azimuths and elevations. Before the fix it failed on `pinna` at the very first pair (10°/350°, L↔R sum-of-squares ≈ 0.47); `synthetic` and `prtf` already passed.

Measured sets (SAF KEMAR, SOFA) are deliberately **not** covered: `measured.rs` interpolates the measurement points as captured, with no symmetrization anywhere — real ears are not symmetric, so an asymmetry there is data, not a bug.

## Validation

- `cargo test -p renderer`: 309 lib tests pass, `cargo fmt --check` clean.
- Confirmed by ear on the rotating pink-noise test: the left/right brightness difference is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)