### PR TITLE
Stop capping the apt install, which turned a slow mirror into a failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    # Generous because the dependency install depends on GitHub's Ubuntu
+    # mirror, which has days where it delivers a 27 MB package at a few
+    # hundred kB/s. 45 minutes proved too tight on such a day. This is a
+    # backstop against a genuine stall, not a performance target.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,16 @@ jobs:
       # whole workspace links exactly as in the release build (cheap, robust).
       - name: Install Linux system dependencies
         run: |
-          # Both of these reach out to Launchpad, and both can hang rather
-          # than fail when it is unwell — `add-apt-repository` fetches the
-          # signing key and the index with no timeout of its own. The retry
-          # loops below are useless against a hang (a command that never
-          # returns never reaches the next attempt), so each call is bounded:
-          # that is what turns a stall into a retry, and a bad day into a
-          # failed job instead of one that sits there for hours.
+          # The two metadata calls below reach Launchpad and can hang rather
+          # than fail when it is unwell, so each is bounded: a retry loop is
+          # useless against a command that never returns.
+          #
+          # The install is NOT capped, deliberately. The archive mirror is
+          # often merely slow — a 27 MB webkit fetch crawling at a few hundred
+          # kB/s is not a stall, and a per-command cap turns a slow run into a
+          # failed one (it did: exit 124 mid-download). `timeout-minutes` on
+          # the job is the right backstop for a genuine stall; here we only
+          # retry, so a dropped download gets another go.
           for attempt in 1 2 3; do
             if sudo timeout 180 add-apt-repository ppa:pipewire-debian/pipewire-upstream -y; then
               break
@@ -93,14 +96,23 @@ jobs:
             fi
             sleep 10
           done
-          sudo timeout 600 apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libssl-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libpipewire-0.3-dev \
-            pkg-config
+          for attempt in 1 2 3; do
+            if sudo apt-get install -y \
+              libwebkit2gtk-4.1-dev \
+              libssl-dev \
+              libgtk-3-dev \
+              libayatana-appindicator3-dev \
+              librsvg2-dev \
+              libpipewire-0.3-dev \
+              pkg-config; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "apt-get install failed after $attempt attempts" >&2
+              exit 1
+            fi
+            sleep 10
+          done
 
       # ── Rust: build + test (strict gate) ──────────────────────────────────
       # No --locked: omniphony-renderer/Cargo.lock is gitignored (matches


### PR DESCRIPTION
Follow-up to #274, which I got partly wrong.

## What #274 assumed, and what the log says

#274 bounded every apt call, on the theory that the step was hanging on `add-apt-repository` talking to Launchpad. Two of those bounds were right. The third made things worse.

The next run on #271 died like this:

```
10:44:57  Get:135 ... libwebkit2gtk-4.1-0 amd64 ... [27.3 MB]
10:46:46  ##[error]Process completed with exit code 124.
```

Exit 124 is `timeout` killing the command — and it wasn't Launchpad. Both metadata calls succeeded; this is `apt-get install`, killed by my `timeout 600` **while it was still downloading**.

The timestamps also correct the original diagnosis: 22 seconds for a 1.1 MB package, seconds apiece for tiny ones. The Ubuntu archive mirror was simply slow. So what I read as a hang was very likely a crawling download all along, and the cap converted "slow but would finish" into "fails".

## The change

- Keep `timeout 180` on `add-apt-repository` and `apt-get update` — those genuinely hang, and a retry loop can't help a command that never returns.
- **Drop the cap on `apt-get install`.** It makes progress; capping it punishes a slow day. `timeout-minutes: 45` on the job is the right backstop for a real stall.
- Give the install the same 3-attempt retry as its neighbours, so a dropped connection gets another go instead of failing the run.

## What's still true from #274

The job-level `timeout-minutes` were the genuinely valuable part and they stay: before them, a stall ran until GitHub's six-hour ceiling. That's what turned a slow mirror into a PR blocked all afternoon.

If this recurs, the durable fix is to stop needing the PPA at all — it exists because ubuntu-22.04 ships PipeWire 0.3.48 and pipewire-rs 0.9.x needs ≥ 0.3.65, and ubuntu-24.04 ships new enough. That's a runner bump with its own risk surface, and a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
