### PR TITLE
Let the telemetry publish its own latency picture

### DIFF
--- a/omniphony-renderer/audio_output/src/output_telemetry.rs
+++ b/omniphony-renderer/audio_output/src/output_telemetry.rs
@@ -15,7 +15,7 @@
 //! the lock-free diag registry stores.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 #[derive(Clone)]
 pub struct OutputTelemetry {
@@ -281,5 +281,200 @@ impl OutputTelemetry {
 impl Default for OutputTelemetry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// One callback's latency picture, in the units the callback already has.
+///
+/// `control_ms` and `rate_adjust` arrive ready-made from the metrics update and
+/// the servo; the three components arrive as sample counts because that is what
+/// the ring, the FIFO and the resampler report.
+pub struct LatencySample {
+    /// Smoothed control level, pacer contribution already folded in.
+    pub smoothed_control_available: usize,
+    pub control_latency_ms: f32,
+    /// Servo ratio, published as ppm deviation from 1.0.
+    pub rate_adjust: f32,
+    /// The three components of `control_available`, plotted separately.
+    pub avail_input_samples: usize,
+    pub output_fifo_input_domain_samples: usize,
+    pub resampler_pending_input_samples: usize,
+}
+
+fn samples_to_ms(samples: usize, channel_count: u32, sample_rate: u32) -> f32 {
+    if channel_count > 0 && sample_rate > 0 {
+        samples as f32 / channel_count as f32 / sample_rate as f32 * 1000.0
+    } else {
+        0.0
+    }
+}
+
+impl OutputTelemetry {
+    /// Publish one callback's latency picture.
+    ///
+    /// Every value lands **twice**: as `f32` bits, which the latency snapshot
+    /// and the OSC meter bundle read, and as `f64` bits, which is the single
+    /// representation the generic diag plot stores. Writing both here is what
+    /// stops the pair from drifting — they are the same number, and a reader
+    /// finding them disagree would have no way to tell which one was right.
+    ///
+    /// The conversion lives here too, so "how many samples is that in
+    /// milliseconds" is answered once rather than by each caller.
+    pub fn publish_latency(&self, sample: &LatencySample, channel_count: u32, sample_rate: u32) {
+        let smoothed_ms = samples_to_ms(
+            sample.smoothed_control_available,
+            channel_count,
+            sample_rate,
+        );
+        self.smoothed_control_latency_ms_bits
+            .store(smoothed_ms.to_bits(), Ordering::Relaxed);
+        self.diag_latency_smoothed_ms_bits
+            .store((smoothed_ms as f64).to_bits(), Ordering::Relaxed);
+
+        self.diag_latency_control_ms_bits.store(
+            (sample.control_latency_ms as f64).to_bits(),
+            Ordering::Relaxed,
+        );
+        self.diag_rate_adjust_ppm_bits.store(
+            (((sample.rate_adjust as f64) - 1.0) * 1e6).to_bits(),
+            Ordering::Relaxed,
+        );
+
+        for (samples, f32_bits, f64_bits) in [
+            (
+                sample.avail_input_samples,
+                &self.avail_input_latency_ms_bits,
+                &self.diag_latency_avail_input_ms_bits,
+            ),
+            (
+                sample.output_fifo_input_domain_samples,
+                &self.output_fifo_latency_ms_bits,
+                &self.diag_latency_output_fifo_ms_bits,
+            ),
+            (
+                sample.resampler_pending_input_samples,
+                &self.resampler_pending_latency_ms_bits,
+                &self.diag_latency_resampler_pending_ms_bits,
+            ),
+        ] {
+            let ms = samples_to_ms(samples, channel_count, sample_rate);
+            f32_bits.store(ms.to_bits(), Ordering::Relaxed);
+            f64_bits.store((ms as f64).to_bits(), Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHANNELS: u32 = 8;
+    const RATE: u32 = 48_000;
+
+    fn f32_at(a: &AtomicU32) -> f32 {
+        f32::from_bits(a.load(Ordering::Relaxed))
+    }
+    fn f64_at(a: &AtomicU64) -> f64 {
+        f64::from_bits(a.load(Ordering::Relaxed))
+    }
+
+    /// Every latency value is published twice — `f32` bits for the snapshot and
+    /// the OSC bundle, `f64` bits for the diag plot — and the two must be the
+    /// same number. A reader finding them disagree has no way to tell which one
+    /// is right, so the pairing is the property worth pinning.
+    #[test]
+    fn each_latency_value_is_published_in_both_representations() {
+        let t = OutputTelemetry::new();
+        // One full second of audio in each component, so the expected value is
+        // 1000 ms and an accidental unit slip would be obvious.
+        let one_second = (CHANNELS * RATE) as usize;
+        t.publish_latency(
+            &LatencySample {
+                smoothed_control_available: one_second,
+                control_latency_ms: 12.5,
+                rate_adjust: 1.0,
+                avail_input_samples: one_second,
+                output_fifo_input_domain_samples: one_second / 2,
+                resampler_pending_input_samples: 0,
+            },
+            CHANNELS,
+            RATE,
+        );
+
+        for (f32_bits, f64_bits, expected, what) in [
+            (
+                &t.smoothed_control_latency_ms_bits,
+                &t.diag_latency_smoothed_ms_bits,
+                1000.0,
+                "smoothed",
+            ),
+            (
+                &t.avail_input_latency_ms_bits,
+                &t.diag_latency_avail_input_ms_bits,
+                1000.0,
+                "avail input",
+            ),
+            (
+                &t.output_fifo_latency_ms_bits,
+                &t.diag_latency_output_fifo_ms_bits,
+                500.0,
+                "output FIFO",
+            ),
+            (
+                &t.resampler_pending_latency_ms_bits,
+                &t.diag_latency_resampler_pending_ms_bits,
+                0.0,
+                "resampler pending",
+            ),
+        ] {
+            assert_eq!(f32_at(f32_bits), expected, "{what} (f32 view)");
+            assert_eq!(f64_at(f64_bits), expected as f64, "{what} (f64 view)");
+        }
+
+        assert_eq!(f64_at(&t.diag_latency_control_ms_bits), 12.5);
+        // The servo ratio is published as ppm deviation, so unity is zero.
+        assert_eq!(f64_at(&t.diag_rate_adjust_ppm_bits), 0.0);
+    }
+
+    /// A ratio above unity must read as a positive ppm deviation, not as the
+    /// ratio itself — the plot's axis is deviation.
+    #[test]
+    fn the_rate_adjust_is_published_as_ppm_deviation() {
+        let t = OutputTelemetry::new();
+        t.publish_latency(
+            &LatencySample {
+                smoothed_control_available: 0,
+                control_latency_ms: 0.0,
+                rate_adjust: 1.000_1,
+                avail_input_samples: 0,
+                output_fifo_input_domain_samples: 0,
+                resampler_pending_input_samples: 0,
+            },
+            CHANNELS,
+            RATE,
+        );
+        let ppm = f64_at(&t.diag_rate_adjust_ppm_bits);
+        assert!((ppm - 100.0).abs() < 0.5, "expected ~100 ppm, got {ppm}");
+    }
+
+    /// A zero rate or channel count must not produce NaN or a division trap —
+    /// the callback publishes before the format is negotiated.
+    #[test]
+    fn an_unconfigured_format_publishes_zero_rather_than_nan() {
+        let t = OutputTelemetry::new();
+        t.publish_latency(
+            &LatencySample {
+                smoothed_control_available: 4096,
+                control_latency_ms: 0.0,
+                rate_adjust: 1.0,
+                avail_input_samples: 4096,
+                output_fifo_input_domain_samples: 4096,
+                resampler_pending_input_samples: 4096,
+            },
+            0,
+            0,
+        );
+        assert_eq!(f32_at(&t.smoothed_control_latency_ms_bits), 0.0);
+        assert_eq!(f32_at(&t.avail_input_latency_ms_bits), 0.0);
     }
 }

--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -17,7 +17,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::output_telemetry::OutputTelemetry;
+use crate::output_telemetry::{LatencySample, OutputTelemetry};
 use crate::{
     ADAPTIVE_BAND_FAR, AdaptiveResamplingConfig, LOCAL_RESAMPLER_MAX_RELATIVE_RATIO,
     adaptive_runtime::{
@@ -1003,15 +1003,6 @@ fn run_pipewire_loop(
     let output_resampler_pending_input_samples_for_callback = telemetry
         .output_resampler_pending_input_samples_bits
         .clone();
-    let diag_latency_smoothed_ms_for_callback = telemetry.diag_latency_smoothed_ms_bits.clone();
-    let diag_latency_control_ms_for_callback = telemetry.diag_latency_control_ms_bits.clone();
-    let diag_rate_adjust_ppm_for_callback = telemetry.diag_rate_adjust_ppm_bits.clone();
-    let diag_latency_avail_input_ms_for_callback =
-        telemetry.diag_latency_avail_input_ms_bits.clone();
-    let diag_latency_output_fifo_ms_for_callback =
-        telemetry.diag_latency_output_fifo_ms_bits.clone();
-    let diag_latency_resampler_pending_ms_for_callback =
-        telemetry.diag_latency_resampler_pending_ms_bits.clone();
     let cumulative_written_for_callback = telemetry.cumulative_written_input_samples.clone();
     let cumulative_drained_for_callback = telemetry.cumulative_drained_input_samples.clone();
     let input_clock_us_for_callback = input_clock_us.clone();
@@ -1387,60 +1378,23 @@ fn run_pipewire_loop(
                     // target. The servo keeps tracking the pacer-excluded
                     // `metrics.smoothed_control_available`; only the displayed
                     // value changes here.
-                    let smoothed_display_available =
-                        metrics.smoothed_control_available.saturating_add(pacer_buffer_samples);
-                    let smoothed_control_latency_ms = if channel_count > 0 && sample_rate > 0 {
-                        smoothed_display_available as f32
-                            / channel_count as f32
-                            / sample_rate as f32
-                            * 1000.0
-                    } else {
-                        0.0
-                    };
-                    telemetry.smoothed_control_latency_ms_bits
-                        .store(smoothed_control_latency_ms.to_bits(), Ordering::Relaxed);
-                    // DIAG: f64-encoded mirrors of the latency / rate signals
-                    // so the generic diag plot can graph them alongside any
-                    // other registered metric on the same time scale.
-                    diag_latency_smoothed_ms_for_callback.store(
-                        (smoothed_control_latency_ms as f64).to_bits(),
-                        Ordering::Relaxed,
+                    telemetry.publish_latency(
+                        &LatencySample {
+                            smoothed_control_available: metrics
+                                .smoothed_control_available
+                                .saturating_add(pacer_buffer_samples),
+                            control_latency_ms: metrics.control_latency_ms,
+                            rate_adjust: f32::from_bits(
+                                rate_adjust_for_callback.load(Ordering::Relaxed),
+                            ),
+                            avail_input_samples: available,
+                            output_fifo_input_domain_samples:
+                                output_fifo_input_domain_samples_raw,
+                            resampler_pending_input_samples: pending_resampler_input_samples,
+                        },
+                        channel_count,
+                        sample_rate,
                     );
-                    let control_latency_ms_now = metrics.control_latency_ms;
-                    diag_latency_control_ms_for_callback.store(
-                        (control_latency_ms_now as f64).to_bits(),
-                        Ordering::Relaxed,
-                    );
-                    let rate_adjust_now =
-                        f32::from_bits(rate_adjust_for_callback.load(Ordering::Relaxed));
-                    diag_rate_adjust_ppm_for_callback.store(
-                        (((rate_adjust_now as f64) - 1.0) * 1e6).to_bits(),
-                        Ordering::Relaxed,
-                    );
-                    // Publish the three components of `control_available` as ms so
-                    // they can be plotted independently in the Studio control plot.
-                    let samples_to_ms = |samples: usize| -> f32 {
-                        if channel_count > 0 && sample_rate > 0 {
-                            samples as f32 / channel_count as f32 / sample_rate as f32 * 1000.0
-                        } else {
-                            0.0
-                        }
-                    };
-                    let avail_input_ms = samples_to_ms(available);
-                    let output_fifo_ms = samples_to_ms(output_fifo_input_domain_samples_raw);
-                    let resampler_pending_ms = samples_to_ms(pending_resampler_input_samples);
-                    telemetry.avail_input_latency_ms_bits.store(avail_input_ms.to_bits(), Ordering::Relaxed);
-                    telemetry.output_fifo_latency_ms_bits.store(output_fifo_ms.to_bits(), Ordering::Relaxed);
-                    telemetry.resampler_pending_latency_ms_bits
-                        .store(resampler_pending_ms.to_bits(), Ordering::Relaxed);
-                    // f64 mirrors for the generic diag plot (replaces the
-                    // standalone components plot).
-                    diag_latency_avail_input_ms_for_callback
-                        .store((avail_input_ms as f64).to_bits(), Ordering::Relaxed);
-                    diag_latency_output_fifo_ms_for_callback
-                        .store((output_fifo_ms as f64).to_bits(), Ordering::Relaxed);
-                    diag_latency_resampler_pending_ms_for_callback
-                        .store((resampler_pending_ms as f64).to_bits(), Ordering::Relaxed);
                     // Band classification feeds the low-recover state machine: use
                     // raw control_available so the hysteresis bands act on the real
                     // buffer level. (The servo gets the smoothed value separately.)


### PR DESCRIPTION
> **Stacked on #277.** Review or merge that first; this rebases cleanly onto main afterwards.

First slice off the process closure. I went looking for the cleanest separable block rather than attempting the whole thing, and it turned up a duplication worth naming.

## What it found

Fifty-four lines in the middle of the audio callback computed six latency figures and stored **each one twice**:

- as `f32` bits, which the latency snapshot and the OSC meter bundle read
- as `f64` bits, which is the single representation the generic diag plot stores

Twelve stores for six numbers, with the pairing maintained by hand and nothing to catch a half-updated pair. They *are* the same number — a reader finding the two views disagree would have no way to tell which one was right.

## The change

`OutputTelemetry` publishes them, since it already owns both sets of atomics (from #277). The samples-to-milliseconds conversion moves with it: the callback carried a local closure for it, and "how many samples is that in milliseconds" is better answered once than at each call site.

The closure goes from **994 to 957 lines**, and six now-dead `Arc` clone bindings go with it.

## Tests

Three, aimed at the properties rather than the arithmetic:

- **both representations of every value agree** — the pairing is the whole point;
- the servo ratio is published as **ppm deviation**, not as the ratio (the plot's axis is deviation, and 1.0 must read as 0);
- an unconfigured format — zero rate, zero channels, which is what the callback sees before negotiation — yields **zero rather than NaN**.

## Verification

The diag metric names are the wire contract with Studio's plot, so they were diffed again rather than trusted: the same 17, unchanged.

621 workspace tests pass, fmt clean.

## Scope, honestly

This is one slice, not the decomposition. The closure is still 957 lines and its centre of mass is untouched: the resampler-vs-direct arm is ~580 of them, and #273 already shared the far-mode step out of it. What remains there is genuinely divergent (one path resamples, the other copies), so the next useful step is probably the callback-state struct the audit suggested — a much larger change, and one I'd rather propose than start unannounced.

## Risk

Nothing audible changed. What could break is the diag plot, and that's checkable in Studio in a few seconds: open it and confirm all 17 traces still populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
