### PR TITLE
fix(output): keep the PipeWire output stream on the device that was asked for

### DIFF
--- a/omniphony-renderer/audio_output/src/pipewire.rs
+++ b/omniphony-renderer/audio_output/src/pipewire.rs
@@ -107,6 +107,37 @@ fn to_pipewire_position(name: &str) -> String {
     }
 }
 
+/// Properties that pin the output stream to `target`.
+///
+/// Four properties, because stating the device once is not enough:
+///
+/// - `target.object` is what WirePlumber 0.5 resolves first; `node.target` is
+///   the deprecated spelling it only falls back to. The input side already
+///   states both (`build_pipewire_bridge_capture_stream_properties`).
+/// - `node.dont-move` makes the session manager ignore a `target.node` entry
+///   in the default metadata. Any mixer offering "play on the default device"
+///   writes `target.node = -1` there, and that entry outranks both properties
+///   above — the stream then leaves the requested device without a word.
+/// - `node.dont-fallback` forbids the consolation prize: when the requested
+///   device cannot be linked, the stream must stay unlinked rather than land
+///   on the default sink.
+///
+/// The last two matter because of what the default sink can be. Omniphony
+/// publishes its own bridge input sink, and a machine that plays through
+/// Omniphony has it set as the default: falling back there loops the rendered
+/// output straight back into the decoder input, and — since that node drives
+/// the graph it is triggered by — hands the output stream a clock that only
+/// this stream keeps alive. The ring then stops draining altogether, which
+/// reads as an endless "Buffer drain timeout" and total silence.
+fn output_target_properties(target: &str) -> [(&'static str, &str); 4] {
+    [
+        ("target.object", target),
+        ("node.target", target),
+        ("node.dont-move", "true"),
+        ("node.dont-fallback", "true"),
+    ]
+}
+
 // Buffer size: 4 seconds of audio at 48kHz, 16 channels
 const BUFFER_SIZE: usize = 48000 * 16 * 4;
 
@@ -876,8 +907,13 @@ fn run_pipewire_loop(
 
     // Set target output node if specified
     if let Some(ref target) = output_device {
-        props.insert("node.target", target.as_str());
-        log::info!("PipeWire output target: {}", target);
+        for (key, value) in output_target_properties(target) {
+            props.insert(key, value);
+        }
+        log::info!(
+            "PipeWire output target: {} (pinned: no session move, no default-sink fallback)",
+            target
+        );
     }
 
     // Set channel names if provided (e.g., "FL,FR,C,LFE,BL,BR")
@@ -2131,4 +2167,27 @@ fn run_pipewire_loop(
     // happens naturally when these objects are dropped on the owning thread.
     main_loop.stop();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_target_is_stated_in_both_spellings() {
+        let props = output_target_properties("bluez_output.AA_BB_CC.1");
+        assert_eq!(
+            props[0],
+            ("target.object", "bluez_output.AA_BB_CC.1"),
+            "WirePlumber 0.5 resolves target.object first"
+        );
+        assert_eq!(props[1], ("node.target", "bluez_output.AA_BB_CC.1"));
+    }
+
+    #[test]
+    fn output_target_refuses_moves_and_default_fallback() {
+        let props = output_target_properties("alsa_output.pci-0000_00_1f.3.analog-stereo");
+        assert!(props.contains(&("node.dont-move", "true")));
+        assert!(props.contains(&("node.dont-fallback", "true")));
+    }
 }

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -239,6 +239,25 @@ impl DecodeHandler {
     }
 
     pub fn poll_runtime_state(&mut self) -> Result<()> {
+        // Live output changes (device, backend, rate, latency) were applied
+        // from `handle_decoded_frame` alone, so they only landed when the
+        // decoder happened to be producing. Idle — between two programmes, or
+        // in front of a test signal — the request sat in `AudioControl` until
+        // something else made frames flow again, which is why switching the
+        // output device looked like it needed an unrelated apply on the *input*
+        // to take effect. Apply it on the idle tick too. Only the request is
+        // consumed here: an invalidated writer is rebuilt by the next frame,
+        // real or fabricated by the speaker-test idle feed.
+        OutputRuntimeCoordinator::new(
+            &mut self.output,
+            &mut self.runtime,
+            self.audio_control.as_deref(),
+        )
+        .sync_all()?;
+        if self.output.audio_writer.is_none() {
+            self.reset_direct_trigger_wiring();
+        }
+
         if let Some(renderer) = self.spatial_renderer.as_ref() {
             let control = renderer.renderer_control();
             let drc_mode = control.live.read().drc_mode.clone();

--- a/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
+++ b/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
@@ -291,6 +291,14 @@ impl<'a> WriterLifecycleCoordinator<'a> {
         match output_backend {
             #[cfg(target_os = "linux")]
             OutputBackend::Pipewire => {
+                if let Some(reason) = bridge_input_loop_reason(
+                    self.runtime.output_device.as_deref(),
+                    self.input_control
+                        .and_then(|ic| ic.applied_snapshot().node_name)
+                        .as_deref(),
+                ) {
+                    return Err(anyhow!(reason));
+                }
                 // Pre-bridge clock atomic: when no live input is wired up
                 // (file decode path) the writer gets a zero-initialised
                 // atomic that never increments, so `use_pre_bridge_clock`
@@ -384,6 +392,31 @@ impl<'a> WriterLifecycleCoordinator<'a> {
     }
 }
 
+/// Why the requested output device cannot be opened, when it is the very sink
+/// this renderer publishes as its live input.
+///
+/// Playing into our own bridge input is not merely a routing curiosity: the
+/// rendered audio re-enters the decoder, and the output stream ends up clocked
+/// by a node that only the output stream keeps running. The first time the
+/// programme stops, the graph has nothing left to drive it, the output ring
+/// never drains, and the session goes silent behind an endless stream of
+/// back-pressure timeouts. Refuse it while it is still a config error; the
+/// message reaches Studio through `set_audio_error`.
+#[cfg(target_os = "linux")]
+fn bridge_input_loop_reason(
+    output_device: Option<&str>,
+    bridge_input_node: Option<&str>,
+) -> Option<String> {
+    let (device, input_node) = (output_device?, bridge_input_node?);
+    (device == input_node).then(|| {
+        format!(
+            "Output device '{device}' is this renderer's own bridge input sink: \
+             routing the render output back into its own input would loop the audio \
+             and stall the output ring. Select a real playback device."
+        )
+    })
+}
+
 fn effective_audio_state(
     output_backend: OutputBackend,
     input_sample_rate: u32,
@@ -398,5 +431,32 @@ fn effective_audio_state(
         OutputBackend::Coreaudio => (output_rate.unwrap_or(input_sample_rate), "f32le"),
         OutputBackend::File => (output_rate.unwrap_or(input_sample_rate), "f32le"),
         _ => (input_sample_rate, "s24le"),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn playing_into_the_own_bridge_input_is_refused() {
+        let reason = bridge_input_loop_reason(Some("omniphony"), Some("omniphony"))
+            .expect("the loop must be refused");
+        assert!(reason.contains("omniphony"));
+    }
+
+    #[test]
+    fn a_real_device_is_allowed() {
+        assert!(
+            bridge_input_loop_reason(Some("bluez_output.AA_BB_CC.1"), Some("omniphony")).is_none()
+        );
+    }
+
+    #[test]
+    fn nothing_to_compare_allows_the_build() {
+        // No device requested (default sink) or no live input published: the
+        // names cannot be compared, so this guard has no opinion.
+        assert!(bridge_input_loop_reason(None, Some("omniphony")).is_none());
+        assert!(bridge_input_loop_reason(Some("omniphony"), None).is_none());
     }
 }


### PR DESCRIPTION
## Why

A speaker test started from idle was silent, behind an endless

```
WARN audio_output::pipewire] Buffer drain timeout after 2s - dropping 24000 remaining samples to prevent OOM (target=ring)
```

The renderer's output stream was not on the device it had requested. Inspecting the live graph:

```
LINK 730 (omniphony-vbap-renderer) -> 537 (omniphony)     # our own bridge input sink
node 730: node.target = bluez_output.…   but   node.driver-id = 537
node 466 (bluez_output.…): suspended, no links
pactl info: Default Sink = omniphony
pw-metadata: id:730 key:'target.node' value:'-1'
```

The stream stated its device in `node.target` alone. WirePlumber 0.5 resolves `target.object` first, treats `node.target` as the deprecated fallback, and lets a `target.node` entry in the default metadata outrank both — `-1` being what a mixer writes for "follow the default device". The requested device was dropped and the stream fell back to the default sink.

That fallback cannot work here: a machine playing through Omniphony has the bridge input sink as its default, so the rendered output looped back into the decoder input, and the output stream took its clock from a node only that same stream keeps running. The first time the programme stopped, nothing drove the graph, the ring stopped draining, and back-pressure dropped every chunk after a 2 s timeout.

While measuring that, a second, older problem surfaced: switching the output device in Studio does nothing until an unrelated apply on the **input** pane. `OutputRuntimeCoordinator::sync_all()` was only reached from `handle_decoded_frame`, so with no programme playing the request sat unapplied; re-applying the input restarts the capture and the pending output change rides along with the first frame.

## What

1. **Pin the output stream** — state `target.object` and `node.target`, and refuse both escapes with `node.dont-move` / `node.dont-fallback`. An unavailable device now leaves the stream unlinked instead of routed somewhere that cannot work.
2. **Refuse the loop** — fail the writer build when the requested device is the node name the live input published. The message reaches Studio through the existing `set_audio_error` path.
3. **Apply output changes when idle** — consume the request from the idle tick too. Only the request is applied; an invalidated writer is still rebuilt by the next frame, real or fabricated by the speaker-test idle feed, so no device is held open while nothing plays.

## Verification

Pinning, against the exact override that caused the incident — a probe stream carrying the four properties, then `pw-metadata <id> target.node -1`:

```
update: id:423 key:'target.node' value:'-1'
link -> 466 bluez_output.…      # stays on the requested device
```

Idle apply, on an isolated instance (own OSC port, own sink, input paused), device change over `/omniphony/control/config/audio` + apply:

| binary | `Applying requested output device` |
| --- | --- |
| before | never logged |
| after | logged on the next tick |

5 unit tests added. `cargo test --workspace` and `cargo fmt --check` pass.

## Known gaps

- With no device requested at all, the default-sink fallback is still reachable, so the loop is still possible that way. Closing it means reading the default sink from the PipeWire metadata; left out of this PR.
- `node.dont-fallback` means an unavailable device yields silence with no visible cause. It should surface in Studio — follow-up.