### PR TITLE
Break the state-broadcast amplification loop that froze Studio

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -941,20 +941,22 @@ fn apply_head_tracking_packet(packet: &OscPacket, ctrl: &RendererControl) -> boo
                     let current = live.binaural.head_pose;
                     live.binaural.head_pose = live.binaural.tracking.ingest(raw, current);
                 }
-                // Re-broadcast the live state so connected clients (Studio) see the
-                // moving pose. Throttled to ~10 Hz so a 60–100 Hz sensor stream
-                // doesn't resend the full state bundle on every packet. (The 3D
-                // head view rides the lighter 30 Hz `/state/head_pose` channel —
-                // see `maybe_broadcast_head_pose`.)
-                static LAST_BUMP_MS: std::sync::atomic::AtomicU64 =
+                // The moving pose rides the dedicated ~30 Hz `/state/head_pose`
+                // channel (see `maybe_broadcast_head_pose`); the full live-state
+                // bundle only needs to go out when the *stream* (re)starts, so
+                // Studio's tracking gate arms from a snapshot that carries a
+                // valid pose. Bumping it per packet — even throttled — kept the
+                // entire state bundle rebroadcasting for as long as the tracker
+                // ran, and every idle client re-applied an unchanged snapshot.
+                static LAST_PACKET_MS: std::sync::atomic::AtomicU64 =
                     std::sync::atomic::AtomicU64::new(0);
+                const STREAM_RESUME_GAP_MS: u64 = 2_000;
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_millis() as u64)
                     .unwrap_or(0);
-                let last = LAST_BUMP_MS.load(std::sync::atomic::Ordering::Relaxed);
-                if now_ms.saturating_sub(last) >= 100 {
-                    LAST_BUMP_MS.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+                let last = LAST_PACKET_MS.swap(now_ms, std::sync::atomic::Ordering::Relaxed);
+                if last == 0 || now_ms.saturating_sub(last) >= STREAM_RESUME_GAP_MS {
                     ctrl.bump_live_state();
                 }
                 return true;

--- a/omniphony-renderer/orender_engine/src/overlay.rs
+++ b/omniphony-renderer/orender_engine/src/overlay.rs
@@ -347,27 +347,43 @@ fn bump_generation() {
 }
 
 /// Mutate the display state under the lock, then publish (and optionally
-/// persist) the change.
+/// persist) the change — but only if the *broadcast* state actually moved.
 ///
 /// Every display mutator goes through this rather than locking directly, so a
 /// new control cannot be added that changes what is drawn without the change
 /// being announced — the omission that let Studio and an mpv keybind drift
 /// apart silently.
+///
+/// The change check compares [`display_state_json`]'s output before and after
+/// the mutation, so it is exact with respect to what clients receive. Without
+/// it, every idempotent control push (Studio re-syncs its seven overlay prefs
+/// on each snapshot apply) bumped the generation and rebroadcast an unchanged
+/// `/omniphony/state/overlay` — the feedback edge of a broadcast storm.
 fn with_display_state<T>(persist: bool, f: impl FnOnce(&mut OverlayState) -> T) -> Option<T> {
-    let out = {
-        let mut s = overlay().state.lock().ok()?;
-        f(&mut s)
+    let o = overlay();
+    let enabled = o.enabled.load(Ordering::Relaxed);
+    let (out, changed) = {
+        let mut s = o.state.lock().ok()?;
+        let before = display_json_locked(enabled, &s);
+        let out = f(&mut s);
+        let changed = display_json_locked(enabled, &s) != before;
+        (out, changed)
     };
-    bump_generation();
-    if persist {
-        save_prefs();
+    if changed {
+        bump_generation();
+        if persist {
+            save_prefs();
+        }
     }
     Some(out)
 }
 
-/// Master enable/disable (Studio toggle; also gates `is_active`).
+/// Master enable/disable (Studio toggle; also gates `is_active`). Publishes
+/// and persists only on an actual flip.
 pub fn set_enabled(on: bool) {
-    overlay().enabled.store(on, Ordering::Relaxed);
+    if overlay().enabled.swap(on, Ordering::Relaxed) == on {
+        return;
+    }
     bump_generation();
     save_prefs();
 }
@@ -525,6 +541,13 @@ pub fn display_state_json() -> String {
     let Ok(s) = o.state.lock() else {
         return "{}".to_string();
     };
+    display_json_locked(enabled, &s)
+}
+
+/// The serialization behind [`display_state_json`], callable while already
+/// holding the state lock — [`with_display_state`] uses it to compare the
+/// broadcast state before and after a mutation.
+fn display_json_locked(enabled: bool, s: &OverlayState) -> String {
     serde_json::json!({
         "enabled": enabled,
         "labelsEnabled": s.labels_enabled,
@@ -1869,6 +1892,43 @@ mod tests {
         assert_eq!(v["trailTtlMs"], 2500);
         assert_eq!(v["trailMode"], "diffuse");
         assert!((v["trailTeleportThreshold"].as_f64().unwrap() - 0.75).abs() < 1e-6);
+    }
+
+    /// Writing a display pref that is already at that value must NOT bump the
+    /// generation: Studio re-pushes all its overlay prefs on every snapshot
+    /// apply, and an unconditional bump rebroadcast an unchanged
+    /// `/omniphony/state/overlay` per push — the feedback edge of a broadcast
+    /// storm.
+    #[test]
+    fn idempotent_display_writes_do_not_publish() {
+        let _g = guard();
+        // Pin every field to a known value, then replay the exact same writes
+        // the way `syncMpvOverlayPrefs` does on each snapshot apply.
+        set_enabled(true);
+        set_labels_enabled(false);
+        set_objects_visible(true);
+        set_heatmap_enabled(true);
+        set_heatmap_bands(7);
+        set_heatmap_colormap(2);
+        set_trail_config(true, 2500, true, 0.75);
+
+        let before = state_generation();
+        set_enabled(true);
+        set_labels_enabled(false);
+        set_objects_visible(true);
+        set_heatmap_enabled(true);
+        set_heatmap_bands(7);
+        set_heatmap_colormap(2);
+        set_trail_config(true, 2500, true, 0.75);
+        assert_eq!(
+            state_generation(),
+            before,
+            "an unchanged pref replay must not republish"
+        );
+
+        // And an actual change right after still publishes.
+        set_heatmap_bands(8);
+        assert!(state_generation() > before, "a real change must publish");
     }
 
     /// Per-frame scene data must NOT bump the generation: it changes every

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -555,6 +555,19 @@ pub struct AppState {
     /// full layout on apply and again post-recompute).
     #[serde(skip)]
     pub last_layout_state_hash: Option<u64>,
+    /// Hash of the last `state:snapshot_ready` payload actually emitted to the
+    /// webview. The domain appliers merge partial payloads and cannot cheaply
+    /// tell "already at these values" from "changed" (the renderer even
+    /// alternates two `/state/input` documents in one bundle), so the dedup
+    /// happens here, on the one thing that matters: the bytes the webview
+    /// would receive. An identical snapshot is not re-emitted — each emit
+    /// triggers a full `applyInitState` UI rebuild on the other side.
+    #[serde(skip)]
+    pub last_snapshot_emit_hash: Option<u64>,
+    /// Same guard for `overlay:state`: the payload is small but each emit makes
+    /// the frontend re-adopt the display prefs and re-render the switches.
+    #[serde(skip)]
+    pub last_overlay_emit_hash: Option<u64>,
 }
 
 impl AppState {
@@ -806,6 +819,8 @@ impl Default for AppState {
             selected_layout_key: None,
             osc_snapshot_ready: false,
             last_layout_state_hash: None,
+            last_snapshot_emit_hash: None,
+            last_overlay_emit_hash: None,
         }
     }
 }

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -1816,6 +1816,34 @@ fn flush_emit_batch(app: &AppHandle) {
     let _ = app.emit("state:batch", serde_json::json!({ "events": events }));
 }
 
+/// Hash a JSON payload for emit-level dedup. `serde_json` serializes both
+/// struct fields (declaration order) and `Value` maps (sorted keys)
+/// deterministically, so byte-equality of the string is content equality.
+fn emit_payload_hash(payload: &serde_json::Value) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    payload.to_string().hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Skip an emit whose payload is byte-identical to the previous one on the
+/// same channel. The domain appliers merge partial `/state/*` payloads and
+/// cannot cheaply tell "already at these values" from "changed" (the renderer
+/// even alternates two `/state/input` documents in one bundle), so the dedup
+/// happens on the one thing that matters: the bytes the webview would
+/// receive. A `state:snapshot_ready` triggers a full `applyInitState` UI
+/// rebuild over there; `overlay:state` re-renders the display switches — both
+/// are worth a hash compare.
+fn already_emitted(last: &mut Option<u64>, payload: &serde_json::Value) -> bool {
+    let hash = emit_payload_hash(payload);
+    if *last == Some(hash) {
+        return true;
+    }
+    *last = Some(hash);
+    false
+}
+
 fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
     // Per-object mutes preserved across a seek/reset so they can be re-emitted to
     // the frontend after the `source:remove` wipe (see the SpatialFrame arm).
@@ -3123,7 +3151,20 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
         if is_batched_event(event) {
             queue_batched_emit(event, payload);
         } else {
-            let _ = app.emit(event, payload);
+            let duplicate = match event {
+                "state:snapshot_ready" => already_emitted(
+                    &mut state.lock().unwrap().last_snapshot_emit_hash,
+                    &payload,
+                ),
+                "overlay:state" => already_emitted(
+                    &mut state.lock().unwrap().last_overlay_emit_hash,
+                    &payload,
+                ),
+                _ => false,
+            };
+            if !duplicate {
+                let _ = app.emit(event, payload);
+            }
         }
     }
 }

--- a/omniphony-studio/src/mpvOverlay.js
+++ b/omniphony-studio/src/mpvOverlay.js
@@ -40,28 +40,50 @@ export function onOverlayState(fn) {
  * This is the authoritative direction: whatever flipped the value — a Studio
  * switch, an mpv keybind, or the prefs restored at orender startup — Studio
  * ends up showing what is actually drawn.
+ *
+ * The listeners only fan out when a field actually moved: they re-render the
+ * switches and reset the energy-volume rebuild throttle, so replaying them on
+ * an unchanged rebroadcast turns broadcast rate into texture-rebuild rate.
  */
 export function applyOverlayState(payload) {
   if (!payload || typeof payload !== 'object') return;
-  if (typeof payload.enabled === 'boolean') overlay.enabled = payload.enabled;
-  if (typeof payload.objectsVisible === 'boolean') app.objectsVisible = payload.objectsVisible;
-  if (typeof payload.labelsEnabled === 'boolean') app.objectLabelsEnabled = payload.labelsEnabled;
+  // Adopt `value` into `obj[key]`, reporting whether it moved.
+  const adopt = (obj, key, value) => {
+    if (obj[key] === value) return false;
+    obj[key] = value;
+    return true;
+  };
+  let changed = false;
+  if (typeof payload.enabled === 'boolean') {
+    changed = adopt(overlay, 'enabled', payload.enabled) || changed;
+  }
+  if (typeof payload.objectsVisible === 'boolean') {
+    changed = adopt(app, 'objectsVisible', payload.objectsVisible) || changed;
+  }
+  if (typeof payload.labelsEnabled === 'boolean') {
+    changed = adopt(app, 'objectLabelsEnabled', payload.labelsEnabled) || changed;
+  }
   if (typeof payload.heatmapEnabled === 'boolean') {
-    app.objectEnergyHeatmapEnabled = payload.heatmapEnabled;
+    changed = adopt(app, 'objectEnergyHeatmapEnabled', payload.heatmapEnabled) || changed;
   }
   if (Number.isFinite(Number(payload.heatmapBands))) {
-    app.objectEnergyHeatmapBandCount = Math.max(1, Math.min(12, Math.round(Number(payload.heatmapBands))));
+    const bands = Math.max(1, Math.min(12, Math.round(Number(payload.heatmapBands))));
+    changed = adopt(app, 'objectEnergyHeatmapBandCount', bands) || changed;
   }
-  if (typeof payload.trailsEnabled === 'boolean') app.trailsEnabled = payload.trailsEnabled;
+  if (typeof payload.trailsEnabled === 'boolean') {
+    changed = adopt(app, 'trailsEnabled', payload.trailsEnabled) || changed;
+  }
   if (Number.isFinite(Number(payload.trailTtlMs))) {
-    app.trailPointTtlMs = Math.max(500, Math.round(Number(payload.trailTtlMs)));
+    const ttl = Math.max(500, Math.round(Number(payload.trailTtlMs)));
+    changed = adopt(app, 'trailPointTtlMs', ttl) || changed;
   }
   if (payload.trailMode === 'diffuse' || payload.trailMode === 'line') {
-    app.trailRenderMode = payload.trailMode;
+    changed = adopt(app, 'trailRenderMode', payload.trailMode) || changed;
   }
   if (Number.isFinite(Number(payload.trailTeleportThreshold))) {
-    app.trailTeleportThreshold = Number(payload.trailTeleportThreshold);
+    changed = adopt(app, 'trailTeleportThreshold', Number(payload.trailTeleportThreshold)) || changed;
   }
+  if (!changed) return;
   for (const fn of stateListeners) {
     try {
       fn(payload);


### PR DESCRIPTION
## Symptom

Studio froze solid within seconds of use: the WebKit web process pinned at ~100% CPU and grew ~15 MB/s (4.4 GB RSS after ten minutes), whenever a head tracker was streaming.

## The loop (each link measured on a live instance)

1. Every accepted head-tracking packet bumped the live-state generation (throttled 10 Hz) → the **full state bundle** (~30 messages, ~150 KiB/s) rebroadcast continuously for as long as the tracker ran.
2. Studio's domain appliers returned `true` unconditionally, so each `/state/*` message emitted a `state:snapshot_ready` carrying the full serialized AppState → complete `applyInitState` UI rebuild per message (~50/s).
3. Each snapshot apply re-pushed all seven overlay prefs (`syncMpvOverlayPrefs`) → `with_display_state()` bumped the generation without checking for change → `/omniphony/state/overlay` rebroadcast at **345 msg/s with one distinct payload and zero transitions**.
4. Each overlay broadcast re-entered Studio's adoption path, which resets the energy-volume rebuild throttle (the one installed in #88 to fix the WebView memory blow-up) → full 3D texture rebuild per broadcast.

## Fixes — one guard per hop, same defect family ("nobody checked that a change had changed anything")

- **renderer/osc**: bump the live state on tracker stream *edges* (first packet, resume after 2 s silence) instead of per packet — the pose rides the dedicated ~30 Hz `/state/head_pose` channel; the bundle only exists to arm the client's tracking gate.
- **renderer/overlay**: `with_display_state()`/`set_enabled()` compare the broadcast display JSON before/after and publish (and persist) only on a real change.
- **studio host**: dedup `state:snapshot_ready` / `overlay:state` at the emit choke point by payload hash — the appliers merge partials and can't cheaply tell "already at these values" apart (the renderer even alternates two `/state/input` documents in one bundle). Hashes are `#[serde(skip)]` and cleared on reconnect.
- **studio frontend**: `applyOverlayState` adopts field by field and skips the listener fan-out (switch re-render + throttle reset) when nothing moved.

## Verification

Isolated instance (own workflow, port 9003), synthetic tracker at 99 Hz for 6 s plus a resume after a 2.5 s gap:

- state bundle rebroadcasts: **2** (stream start + resume) — was one per 100 ms
- `/state/head_pose`: still ~26 Hz (fast channel untouched)
- 10 rounds of 6 identical overlay control pushes: **0** rebroadcasts after the first round's real changes; one real change still broadcasts
- new test `idempotent_display_writes_do_not_publish`; full `orender_engine` suite (149) and studio host suite (25) green; `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)