### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,7 +20,10 @@ their component actually changed.
 ## 1. Preconditions
 
 - The integration tree (`workflows/integration/omniphony`) is clean and on
-  `main`; no completed work is sitting uncommitted.
+  `main`; no completed work is sitting uncommitted. If integration is parked
+  on another branch (a concurrent session's WIP), do not disturb it: drive
+  the release from a dedicated temporary worktree of `main` instead
+  (`git worktree add <dir> origin/main`) — done that way at 0.5.2.
 - `git fetch origin --tags` exits non-zero because the rolling `integration`
   and `mpv-integration` tags move on every integration build ("would clobber
   existing tag"). That rejection is harmless — the branches and release tags
@@ -118,15 +121,42 @@ standalone `.so`/`.dll`/`.dylib`. Skipped at 0.5.0 and 0.5.1.
 
 ## 7. Optional: mpv-omniphony bundle release
 
-Source lives in `mgth/mpv-omniphony`, assets are published on
-`mgth/Omniphony` under `mpv-v*`. Summary (see the memory fiche and
-`docs/mpv-omniphony.md` for detail): bump `OMNIPHONY_REF` to the new tag in
-its `release.yml`, regenerate `patches/` from the fork's `orender` branch,
-copy `ad_orender.c`, PR to its `main`, tag `vX.Y.Z` there. Its PR CI builds
-against a **mock liborender** — new FFI functions must be added to
-`.github/scripts/mock-liborender.sh` or the tag build fails where the PR
-passed. Pushing workflow-file changes needs the SSH remote
-(`git@github.com-mgth:…`); the HTTPS token lacks the `workflow` scope.
+Cut this whenever the player side changed: patches, launcher behaviour, or a
+liborender ABI addition the player consumes (e.g. the PTS latency
+compensation at 0.5.2). Source lives in `mgth/mpv-omniphony`; its tag build
+publishes the bundles as a **draft on `mgth/Omniphony` under `mpv-vX.Y.Z`**
+(via the `OMNIPHONY_RELEASE_TOKEN` secret).
+
+1. The fork's `orender` branch (main tree `workflows/integration/mpv`, based
+   on the pinned `v0.41.0`) carries everything to ship and is pushed.
+2. In `mpv-omniphony`:
+   - `scripts/regenerate-patches.sh <fork-path>` — regenerates `patches/`
+     from `v0.41.0..orender`. (`patches-master/` is the separate series for
+     the local Dolby Vision FEL build; it has its own regenerate script whose
+     default base ref is stale — base it on the parent of the first fork
+     commit — and it is NOT part of this release.)
+   - `cp <fork>/audio/decode/ad_orender.c src/ad_orender.c` (kept in sync as
+     the regenerate scripts remind).
+   - Bump `OMNIPHONY_REF` in `.github/workflows/release.yml` to the new
+     Omniphony tag — the build compiles liborender **from source at that
+     ref**, so the Omniphony `vX.Y.Z` tag must exist before this repo's tag
+     build runs.
+   - If the liborender ABI gained symbols, extend
+     `.github/scripts/stub-liborender.sh` (successor of the old
+     mock-liborender): dlsym-optional symbols only degrade gracefully in the
+     CI loader tests, but the stub should stay representative of the real
+     surface.
+3. PR to its `main`; merge when its CI is green. Pushing workflow-file
+   changes needs the SSH remote (`git@github.com-mgth:mgth/mpv-omniphony.git`);
+   the HTTPS token lacks the `workflow` scope.
+4. After the Omniphony tag exists: `git tag vX.Y.Z && git push origin vX.Y.Z`
+   in `mpv-omniphony`. Publish the resulting `mpv-vX.Y.Z` draft on
+   `mgth/Omniphony` **not-latest**, notes in the established style.
+5. The local FEL build (`mpvo-fel`, `patches-master/`,
+   `scripts/build-fel-local.sh`) is a dev-only artifact, never released;
+   regenerate it locally whenever the fork's `orender` branch moves
+   (`FEL_RENDERER_DIR` selects which renderer checkout provides the
+   link-time liborender).
 
 ## 8. Post-release checks
 

--- a/omniphony-renderer/orender_ffi/Cargo.toml
+++ b/omniphony-renderer/orender_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orender_ffi"
-version = "0.5.1"
+version = "0.5.2"
 # Edition 2021 (not 2024) so cbindgen sees plain #[no_mangle] and unsafe fn
 # bodies stay implicitly unsafe — simpler for a thin C ABI shim.
 edition = "2021"

--- a/omniphony-studio/package-lock.json
+++ b/omniphony-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omniphony-studio",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omniphony-studio",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@codemirror/language": "^6",
         "@codemirror/legacy-modes": "^6",

--- a/omniphony-studio/package.json
+++ b/omniphony-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniphony-studio",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Visualisation 3D d'objets audio spatialisés via OSC",
   "scripts": {
     "dev": "vite",

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "omniphony-studio"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "flate2",
  "image",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omniphony-studio"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [[bin]]

--- a/omniphony-studio/src-tauri/tauri.conf.json
+++ b/omniphony-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "fr.omniphony.studio",
   "productName": "Omniphony Studio",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173",


### PR DESCRIPTION
Version bump to 0.5.2 across the six release-tracked files, plus the release-process amendments this release taught: the full mpv-omniphony §7 recipe (patch regeneration, `OMNIPHONY_REF` from-source coupling and tag ordering, stub-liborender upkeep, SSH push for workflow files, FEL as dev-only artifact) and the dedicated-worktree fallback when integration is parked on another branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)