### PR TITLE
Share one cell indexer across the gain-table volumes

### DIFF
--- a/omniphony-studio/src/scene/discontinuity-volume.js
+++ b/omniphony-studio/src/scene/discontinuity-volume.js
@@ -22,7 +22,12 @@
 
 import { app } from '../state.js';
 import { EnergyVolume } from './energy-volume-core.js';
-import { VOLUME_REBUILD_INTERVAL_MS, clampVolumeGamma } from './object-energy-shared.js';
+import {
+  VOLUME_REBUILD_INTERVAL_MS,
+  clampVolumeGamma,
+  makeCellIndexer,
+  signaturesEqual,
+} from './object-energy-shared.js';
 import { getDiscontinuityTable } from './speaker-gaintable.js';
 
 const volume = new EnergyVolume();
@@ -33,13 +38,6 @@ export const DISCONTINUITY_SCALE_MAX = 2;
 export const DISCONTINUITY_SCALE_DEFAULT = 0.5;
 
 let lastBuildSig = null;
-function sigEqual(a, b) {
-  if (!a || !b || a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
 
 export function hideDiscontinuityVolume() {
   volume.hide();
@@ -54,25 +52,6 @@ export function discontinuityScale() {
   const raw = Number(app.discontinuityHeatmapScale);
   if (!Number.isFinite(raw) || raw <= 0) return DISCONTINUITY_SCALE_DEFAULT;
   return Math.max(DISCONTINUITY_SCALE_MIN, Math.min(DISCONTINUITY_SCALE_MAX, raw));
-}
-
-function clampIdx(value, n) {
-  if (value < 0) return 0;
-  if (value > n - 1) return n - 1;
-  return value;
-}
-
-function nearestIndex(positions, n, value) {
-  let best = 0;
-  let bestDist = Infinity;
-  for (let i = 0; i < n; i += 1) {
-    const d = Math.abs(positions[i] - value);
-    if (d < bestDist) {
-      bestDist = d;
-      best = i;
-    }
-  }
-  return best;
 }
 
 export function refreshDiscontinuityVolume(nowMs) {
@@ -100,7 +79,7 @@ export function refreshDiscontinuityVolume(nowMs) {
     app.objectEnergyVolumeGammaMip,
     ratio.height, ratio.lower, ratio.width, ratio.rear, ratio.length,
   ];
-  if (sigEqual(sig, lastBuildSig)) return;
+  if (signaturesEqual(sig, lastBuildSig)) return;
 
   const now = Number.isFinite(nowMs) ? nowMs : performance.now();
   const refreshMs = Number(app.volumeRefreshMs) > 0
@@ -110,7 +89,7 @@ export function refreshDiscontinuityVolume(nowMs) {
   app.lastDiscontinuityVolumeAt = now;
   lastBuildSig = sig;
 
-  const { nx, ny, nz, bands, zPositions } = table;
+  const { bands } = table;
   const nbands = bands.length;
   if (nbands < 1) {
     hideDiscontinuityVolume();
@@ -134,25 +113,7 @@ export function refreshDiscontinuityVolume(nowMs) {
     }
     jumps = worst;
   }
-  const nxh = nx - 1;
-  const nyh = ny - 1;
-  const nzh = nz - 1;
-
-  let cachedOh = NaN;
-  let cachedZi = 0;
-  const lookupZi = (oh) => {
-    if (oh === cachedOh) return cachedZi;
-    cachedOh = oh;
-    cachedZi = zPositions
-      ? nearestIndex(zPositions, nz, oh)
-      : clampIdx(Math.round(((oh + 1) * 0.5) * nzh), nz);
-    return cachedZi;
-  };
-  const cellIndex = (ow, od, oh) => {
-    const xi = clampIdx(Math.round(((ow + 1) * 0.5) * nxh), nx);
-    const yi = clampIdx(Math.round(((od + 1) * 0.5) * nyh), ny);
-    return xi + nx * (yi + ny * lookupZi(oh));
-  };
+  const cellIndex = makeCellIndexer(table);
 
   const invScale = 1 / scale;
   volume.update({

--- a/omniphony-studio/src/scene/global-energy-volume.js
+++ b/omniphony-studio/src/scene/global-energy-volume.js
@@ -25,7 +25,12 @@
 
 import { app } from '../state.js';
 import { EnergyVolume } from './energy-volume-core.js';
-import { VOLUME_REBUILD_INTERVAL_MS, clampVolumeGamma } from './object-energy-shared.js';
+import {
+  VOLUME_REBUILD_INTERVAL_MS,
+  clampVolumeGamma,
+  makeCellIndexer,
+  signaturesEqual,
+} from './object-energy-shared.js';
 import { getGlobalEnergyTable } from './speaker-gaintable.js';
 
 const volume = new EnergyVolume();
@@ -41,13 +46,6 @@ export const GLOBAL_ENERGY_SCALE_DEFAULT_DB = 6;
 const SILENCE_AMPLITUDE = 1e-6;
 
 let lastBuildSig = null;
-function sigEqual(a, b) {
-  if (!a || !b || a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
 
 export function hideGlobalEnergyVolume() {
   volume.hide();
@@ -62,25 +60,6 @@ export function globalEnergyScaleDb() {
   const raw = Number(app.globalEnergyHeatmapScaleDb);
   if (!Number.isFinite(raw) || raw <= 0) return GLOBAL_ENERGY_SCALE_DEFAULT_DB;
   return Math.max(GLOBAL_ENERGY_SCALE_MIN_DB, Math.min(GLOBAL_ENERGY_SCALE_MAX_DB, raw));
-}
-
-function clampIdx(value, n) {
-  if (value < 0) return 0;
-  if (value > n - 1) return n - 1;
-  return value;
-}
-
-function nearestIndex(positions, n, value) {
-  let best = 0;
-  let bestDist = Infinity;
-  for (let i = 0; i < n; i += 1) {
-    const d = Math.abs(positions[i] - value);
-    if (d < bestDist) {
-      bestDist = d;
-      best = i;
-    }
-  }
-  return best;
 }
 
 export function refreshGlobalEnergyVolume(nowMs) {
@@ -108,7 +87,7 @@ export function refreshGlobalEnergyVolume(nowMs) {
     app.objectEnergyVolumeGammaMip,
     ratio.height, ratio.lower, ratio.width, ratio.rear, ratio.length,
   ];
-  if (sigEqual(sig, lastBuildSig)) return;
+  if (signaturesEqual(sig, lastBuildSig)) return;
 
   const now = Number.isFinite(nowMs) ? nowMs : performance.now();
   const refreshMs = Number(app.volumeRefreshMs) > 0
@@ -118,7 +97,7 @@ export function refreshGlobalEnergyVolume(nowMs) {
   app.lastGlobalEnergyVolumeAt = now;
   lastBuildSig = sig;
 
-  const { nx, ny, nz, bands, zPositions } = table;
+  const { bands } = table;
   const nbands = bands.length;
   if (nbands < 1) {
     hideGlobalEnergyVolume();
@@ -142,25 +121,7 @@ export function refreshGlobalEnergyVolume(nowMs) {
     for (let i = 0; i < cells; i += 1) total[i] = Math.sqrt(total[i]);
     amplitudes = total;
   }
-  const nxh = nx - 1;
-  const nyh = ny - 1;
-  const nzh = nz - 1;
-
-  let cachedOh = NaN;
-  let cachedZi = 0;
-  const lookupZi = (oh) => {
-    if (oh === cachedOh) return cachedZi;
-    cachedOh = oh;
-    cachedZi = zPositions
-      ? nearestIndex(zPositions, nz, oh)
-      : clampIdx(Math.round(((oh + 1) * 0.5) * nzh), nz);
-    return cachedZi;
-  };
-  const cellIndex = (ow, od, oh) => {
-    const xi = clampIdx(Math.round(((ow + 1) * 0.5) * nxh), nx);
-    const yi = clampIdx(Math.round(((od + 1) * 0.5) * nyh), ny);
-    return xi + nx * (yi + ny * lookupZi(oh));
-  };
+  const cellIndex = makeCellIndexer(table);
 
   const invScale = 1 / scaleDb;
   volume.update({

--- a/omniphony-studio/src/scene/object-energy-shared.js
+++ b/omniphony-studio/src/scene/object-energy-shared.js
@@ -176,6 +176,86 @@ export function objectEnergyLinear(rmsDbfs) {
   return Math.pow(10, db / 10);
 }
 
+// ---------------------------------------------------------------------------
+// Static-field plumbing, shared by the three gain-table volume providers
+// (speaker solo, global energy, discontinuity)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two build signatures element-wise.
+ *
+ * The gain-table fields are STATIC (a precomputed table, no live levels), so a
+ * provider skips the whole n³ resample + texture upload while nothing that
+ * shapes the field changes. Signatures are flat arrays of scalars plus the
+ * table identity, so `===` per element is the whole comparison.
+ */
+export function signaturesEqual(a, b) {
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function clampIdx(value, n) {
+  if (value < 0) return 0;
+  if (value > n - 1) return n - 1;
+  return value;
+}
+
+/** Nearest cell index in a (small) position array, by absolute distance. */
+function nearestIndex(positions, n, value) {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < n; i += 1) {
+    const d = Math.abs(positions[i] - value);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/**
+ * Build the Omniphony-position → gain-table cell lookup for one decoded table.
+ *
+ * Returns `(ow, od, oh) => cellIndex`, matching the volume core's sampler
+ * signature (width, depth, height), where
+ * `gain = bands[band].gains[cellIndex]`.
+ *
+ * The width (x) and depth (y) axes are regular, so their index is a direct
+ * computation. The height (z) axis is not: `cartesian_z_axis`
+ * (`renderer/src/render_backend.rs`) lays a negative half below a positive
+ * half, so the index has to come from the real cell-centre positions the table
+ * ships. That lookup is memoised on the last height asked for — the volume core
+ * walks depth innermost with the height held constant, so one lookup serves a
+ * whole row.
+ */
+export function makeCellIndexer(table) {
+  const { nx, ny, nz, zPositions } = table;
+  const nxh = nx - 1;
+  const nyh = ny - 1;
+  const nzh = nz - 1;
+
+  let cachedOh = NaN;
+  let cachedZi = 0;
+  const lookupZi = (oh) => {
+    if (oh === cachedOh) return cachedZi;
+    cachedOh = oh;
+    cachedZi = zPositions
+      ? nearestIndex(zPositions, nz, oh)
+      : clampIdx(Math.round(((oh + 1) * 0.5) * nzh), nz);
+    return cachedZi;
+  };
+
+  return (ow, od, oh) => {
+    const xi = clampIdx(Math.round(((ow + 1) * 0.5) * nxh), nx);
+    const yi = clampIdx(Math.round(((od + 1) * 0.5) * nyh), ny);
+    return xi + nx * (yi + ny * lookupZi(oh));
+  };
+}
+
 // Reusable scratch list of active objects, refilled each tick (no per-tick alloc
 // once the array has grown to its working size). Shared across both renderers —
 // only one runs per frame, so there is no contention.

--- a/omniphony-studio/src/scene/speaker-solo-volume.js
+++ b/omniphony-studio/src/scene/speaker-solo-volume.js
@@ -22,7 +22,9 @@ import {
   VOLUME_REBUILD_INTERVAL_MS,
   clampVolumeGamma,
   colormapIndex,
+  makeCellIndexer,
   objectEnergyColor,
+  signaturesEqual,
 } from './object-energy-shared.js';
 import { getSpeakerGainTable } from './speaker-gaintable.js';
 
@@ -31,13 +33,6 @@ const volume = new EnergyVolume();
 // Signature of the last built field. The speaker field is static, so we skip the
 // whole rebuild while nothing that shapes it changes (see refreshSpeakerSoloVolume).
 let lastBuildSig = null;
-function sigEqual(a, b) {
-  if (!a || !b || a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
 
 // Audible-frequency span used to place each band on the colour gradient (log scale).
 const FMIN_HZ = 20;
@@ -51,26 +46,6 @@ export function hideSpeakerSoloVolume() {
 
 export function clearSpeakerSoloVolume() {
   volume.dispose();
-}
-
-function clampIdx(value, n) {
-  if (value < 0) return 0;
-  if (value > n - 1) return n - 1;
-  return value;
-}
-
-/** Nearest cell index in a (small) position array, by absolute distance. */
-function nearestIndex(positions, n, value) {
-  let best = 0;
-  let bestDist = Infinity;
-  for (let i = 0; i < n; i += 1) {
-    const d = Math.abs(positions[i] - value);
-    if (d < bestDist) {
-      bestDist = d;
-      best = i;
-    }
-  }
-  return best;
 }
 
 /** Position of a band on the [0,1] colour gradient from its log-frequency centre. */
@@ -120,7 +95,7 @@ export function refreshSpeakerSoloVolume(nowMs) {
     app.objectEnergyVolumeGammaMip,
     ratio.height, ratio.lower, ratio.width, ratio.rear, ratio.length,
   ];
-  if (sigEqual(sig, lastBuildSig)) return;
+  if (signaturesEqual(sig, lastBuildSig)) return;
 
   const now = Number.isFinite(nowMs) ? nowMs : performance.now();
   const refreshMs = Number(app.volumeRefreshMs) > 0 ? Number(app.volumeRefreshMs) : VOLUME_REBUILD_INTERVAL_MS;
@@ -130,30 +105,9 @@ export function refreshSpeakerSoloVolume(nowMs) {
   app.lastSpeakerSoloVolumeAt = now;
   lastBuildSig = sig;
 
-  const { nx, ny, nz, bands, zPositions } = table;
+  const { bands } = table;
   const nbands = bands.length;
-  const nxh = nx - 1;
-  const nyh = ny - 1;
-  const nzh = nz - 1;
-
-  // Height (z) axis is non-uniform → map omni height through the real cell-centre
-  // positions (see the cartesian_z_axis note); memoised across the inner depth loop.
-  let cachedOh = NaN;
-  let cachedZi = 0;
-  const lookupZi = (oh) => {
-    if (oh === cachedOh) return cachedZi;
-    cachedOh = oh;
-    cachedZi = zPositions
-      ? nearestIndex(zPositions, nz, oh)
-      : clampIdx(Math.round(((oh + 1) * 0.5) * nzh), nz);
-    return cachedZi;
-  };
-  const cellIndex = (ow, od, oh) => {
-    const xi = clampIdx(Math.round(((ow + 1) * 0.5) * nxh), nx);
-    const yi = clampIdx(Math.round(((od + 1) * 0.5) * nyh), ny);
-    const zi = lookupZi(oh);
-    return xi + nx * (yi + ny * zi);
-  };
+  const cellIndex = makeCellIndexer(table);
 
   const common = {
     resolution: app.objectEnergyHeatmapResolution,


### PR DESCRIPTION
Phase 1 of the Studio Rust/Web rebalancing plan.

## What this changes

The three static volume providers — per-speaker heatmap (`speaker-solo-volume.js`), global energy (`global-energy-volume.js`) and discontinuity (`discontinuity-volume.js`) — each carried their own copy of `sigEqual`, `clampIdx`, `nearestIndex` and the `lookupZi`/`cellIndex` pair. Four identical helpers, three times over, with the non-obvious part explained in only one of them: the height axis is non-uniform (`cartesian_z_axis` lays a negative half below a positive half), so its index has to come from the table's real cell-centre positions, and the lookup is memoised because the volume core walks depth innermost with the height held constant.

Those move to `object-energy-shared.js` as `signaturesEqual()` and `makeCellIndexer(table)`, documented once.

Pure deduplication: same arithmetic, same memoisation, same signature semantics. No behaviour change. -147/+103 lines.

## Why Phase 1 landed as a refactor and not the planned perf work

The plan's two Phase 1 items were written against an audit that does not match the current tree:

- **1.1 — LUT for `inverseMapRoomDepth()`.** The premise was that the 28-iteration bisection runs per voxel (64³ = 262k). It does not. `energy-volume-core.js` inverts the warp **once per depth slice** into `depthByI` (L243-246) and the voxel loop (L263-288) only reads that array — `n` inversions, not `n³`, which the file header already states. At n=64 and a 160 ms rebuild that is ~400 bisections/s. A LUT would optimise something that costs nothing.

  Worth noting had it been needed: a 1e-3 LUT would have been too coarse to substitute everywhere. `scenePositionToNormalizedOmniphony()` feeds stored cartesian values and relies on the bisection's ~1.86e-9 accuracy to stay under the 1e-5 `snapToCardinal` tolerance (see the comment at `coordinates.js:189-201`).

- **1.2 — O(n) searches in voxel loops.** `nearestIndex()` is not called per voxel: each provider memoises it on the last height, and the core's loop order (width → height → depth) holds the height constant across the whole inner row, so it runs `n²` times, not `n³` — and only when the build signature changes, which for a static field is rare.

## The hotspot the audit missed

If per-frame Studio CPU is the concern, the evidence points elsewhere: `object-energy-volume.js` is the one volume with no signature gate, because its field tracks live object levels. It rebuilds every 160 ms and its `sampleEnergy` callback runs `n³ × objectCount` times — at the default resolution of 64 (`state.js:525`) that is 262k voxels × one inverse-square term per active object, per rebuild, through a per-voxel closure call.

The plan lists rewriting that loop as out of scope "revisit only with profiling evidence" — but that exclusion was written on the assumption the depth warp was the cost. Not touched here; flagging it as the candidate that would actually need a profile.

## Verification

- `npm run build` green.
- `npm run lint:dead` (knip) reports no new unused exports; the flagged ones in `object-energy-shared.js` are pre-existing.
- Not exercised against a live renderer yet — the three affected heatmaps (per-speaker, global energy, discontinuity) still need a click-through to confirm the volumes render identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)