### PR TITLE
Shared geometry crate, the frame bug it exposed, and the renderer migration (#294 folded in)

### DIFF
--- a/omniphony-renderer/Cargo.toml
+++ b/omniphony-renderer/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["renderer", "audio_input", "audio_output", "sys", "bridge_api", "spdif", "runtime_control", "orender_engine", "orender_ffi", "host_audio", "example_backend", "script_backend", "reference_bridge", "dsp_fixtures"]
+members = ["renderer", "audio_input", "audio_output", "sys", "bridge_api", "spdif", "runtime_control", "orender_engine", "orender_ffi", "host_audio", "example_backend", "script_backend", "reference_bridge", "dsp_fixtures", "omniphony-geometry"]
 resolver = "2"
 
 [package]

--- a/omniphony-renderer/omniphony-geometry/Cargo.toml
+++ b/omniphony-renderer/omniphony-geometry/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "omniphony-geometry"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-or-later"
+description = "Canonical coordinate, angle and room-geometry math shared by the Omniphony renderer and Studio"
+repository = "https://github.com/mgth/Omniphony"
+rust-version = "1.87.0"
+
+# Deliberately dependency-free.
+#
+# This crate is consumed from OUTSIDE the renderer workspace (the Studio's
+# `src-tauri`, which is its own cargo project). Anything pulled in here lands in
+# the Studio build too, so the renderer's DSP dependencies (realfft, rayon, sys)
+# must never reach this crate. Keep it std-only.
+[dependencies]

--- a/omniphony-renderer/omniphony-geometry/src/lib.rs
+++ b/omniphony-renderer/omniphony-geometry/src/lib.rs
@@ -1,0 +1,590 @@
+//! Canonical coordinate, angle and room-geometry math for Omniphony.
+//!
+//! Before this crate the same handful of formulas existed in five places: four
+//! copies of the room depth warp inside the renderer workspace
+//! (`renderer::speaker_layout`, `renderer::render_backend::room_transform`,
+//! `renderer::render_backend::file_loaded_evaluator`,
+//! `orender_engine::virtual_bed`), plus one in the Studio frontend — and two
+//! independent cartesian/spherical pairs that did **not** agree (see
+//! "Frames" below).
+//!
+//! # Frames
+//!
+//! **ADM space** is the wire, file and renderer frame. It is what a layout
+//! YAML stores and what OSC carries:
+//!
+//! ```text
+//! x: left(-1) -> right(+1)
+//! y: back(-1) -> front(+1)
+//! z: floor(-1) -> ceiling(+1)
+//! ```
+//!
+//! Angles are degrees: azimuth `0` = front (`+y`), `+90` = right (`+x`);
+//! elevation `0` = ear level, `+90` = straight up.
+//!
+//! **Scene space** is the Three.js frame the Studio frontend draws in. It is
+//! the same room with the axes relabelled:
+//!
+//! ```text
+//! scene = (adm.y, adm.z, adm.x)   // x = depth/front, y = up, z = right
+//! ```
+//!
+//! The two frames describe *the same angles*, because the swizzle lines the
+//! components up again:
+//!
+//! ```text
+//! scene azimuth = atan2(scene.z, scene.x) = atan2(adm.x, adm.y) = adm azimuth
+//! ```
+//!
+//! That equivalence is the trap this crate exists to close. Applying the
+//! scene-ordered formula to ADM-ordered components — `atan2(z, x)` on ADM data,
+//! without the swizzle — compiles, runs, and yields a *different frame*: it
+//! reads a hard-right speaker as dead ahead and 45° up. The Studio backend did
+//! exactly that on every layout it parsed. Convert frames explicitly with
+//! [`adm_to_scene`](f64::adm_to_scene) / [`scene_to_adm`](f64::scene_to_adm);
+//! never reorder components by hand.
+//!
+//! # Precision
+//!
+//! Every function exists in both [`f32`] (what the renderer's audio path uses)
+//! and [`f64`] (what the Studio backend uses). The two are generated from one
+//! macro so they cannot drift; the arithmetic is written to match the existing
+//! renderer implementations term for term, so adopting this crate there is a
+//! bit-for-bit no-op.
+//!
+//! # Hot paths
+//!
+//! Everything here is allocation-free and branch-light: these run per object
+//! per frame in the renderer, and the embedded target has no cycles to spare.
+
+#![forbid(unsafe_code)]
+
+/// Smallest distance a speaker or object may sit at, in metres.
+///
+/// A zero-distance position has no defined direction, so the angle pair would
+/// be arbitrary; clamping keeps every stored coordinate invertible.
+pub const MIN_DISTANCE: f64 = 0.01;
+
+/// Floor applied to room ratios before dividing by them.
+pub const MIN_ROOM_RATIO: f64 = 0.01;
+
+macro_rules! geometry_for {
+    ($module:ident, $f:ty) => {
+        /// Geometry in `
+        #[doc = stringify!($f)]
+        /// ` precision. See the crate docs for conventions.
+        pub mod $module {
+            /// Smallest representable distance, in metres.
+            pub const MIN_DISTANCE: $f = super::MIN_DISTANCE as $f;
+            /// Floor applied to room ratios before dividing by them.
+            pub const MIN_ROOM_RATIO: $f = super::MIN_ROOM_RATIO as $f;
+
+            // ---------------------------------------------------------------
+            // Frames
+            // ---------------------------------------------------------------
+
+            /// ADM `(x, y, z)` -> Three.js scene `(depth, up, right)`.
+            #[inline]
+            pub fn adm_to_scene(position: [$f; 3]) -> [$f; 3] {
+                [position[1], position[2], position[0]]
+            }
+
+            /// Three.js scene `(depth, up, right)` -> ADM `(x, y, z)`.
+            #[inline]
+            pub fn scene_to_adm(position: [$f; 3]) -> [$f; 3] {
+                [position[2], position[0], position[1]]
+            }
+
+            // ---------------------------------------------------------------
+            // Cartesian <-> spherical (ADM frame, degrees)
+            // ---------------------------------------------------------------
+
+            /// ADM cartesian -> `(azimuth_deg, elevation_deg, distance)`.
+            ///
+            /// Exact vertical directions are kept stable: straight up reads
+            /// `+90`, straight down `-90`, and the origin `0` rather than
+            /// whatever `atan2(0.0, 0.0)` happens to give.
+            #[inline]
+            pub fn to_spherical(x: $f, y: $f, z: $f) -> ($f, $f, $f) {
+                let distance = (x * x + y * y + z * z).sqrt();
+                let horizontal = (x * x + y * y).sqrt();
+
+                let azimuth_deg = x.atan2(y).to_degrees();
+                let elevation_deg = if horizontal < 1e-6 {
+                    if z > 0.0 {
+                        90.0
+                    } else if z < 0.0 {
+                        -90.0
+                    } else {
+                        0.0
+                    }
+                } else {
+                    z.atan2(horizontal).to_degrees()
+                };
+
+                (azimuth_deg, elevation_deg, distance)
+            }
+
+            /// `(azimuth_deg, elevation_deg, distance)` -> ADM cartesian.
+            #[inline]
+            pub fn from_spherical(
+                azimuth_deg: $f,
+                elevation_deg: $f,
+                distance: $f,
+            ) -> ($f, $f, $f) {
+                let az = azimuth_deg.to_radians();
+                let el = elevation_deg.to_radians();
+                let horizontal = distance * el.cos();
+                (
+                    horizontal * az.sin(),
+                    horizontal * az.cos(),
+                    distance * el.sin(),
+                )
+            }
+
+            // ---------------------------------------------------------------
+            // Angles
+            // ---------------------------------------------------------------
+
+            /// Wrap to `[-180, 180]` by repeated addition — matches
+            /// `orender_engine::spatial::normalize_azimuth_deg`.
+            #[inline]
+            pub fn normalize_deg(angle: $f) -> $f {
+                let mut a = angle;
+                while a < -180.0 {
+                    a += 360.0;
+                }
+                while a > 180.0 {
+                    a -= 360.0;
+                }
+                a
+            }
+
+            /// Wrap to `(-180, 180]`, mapping the `-180` seam onto `+180` so a
+            /// lookup table has one entry per direction, not two.
+            #[inline]
+            pub fn wrap_deg(value: $f) -> $f {
+                let wrapped = (value + 180.0).rem_euclid(360.0) - 180.0;
+                if wrapped == -180.0 { 180.0 } else { wrapped }
+            }
+
+            /// Shortest angular separation, in `[0, 180]`.
+            #[inline]
+            pub fn wrapped_distance_deg(a: $f, b: $f) -> $f {
+                let delta = (a - b).rem_euclid(360.0);
+                delta.min(360.0 - delta)
+            }
+
+            /// Snap to the nearest multiple of `step`, but only when already
+            /// within `threshold` of it. Outside that window the angle is
+            /// returned untouched, so snapping never fights a deliberate edit.
+            #[inline]
+            pub fn snap_deg(angle: $f, step: $f, threshold: $f) -> $f {
+                if step <= 0.0 {
+                    return angle;
+                }
+                let snapped = (angle / step).round() * step;
+                if (angle - snapped).abs() <= threshold {
+                    snapped
+                } else {
+                    angle
+                }
+            }
+
+            // ---------------------------------------------------------------
+            // Room geometry
+            // ---------------------------------------------------------------
+
+            /// Non-linear depth warp on the front/back axis.
+            ///
+            /// A cubic through `(0, 0)` and `(±1, ±ratio)` whose slope at the
+            /// origin is `center_ratio`, so the room can be stretched towards
+            /// the front and the rear by different amounts while the listener
+            /// position stays put and the curve stays smooth across it.
+            /// `center_blend` picks where that origin slope sits between the
+            /// rear and front ratios.
+            #[inline]
+            pub fn map_depth(depth: $f, front_ratio: $f, rear_ratio: $f, center_blend: $f) -> $f {
+                let d = depth.clamp(-1.0, 1.0);
+                let blend = center_blend.clamp(0.0, 1.0);
+                let center_ratio = rear_ratio + (front_ratio - rear_ratio) * blend;
+                if d >= 0.0 {
+                    let t = d;
+                    let a = center_ratio - front_ratio;
+                    let b = 2.0 * (front_ratio - center_ratio);
+                    a * t * t * t + b * t * t + center_ratio * t
+                } else {
+                    let t = -d;
+                    let a = center_ratio - rear_ratio;
+                    let b = 2.0 * (rear_ratio - center_ratio);
+                    -(a * t * t * t + b * t * t + center_ratio * t)
+                }
+            }
+
+            /// Invert [`map_depth`] by bisection.
+            ///
+            /// 28 halvings of a unit interval, so the result is good to about
+            /// `2^-29`. The warp is a monotone cubic with no closed-form
+            /// inverse worth the branch count here; this matches the two
+            /// existing implementations (`orender_engine::virtual_bed` and the
+            /// Studio frontend) iteration for iteration, which is what lets
+            /// them be replaced without moving a single stored coordinate.
+            pub fn inverse_map_depth(
+                mapped_depth: $f,
+                front_ratio: $f,
+                rear_ratio: $f,
+                center_blend: $f,
+            ) -> $f {
+                let (target, mut lo, mut hi) = if mapped_depth >= 0.0 {
+                    (
+                        mapped_depth.clamp(0.0, front_ratio.max(0.0)),
+                        0.0 as $f,
+                        1.0 as $f,
+                    )
+                } else {
+                    (
+                        mapped_depth.clamp(-rear_ratio.max(0.0), 0.0),
+                        -1.0 as $f,
+                        0.0 as $f,
+                    )
+                };
+                for _ in 0..28 {
+                    let mid = (lo + hi) * 0.5;
+                    if map_depth(mid, front_ratio, rear_ratio, center_blend) < target {
+                        lo = mid;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                (lo + hi) * 0.5
+            }
+
+            /// Scale a normalised ADM position into room-relative space: the
+            /// coordinates gain models pan in, and that distance attenuation
+            /// measures from.
+            ///
+            /// `room_ratio` is `[width, front, height]`; the rear and lower
+            /// ratios cover the half-axes that are allowed to differ.
+            #[inline]
+            pub fn room_scaled_position(
+                position: [$f; 3],
+                room_ratio: [$f; 3],
+                rear_ratio: $f,
+                lower_ratio: $f,
+                center_blend: $f,
+            ) -> [$f; 3] {
+                [
+                    position[0] * room_ratio[0],
+                    map_depth(position[1], room_ratio[1], rear_ratio, center_blend),
+                    if position[2] >= 0.0 {
+                        position[2] * room_ratio[2]
+                    } else {
+                        position[2] * lower_ratio
+                    },
+                ]
+            }
+
+            /// Inverse of [`room_scaled_position`], clamped back into the
+            /// normalised `[-1, 1]` cube.
+            #[inline]
+            pub fn inverse_room_scaled_position(
+                position: [$f; 3],
+                room_ratio: [$f; 3],
+                rear_ratio: $f,
+                lower_ratio: $f,
+                center_blend: $f,
+            ) -> [$f; 3] {
+                let width = room_ratio[0].max(MIN_ROOM_RATIO);
+                let front = room_ratio[1].max(MIN_ROOM_RATIO);
+                let height = room_ratio[2].max(MIN_ROOM_RATIO);
+                let rear = rear_ratio.max(MIN_ROOM_RATIO);
+                let lower = lower_ratio.max(MIN_ROOM_RATIO);
+
+                [
+                    (position[0] / width).clamp(-1.0, 1.0),
+                    inverse_map_depth(position[1], front, rear, center_blend).clamp(-1.0, 1.0),
+                    if position[2] >= 0.0 {
+                        (position[2] / height).clamp(-1.0, 1.0)
+                    } else {
+                        (position[2] / lower).clamp(-1.0, 1.0)
+                    },
+                ]
+            }
+
+            // ---------------------------------------------------------------
+            // Coordinate hydration
+            // ---------------------------------------------------------------
+
+            /// Derive the polar representation of a speaker given its
+            /// cartesian one, clamping the inputs to the normalised cube and
+            /// the distance to [`MIN_DISTANCE`].
+            #[inline]
+            pub fn hydrate_from_cartesian(x: $f, y: $f, z: $f) -> ($f, $f, $f) {
+                let x = x.clamp(-1.0, 1.0);
+                let y = y.clamp(-1.0, 1.0);
+                let z = z.clamp(-1.0, 1.0);
+                let (az, el, dist) = to_spherical(x, y, z);
+                (az, el, dist.max(MIN_DISTANCE))
+            }
+
+            /// Derive the cartesian representation of a speaker given its
+            /// polar one, clamping the result to the normalised cube.
+            #[inline]
+            pub fn hydrate_from_spherical(
+                azimuth_deg: $f,
+                elevation_deg: $f,
+                distance: $f,
+            ) -> ($f, $f, $f) {
+                let (x, y, z) =
+                    from_spherical(azimuth_deg, elevation_deg, distance.max(MIN_DISTANCE));
+                (x.clamp(-1.0, 1.0), y.clamp(-1.0, 1.0), z.clamp(-1.0, 1.0))
+            }
+        }
+    };
+}
+
+geometry_for!(f32, ::core::primitive::f32);
+geometry_for!(f64, ::core::primitive::f64);
+
+#[cfg(test)]
+mod tests {
+    use super::f64::*;
+
+    const EPS: f64 = 1e-9;
+
+    fn close(a: f64, b: f64) {
+        assert!((a - b).abs() < 1e-6, "expected {b}, got {a}");
+    }
+
+    // ── Frames ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn adm_cardinal_directions_read_as_expected() {
+        // Front centre.
+        let (az, el, _) = to_spherical(0.0, 1.0, 0.0);
+        close(az, 0.0);
+        close(el, 0.0);
+
+        // Hard right.
+        let (az, el, _) = to_spherical(1.0, 0.0, 0.0);
+        close(az, 90.0);
+        close(el, 0.0);
+
+        // Hard left.
+        let (az, _, _) = to_spherical(-1.0, 0.0, 0.0);
+        close(az, -90.0);
+
+        // Directly overhead: azimuth is arbitrary, elevation must be exact.
+        let (_, el, _) = to_spherical(0.0, 0.0, 1.0);
+        close(el, 90.0);
+    }
+
+    /// The regression this crate was written for: the Studio backend used the
+    /// scene-space formula on ADM-ordered components. `FR` from `7.1.4.yaml`
+    /// (x=1, y=1, z=0) is front-right at ear level, and must not read as
+    /// straight-ahead-and-elevated.
+    #[test]
+    fn front_right_speaker_is_not_read_as_elevated_centre() {
+        let (az, el, _) = to_spherical(1.0, 1.0, 0.0);
+        close(az, 45.0);
+        close(el, 0.0);
+
+        // What the un-swizzled formula produced, for the record.
+        let wrong_az = 0.0f64.atan2(1.0).to_degrees();
+        let wrong_el = 1.0f64.atan2((1.0f64 + 0.0).sqrt()).to_degrees();
+        close(wrong_az, 0.0);
+        close(wrong_el, 45.0);
+    }
+
+    #[test]
+    fn scene_swizzle_preserves_angles() {
+        // Applying the scene-ordered azimuth formula to swizzled components
+        // must agree with the ADM formula on the originals.
+        for &(x, y, z) in &[
+            (1.0, 1.0, 0.0),
+            (-0.3, 0.8, 0.5),
+            (0.0, -1.0, -0.25),
+            (0.7, 0.0, 1.0),
+        ] {
+            let scene = adm_to_scene([x, y, z]);
+            let scene_az = scene[2].atan2(scene[0]).to_degrees();
+            let (adm_az, _, _) = to_spherical(x, y, z);
+            close(scene_az, adm_az);
+
+            let scene_el = scene[1]
+                .atan2((scene[0] * scene[0] + scene[2] * scene[2]).sqrt())
+                .to_degrees();
+            let (_, adm_el, _) = to_spherical(x, y, z);
+            close(scene_el, adm_el);
+        }
+    }
+
+    #[test]
+    fn frame_conversion_round_trips() {
+        let adm = [0.25, -0.5, 0.75];
+        assert_eq!(scene_to_adm(adm_to_scene(adm)), adm);
+    }
+
+    #[test]
+    fn spherical_round_trips() {
+        for &(az, el, dist) in &[
+            (0.0, 0.0, 1.0),
+            (45.0, 30.0, 0.8),
+            (-120.0, -15.0, 1.0),
+            (179.0, 89.0, 0.5),
+        ] {
+            let (x, y, z) = from_spherical(az, el, dist);
+            let (az2, el2, dist2) = to_spherical(x, y, z);
+            close(az2, az);
+            close(el2, el);
+            close(dist2, dist);
+        }
+    }
+
+    // ── Angles ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_and_wrap_agree_away_from_the_seam() {
+        for a in [-359.0, -181.0, -90.0, 0.0, 90.0, 181.0, 540.0] {
+            close(normalize_deg(a), wrap_deg(a));
+        }
+    }
+
+    #[test]
+    fn wrap_folds_the_negative_seam_onto_positive() {
+        close(wrap_deg(-180.0), 180.0);
+        close(wrap_deg(180.0), 180.0);
+        // normalize_deg keeps -180 as itself; that difference is deliberate.
+        close(normalize_deg(-180.0), -180.0);
+    }
+
+    #[test]
+    fn wrapped_distance_takes_the_short_way() {
+        close(wrapped_distance_deg(170.0, -170.0), 20.0);
+        close(wrapped_distance_deg(-170.0, 170.0), 20.0);
+        close(wrapped_distance_deg(0.0, 180.0), 180.0);
+        close(wrapped_distance_deg(10.0, 10.0), 0.0);
+    }
+
+    #[test]
+    fn snap_only_inside_the_threshold() {
+        close(snap_deg(44.0, 45.0, 2.0), 45.0);
+        close(snap_deg(41.0, 45.0, 2.0), 41.0);
+        close(snap_deg(41.0, 0.0, 2.0), 41.0);
+    }
+
+    // ── Room geometry ───────────────────────────────────────────────────────
+
+    #[test]
+    fn depth_warp_pins_its_endpoints() {
+        let (front, rear, blend) = (2.0, 1.5, 0.5);
+        close(map_depth(0.0, front, rear, blend), 0.0);
+        close(map_depth(1.0, front, rear, blend), front);
+        close(map_depth(-1.0, front, rear, blend), -rear);
+    }
+
+    #[test]
+    fn depth_warp_is_monotone() {
+        let (front, rear, blend) = (2.0, 1.2, 0.35);
+        let mut previous = map_depth(-1.0, front, rear, blend);
+        for i in 1..=200 {
+            let d = -1.0 + 2.0 * (i as f64) / 200.0;
+            let current = map_depth(d, front, rear, blend);
+            assert!(current > previous, "not monotone at d={d}");
+            previous = current;
+        }
+    }
+
+    #[test]
+    fn depth_warp_inverts() {
+        for &(front, rear, blend) in &[
+            (1.0, 1.0, 0.5),
+            (2.0, 1.5, 0.5),
+            (3.0, 0.8, 0.0),
+            (1.2, 2.4, 1.0),
+        ] {
+            for i in 0..=40 {
+                let d = -1.0 + 2.0 * (i as f64) / 40.0;
+                let mapped = map_depth(d, front, rear, blend);
+                let back = inverse_map_depth(mapped, front, rear, blend);
+                assert!(
+                    (back - d).abs() < 1e-6,
+                    "depth {d} round-tripped to {back} (front={front}, rear={rear}, blend={blend})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn room_scaling_inverts() {
+        let ratio = [1.5, 2.0, 1.1];
+        let (rear, lower, blend) = (1.3, 0.6, 0.5);
+        for &position in &[
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [-1.0, -1.0, -1.0],
+            [0.3, -0.7, 0.25],
+        ] {
+            let scaled = room_scaled_position(position, ratio, rear, lower, blend);
+            let back = inverse_room_scaled_position(scaled, ratio, rear, lower, blend);
+            for axis in 0..3 {
+                assert!(
+                    (back[axis] - position[axis]).abs() < 1e-6,
+                    "axis {axis}: {:?} -> {:?}",
+                    position,
+                    back
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn degenerate_ratios_do_not_divide_by_zero() {
+        let back = inverse_room_scaled_position([0.5, 0.5, -0.5], [0.0, 0.0, 0.0], 0.0, 0.0, 0.5);
+        assert!(back.iter().all(|v| v.is_finite()));
+    }
+
+    // ── Hydration ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn hydration_round_trips_a_layout_speaker() {
+        // FR from layouts/7.1.4.yaml.
+        let (az, el, dist) = hydrate_from_cartesian(1.0, 1.0, 0.0);
+        close(az, 45.0);
+        close(el, 0.0);
+        close(dist, 2.0f64.sqrt());
+
+        let (x, y, z) = hydrate_from_spherical(az, el, dist);
+        close(x, 1.0);
+        close(y, 1.0);
+        close(z, 0.0);
+    }
+
+    #[test]
+    fn hydration_floors_the_distance() {
+        let (_, _, dist) = hydrate_from_cartesian(0.0, 0.0, 0.0);
+        assert!(dist >= MIN_DISTANCE - EPS);
+    }
+
+    #[test]
+    fn hydration_clamps_out_of_range_cartesian() {
+        let (az, _, _) = hydrate_from_cartesian(5.0, 0.0, 0.0);
+        close(az, 90.0);
+    }
+
+    // ── Precision parity ────────────────────────────────────────────────────
+
+    #[test]
+    fn f32_and_f64_agree_within_single_precision() {
+        for &(x, y, z) in &[(1.0, 1.0, 0.0), (-0.3, 0.8, 0.5), (0.0, -1.0, -0.25)] {
+            let (az64, el64, _) = to_spherical(x, y, z);
+            let (az32, el32, _) = super::f32::to_spherical(x as f32, y as f32, z as f32);
+            assert!((az32 as f64 - az64).abs() < 1e-4);
+            assert!((el32 as f64 - el64).abs() < 1e-4);
+        }
+
+        let m64 = map_depth(0.4, 2.0, 1.5, 0.5);
+        let m32 = super::f32::map_depth(0.4, 2.0, 1.5, 0.5);
+        assert!((m32 as f64 - m64).abs() < 1e-5);
+    }
+}

--- a/omniphony-studio/src-tauri/Cargo.lock
+++ b/omniphony-studio/src-tauri/Cargo.lock
@@ -2566,6 +2566,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "omniphony-geometry"
+version = "0.1.0"
+
+[[package]]
 name = "omniphony-studio"
 version = "0.5.2"
 dependencies = [
@@ -2573,6 +2577,7 @@ dependencies = [
  "image",
  "log",
  "memory-stats",
+ "omniphony-geometry",
  "rfd 0.15.4",
  "rosc",
  "serde",

--- a/omniphony-studio/src-tauri/Cargo.toml
+++ b/omniphony-studio/src-tauri/Cargo.toml
@@ -8,6 +8,11 @@ name = "omniphony-studio"
 path = "src/main.rs"
 
 [dependencies]
+# Single source of truth for coordinate frames, angle wrapping and the room
+# depth warp, shared with the renderer. Dependency-free by design — check the
+# crate's own Cargo.toml before adding anything to it, because whatever it
+# pulls in lands in the Studio build too.
+omniphony-geometry = { path = "../../omniphony-renderer/omniphony-geometry" }
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/omniphony-studio/src-tauri/src/layouts.rs
+++ b/omniphony-studio/src-tauri/src/layouts.rs
@@ -1,3 +1,4 @@
+use omniphony_geometry::f64 as geometry;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -136,26 +137,12 @@ fn clamp(v: f64, min: f64, max: f64) -> f64 {
     v.max(min).min(max)
 }
 
-fn spherical_to_cartesian(az_deg: f64, el_deg: f64, dist: f64) -> (f64, f64, f64) {
-    let az = az_deg.to_radians();
-    let el = el_deg.to_radians();
-    (
-        dist * el.cos() * az.cos(),
-        dist * el.sin(),
-        dist * el.cos() * az.sin(),
-    )
-}
-
-fn cartesian_to_spherical(x: f64, y: f64, z: f64) -> (f64, f64, f64) {
-    let dist = (x * x + y * y + z * z).sqrt();
-    let az = z.atan2(x).to_degrees();
-    let el = if dist > 0.0 {
-        y.atan2((x * x + z * z).sqrt()).to_degrees()
-    } else {
-        0.0
-    };
-    (az, el, dist)
-}
+// Coordinate conversions come from `omniphony-geometry`, which the renderer
+// shares. They used to live here, and applied the Three.js scene-space formula
+// (`az = atan2(z, x)`, elevation off +Y) to layout files written in the ADM
+// frame the renderer uses (`az = atan2(x, y)`, elevation off +Z). The axes were
+// never swizzled, so the two disagreed: `FR` in layouts/7.1.4.yaml — x=1, y=1,
+// z=0, front-right at ear level — parsed as azimuth 0°, elevation 45°.
 
 // ── raw deserialization types ─────────────────────────────────────────────
 
@@ -283,7 +270,7 @@ fn normalize_speaker(raw: RawSpeaker) -> Speaker {
         let x = clamp(x, -1.0, 1.0);
         let y = clamp(y, -1.0, 1.0);
         let z = clamp(z, -1.0, 1.0);
-        let (derived_az, derived_el, derived_dist) = cartesian_to_spherical(x, y, z);
+        let (derived_az, derived_el, derived_dist) = geometry::hydrate_from_cartesian(x, y, z);
         return Speaker {
             id,
             x,
@@ -303,13 +290,13 @@ fn normalize_speaker(raw: RawSpeaker) -> Speaker {
     let az = raw.azimuth.or(raw.az).unwrap_or(0.0);
     let el = raw.elevation.or(raw.el).unwrap_or(0.0);
     let dist = raw.distance.or(raw.dist).unwrap_or(1.0).max(0.01);
-    let (x, y, z) = spherical_to_cartesian(az, el, dist);
+    let (x, y, z) = geometry::hydrate_from_spherical(az, el, dist);
 
     Speaker {
         id,
-        x: clamp(x, -1.0, 1.0),
-        y: clamp(y, -1.0, 1.0),
-        z: clamp(z, -1.0, 1.0),
+        x,
+        y,
+        z,
         azimuth_deg: az,
         elevation_deg: el,
         distance_m: dist,
@@ -613,6 +600,63 @@ pub fn save_layout_file(path: &Path, layout: &Layout) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::{normalize_speaker, parse_yaml_layout, RawSpeaker};
+
+    /// A cartesian speaker must derive its angles in the ADM frame the layout
+    /// file is written in — the same one the renderer reads it with.
+    ///
+    /// `FR` from layouts/7.1.4.yaml is x=1, y=1, z=0: front-right, ear level.
+    /// The scene-space formula this code used to carry read it as azimuth 0°
+    /// (straight ahead) and elevation 45° (up), because it never swizzled the
+    /// axes. Angles are only derived when the file omits them, and cartesian
+    /// export drops them again, so the corruption surfaced on round-trip:
+    /// `coord_mode` defaults to polar when the key is absent, and a layout
+    /// carrying x/y/z but no `coord_mode` exported these derived angles.
+    #[test]
+    fn derives_speaker_angles_in_the_adm_frame() {
+        let speaker = normalize_speaker(RawSpeaker {
+            name: Some(serde_json::json!("FR")),
+            x: Some(1.0),
+            y: Some(1.0),
+            z: Some(0.0),
+            ..RawSpeaker::default()
+        });
+        assert!(
+            (speaker.azimuth_deg - 45.0).abs() < 1e-6,
+            "azimuth {} should be 45° (front-right), not 0°",
+            speaker.azimuth_deg
+        );
+        assert!(
+            speaker.elevation_deg.abs() < 1e-6,
+            "elevation {} should be 0° (ear level), not 45°",
+            speaker.elevation_deg
+        );
+    }
+
+    /// Overhead must read as +90° elevation, and the polar->cartesian
+    /// direction has to land back on the same axis.
+    #[test]
+    fn derives_overhead_and_lateral_speakers_consistently() {
+        let top = normalize_speaker(RawSpeaker {
+            name: Some(serde_json::json!("TOP")),
+            x: Some(0.0),
+            y: Some(0.0),
+            z: Some(1.0),
+            ..RawSpeaker::default()
+        });
+        assert!((top.elevation_deg - 90.0).abs() < 1e-6);
+
+        // Hard right in polar must come back as +X, not +Z.
+        let right = normalize_speaker(RawSpeaker {
+            name: Some(serde_json::json!("R")),
+            azimuth: Some(90.0),
+            elevation: Some(0.0),
+            distance: Some(1.0),
+            ..RawSpeaker::default()
+        });
+        assert!((right.x - 1.0).abs() < 1e-6, "x was {}", right.x);
+        assert!(right.y.abs() < 1e-6, "y was {}", right.y);
+        assert!(right.z.abs() < 1e-6, "z was {}", right.z);
+    }
 
     #[test]
     fn normalizes_freq_fields_from_json_variants() {

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -1,3 +1,4 @@
+use omniphony_geometry::f64 as geometry;
 use rosc::{decoder, OscPacket, OscType};
 use std::net::UdpSocket;
 use std::sync::{Arc, Mutex};
@@ -233,30 +234,10 @@ fn clamp_layout_value(value: f64, min: f64, max: f64) -> f64 {
     value.max(min).min(max)
 }
 
-fn cartesian_to_spherical(x: f64, y: f64, z: f64) -> (f64, f64, f64) {
-    let distance = (x * x + y * y + z * z).sqrt();
-    let azimuth = z.atan2(x).to_degrees();
-    let elevation = if distance > 0.0 {
-        y.atan2((x * x + z * z).sqrt()).to_degrees()
-    } else {
-        0.0
-    };
-    (azimuth, elevation, distance)
-}
-
-fn spherical_to_cartesian(
-    azimuth_deg: f64,
-    elevation_deg: f64,
-    distance_m: f64,
-) -> (f64, f64, f64) {
-    let azimuth = azimuth_deg.to_radians();
-    let elevation = elevation_deg.to_radians();
-    (
-        distance_m * elevation.cos() * azimuth.cos(),
-        distance_m * elevation.sin(),
-        distance_m * elevation.cos() * azimuth.sin(),
-    )
-}
+// Conversions come from `omniphony-geometry`, shared with the renderer. The
+// copies that lived here read the ADM coordinates the renderer publishes as if
+// they were Three.js scene coordinates — the same missing axis swizzle as
+// `layouts.rs`, but on the LIVE layout rather than a file.
 
 fn scalar_string(value: Option<serde_json::Value>, fallback: &str) -> String {
     match value {
@@ -315,7 +296,7 @@ fn normalized_layout_domain_speaker(raw: LayoutDomainSpeakerState) -> Speaker {
         let y = clamp_layout_value(y, -1.0, 1.0);
         let z = clamp_layout_value(z, -1.0, 1.0);
         let (fallback_azimuth, fallback_elevation, fallback_distance) =
-            cartesian_to_spherical(x, y, z);
+            geometry::to_spherical(x, y, z);
         return Speaker {
             id,
             x,
@@ -339,12 +320,13 @@ fn normalized_layout_domain_speaker(raw: LayoutDomainSpeakerState) -> Speaker {
     let azimuth = raw.azimuth.unwrap_or(0.0);
     let elevation = raw.elevation.unwrap_or(0.0);
     let distance_m = raw.distance.unwrap_or(1.0).max(0.01);
-    let (x, y, z) = spherical_to_cartesian(azimuth, elevation, distance_m);
+    // hydrate_from_spherical already clamps to the normalised cube.
+    let (x, y, z) = geometry::hydrate_from_spherical(azimuth, elevation, distance_m);
     Speaker {
         id,
-        x: clamp_layout_value(x, -1.0, 1.0),
-        y: clamp_layout_value(y, -1.0, 1.0),
-        z: clamp_layout_value(z, -1.0, 1.0),
+        x,
+        y,
+        z,
         azimuth_deg: azimuth,
         elevation_deg: elevation,
         distance_m,
@@ -3166,5 +3148,49 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                 let _ = app.emit(event, payload);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalized_layout_domain_speaker, LayoutDomainSpeakerState};
+
+    /// The live layout the renderer publishes is in the ADM frame, same as a
+    /// layout file. This path used to read it as Three.js scene coordinates —
+    /// the same missing swizzle `layouts.rs` had, but on the running layout.
+    #[test]
+    fn derives_live_speaker_angles_in_the_adm_frame() {
+        let speaker = normalized_layout_domain_speaker(LayoutDomainSpeakerState {
+            name: Some(serde_json::json!("FR")),
+            x: Some(1.0),
+            y: Some(1.0),
+            z: Some(0.0),
+            ..LayoutDomainSpeakerState::default()
+        });
+        assert!(
+            (speaker.azimuth_deg - 45.0).abs() < 1e-6,
+            "azimuth {} should be 45° (front-right), not 0°",
+            speaker.azimuth_deg
+        );
+        assert!(
+            speaker.elevation_deg.abs() < 1e-6,
+            "elevation {} should be 0° (ear level), not 45°",
+            speaker.elevation_deg
+        );
+    }
+
+    /// Polar -> cartesian on the same path: hard right is +X, not +Z.
+    #[test]
+    fn derives_live_speaker_cartesian_in_the_adm_frame() {
+        let speaker = normalized_layout_domain_speaker(LayoutDomainSpeakerState {
+            name: Some(serde_json::json!("R")),
+            azimuth: Some(90.0),
+            elevation: Some(0.0),
+            distance: Some(1.0),
+            ..LayoutDomainSpeakerState::default()
+        });
+        assert!((speaker.x - 1.0).abs() < 1e-6, "x was {}", speaker.x);
+        assert!(speaker.y.abs() < 1e-6, "y was {}", speaker.y);
+        assert!(speaker.z.abs() < 1e-6, "z was {}", speaker.z);
     }
 }

--- a/omniphony-studio/src-tauri/src/osc_parser.rs
+++ b/omniphony-studio/src-tauri/src/osc_parser.rs
@@ -1,3 +1,4 @@
+use omniphony_geometry::f64 as geometry;
 use rosc::OscType;
 use serde::Serialize;
 
@@ -45,14 +46,12 @@ fn clamp(v: f64, min: f64, max: f64) -> f64 {
     v.max(min).min(max)
 }
 
-fn spherical_to_cartesian(az_deg: f64, el_deg: f64, dist: f64) -> (f64, f64, f64) {
-    let az = az_deg.to_radians();
-    let el = el_deg.to_radians();
-    let x = dist * el.cos() * az.cos();
-    let y = dist * el.sin();
-    let z = dist * el.cos() * az.sin();
-    (x, y, z)
-}
+// Polar -> cartesian comes from `omniphony-geometry`, shared with the renderer.
+// The copy that lived here read the angles in the Three.js scene frame while
+// labelling the result as ADM, so an object sent at azimuth 90° (hard right)
+// was stored at ADM (0, 0, dist) — directly overhead. Objects arriving in polar
+// form also carry their angles, and the frontend re-derives cartesian from
+// those, which is why this mostly stayed invisible.
 
 fn find_id_in_address(parts: &[&str]) -> Option<String> {
     let anchors = ["source", "sources", "object", "obj", "track", "channel"];
@@ -1299,7 +1298,7 @@ pub fn parse_osc_message(
 
     let (x, y, z) = if has_spherical {
         let (px, py, pz) =
-            spherical_to_cartesian(numeric_args[0], numeric_args[1], numeric_args[2]);
+            geometry::from_spherical(numeric_args[0], numeric_args[1], numeric_args[2]);
         (px, py, pz)
     } else {
         (numeric_args[0], numeric_args[1], numeric_args[2])


### PR DESCRIPTION
Phase 2.1 of the Studio Rust/Web rebalancing plan.

## Why this is bigger than the plan expected

The plan says the room depth-warp polynomial *"exists **only** in JS."* It does not. It exists **five** times — four of them inside the renderer workspace:

| Copy | Location |
|---|---|
| Renderer, speaker layout | `renderer/src/speaker_layout.rs:45` |
| Renderer, pan space | `renderer/src/render_backend/room_transform.rs:9` |
| Renderer, file evaluator | `renderer/src/render_backend/file_loaded_evaluator.rs:418` |
| Engine, virtual bed | `orender_engine/src/virtual_bed.rs:19` — plus `inverse_map_depth_with_room_ratios` at `:41`, a 28-iteration bisection twin of the JS one |
| Studio frontend | `src/coordinates.js:92` |

All four Rust copies are logically identical, so this is a clean extraction rather than a reconciliation.

## The crate

`omniphony-geometry` — frames, angle wrapping/snapping, the depth warp and its inverse, room scaling and its inverse, coordinate hydration.

- **Dependency-free.** It is consumed from outside the renderer workspace (src-tauri is its own cargo project), so anything added here lands in the Studio build. The renderer crate itself was never an option: it pulls `realfft`, `rayon`, `sys`.
- **f32 and f64 from one macro**, so the renderer's audio precision and the Studio's cannot drift apart.
- **Arithmetic matches the existing renderer implementations term for term**, so migrating the four in-tree copies is a bit-for-bit no-op. That migration is a deliberate follow-up — this PR only adds the crate and adopts it in the Studio backend.

## The frame bug this exposed

The Studio backend applied the Three.js **scene-space** formula (`az = atan2(z, x)`, elevation off +Y) to data in the **ADM** frame the renderer uses (`az = atan2(x, y)`, elevation off +Z) — without ever swizzling the axes. Same room, same rotation, so it compiled, ran, and quietly reported a different direction.

`FR` from `layouts/7.1.4.yaml` is `x: 1.0, y: 1.0, z: 0.0` — front-right, ear level:

| | azimuth | elevation |
|---|---|---|
| Renderer | 45° ✓ | 0° ✓ |
| Studio backend (before) | **0°** — straight ahead | **45°** — elevated |

**Where it could bite.** Angles are only derived when the layout file omits them, and cartesian-mode export drops them again — so the exposure is round-trip: `coord_mode` defaults to `"polar"` when the key is absent (`layouts.rs:241`), while the renderer infers `"cartesian"` from the presence of x/y/z. A layout carrying x/y/z but **no `coord_mode` key** was therefore read as polar and exported with angles computed in the wrong frame. Every bundled layout has an explicit `coord_mode: "cartesian"` and dodges it; hand-written or third-party ones may not.

`osc_parser.rs` had the same inversion on the live path: an object sent at azimuth 90° (hard right) was stored at ADM `(0, 0, dist)` — directly overhead. That one stayed latent because polar updates also carry their angles and the frontend re-derives cartesian from those.

**The frontend was never wrong.** It swizzles omni→scene *before* computing angles, so `atan2(scene.z, scene.x)` == `atan2(adm.x, adm.y)`. It has always agreed with the renderer. Only the Rust copy skipped the swizzle — which is exactly why the crate documents the equivalence and offers `adm_to_scene`/`scene_to_adm` instead of leaving component reordering to the reader.

## Verification

- **18 crate tests**: cardinal directions, the FR regression, scene-swizzle angle equivalence, spherical round-trip, wrap/normalize seam behaviour, warp endpoints + monotonicity + inversion across four room configs, degenerate-ratio guards, f32/f64 parity.
- **2 regression tests** in `layouts.rs` pinning the ADM frame for both conversion directions.
- Full src-tauri suite: **27 passed**. (src-tauri is not in CI — run locally.)
- `cargo fmt --check` clean across the renderer workspace. src-tauri has pre-existing fmt divergence in `osc_parser.rs`/`osc_listener.rs`; none of it is at my edit sites, and `layouts.rs` is clean.

## Not verified

Not yet run against a live renderer. Worth a click-through of the speaker panel with a cartesian layout loaded — the displayed angles come from the frontend's own hydration and should be unchanged, but the backend's copy of them now differs, so this is the moment to confirm nothing downstream was quietly relying on the old values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)