### PR TITLE
Delete the in-tree geometry copies across the renderer

### DIFF
--- a/omniphony-renderer/orender_engine/Cargo.toml
+++ b/omniphony-renderer/orender_engine/Cargo.toml
@@ -13,6 +13,7 @@ renderer = { version = "0.2.4", path = "../renderer" }
 example_backend = { path = "../example_backend" }
 # User-scriptable (Lua) render backend, registered at startup.
 script_backend = { path = "../script_backend" }
+omniphony-geometry = { version = "0.1.0", path = "../omniphony-geometry" }
 bridge_api = { version = "0.3.0", path = "../bridge_api" }
 runtime_control = { version = "0.2.4", path = "../runtime_control" }
 sys = { version = "0.1.0", path = "../sys" }

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -9,15 +9,7 @@ use renderer::spatial_renderer::SpatialChannelEvent;
 use std::collections::HashMap;
 
 /// Wrap an azimuth in degrees into `[-180, 180]`.
-pub fn normalize_azimuth_deg(mut azimuth_deg: f32) -> f32 {
-    while azimuth_deg < -180.0 {
-        azimuth_deg += 360.0;
-    }
-    while azimuth_deg > 180.0 {
-        azimuth_deg -= 360.0;
-    }
-    azimuth_deg
-}
+pub use omniphony_geometry::f32::normalize_deg as normalize_azimuth_deg;
 
 /// Raw, unconverted position `[x, y, z]` exactly as the event carries it (no
 /// coordinate-format conversion). Used for OSC object broadcast, where the

--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -15,92 +15,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-#[inline]
-fn map_depth_with_room_ratios(
-    depth: f32,
-    front_ratio: f32,
-    rear_ratio: f32,
-    center_blend: f32,
-) -> f32 {
-    let d = depth.clamp(-1.0, 1.0);
-    let blend = center_blend.clamp(0.0, 1.0);
-    let center_ratio = rear_ratio + (front_ratio - rear_ratio) * blend;
-    if d >= 0.0 {
-        let t = d;
-        let a = center_ratio - front_ratio;
-        let b = 2.0 * (front_ratio - center_ratio);
-        a * t * t * t + b * t * t + center_ratio * t
-    } else {
-        let t = -d;
-        let a = center_ratio - rear_ratio;
-        let b = 2.0 * (rear_ratio - center_ratio);
-        -(a * t * t * t + b * t * t + center_ratio * t)
-    }
-}
-
-fn inverse_map_depth_with_room_ratios(
-    mapped_depth: f32,
-    front_ratio: f32,
-    rear_ratio: f32,
-    center_blend: f32,
-) -> f32 {
-    let y = mapped_depth;
-    if y >= 0.0 {
-        let target = y.clamp(0.0, front_ratio.max(0.0));
-        let mut lo = 0.0f32;
-        let mut hi = 1.0f32;
-        for _ in 0..28 {
-            let mid = (lo + hi) * 0.5;
-            let val = map_depth_with_room_ratios(mid, front_ratio, rear_ratio, center_blend);
-            if val < target {
-                lo = mid;
-            } else {
-                hi = mid;
-            }
-        }
-        (lo + hi) * 0.5
-    } else {
-        let target = y.clamp(-rear_ratio.max(0.0), 0.0);
-        let mut lo = -1.0f32;
-        let mut hi = 0.0f32;
-        for _ in 0..28 {
-            let mid = (lo + hi) * 0.5;
-            let val = map_depth_with_room_ratios(mid, front_ratio, rear_ratio, center_blend);
-            if val < target {
-                lo = mid;
-            } else {
-                hi = mid;
-            }
-        }
-        (lo + hi) * 0.5
-    }
-}
-
-fn inverse_room_ratio_map_for_virtual_object(
-    target_x: f32,
-    target_y: f32,
-    target_z: f32,
-    room_ratio: [f32; 3],
-    room_ratio_rear: f32,
-    room_ratio_lower: f32,
-    room_ratio_center_blend: f32,
-) -> (f32, f32, f32) {
-    let width = room_ratio[0].max(0.01);
-    let front = room_ratio[1].max(0.01);
-    let height = room_ratio[2].max(0.01);
-    let rear = room_ratio_rear.max(0.01);
-    let lower = room_ratio_lower.max(0.01);
-
-    let x = (target_x / width).clamp(-1.0, 1.0);
-    let y = inverse_map_depth_with_room_ratios(target_y, front, rear, room_ratio_center_blend)
-        .clamp(-1.0, 1.0);
-    let z = if target_z >= 0.0 {
-        (target_z / height).clamp(-1.0, 1.0)
-    } else {
-        (target_z / lower).clamp(-1.0, 1.0)
-    };
-    (x, y, z)
-}
+use omniphony_geometry::f32::inverse_room_scaled_position;
 
 #[derive(Clone)]
 struct VirtualBedLayouts {
@@ -228,10 +143,8 @@ fn speaker_pose_to_normalized(
             speaker.elevation,
             speaker.distance,
         );
-        let (x, y, z) = inverse_room_ratio_map_for_virtual_object(
-            sx,
-            sy,
-            sz,
+        let [x, y, z] = inverse_room_scaled_position(
+            [sx, sy, sz],
             room_ratio,
             room_ratio_rear,
             room_ratio_lower,

--- a/omniphony-renderer/renderer/Cargo.toml
+++ b/omniphony-renderer/renderer/Cargo.toml
@@ -10,6 +10,7 @@ name = "renderer"
 
 [dependencies]
 anyhow = "1"
+omniphony-geometry = { version = "0.1.0", path = "../omniphony-geometry" }
 bridge_api = { version = "0.3.0", path = "../bridge_api" }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/omniphony-renderer/renderer/src/render_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend.rs
@@ -1720,17 +1720,13 @@ fn sample_wrapped_axis(values: &[f32], position: f32, interpolate: bool) -> Axis
     best
 }
 
-#[inline]
-fn wrap_degrees(value: f32) -> f32 {
-    let wrapped = (value + 180.0).rem_euclid(360.0) - 180.0;
-    if wrapped == -180.0 { 180.0 } else { wrapped }
-}
+use omniphony_geometry::f32::wrap_deg as wrap_degrees;
 
-#[inline]
-fn wrapped_angle_distance(a: f32, b: f32) -> f32 {
-    let delta = (a - b).abs().rem_euclid(360.0);
-    delta.min(360.0 - delta)
-}
+// The local version took `(a - b).abs()` before `rem_euclid`; the crate's does
+// not. `rem_euclid` is already non-negative, and for a negative delta it yields
+// `360 - |delta| mod 360`, which the following `min` folds back to the same
+// answer — so the two agree for every input.
+use omniphony_geometry::f32::wrapped_distance_deg as wrapped_angle_distance;
 
 #[cfg(test)]
 mod cartesian_lookup_bench {

--- a/omniphony-renderer/renderer/src/render_backend/file_loaded_evaluator.rs
+++ b/omniphony-renderer/renderer/src/render_backend/file_loaded_evaluator.rs
@@ -415,27 +415,7 @@ pub fn build_from_file_render_engine(
     )
 }
 
-fn map_depth_with_room_ratios(
-    depth: f32,
-    front_ratio: f32,
-    rear_ratio: f32,
-    center_blend: f32,
-) -> f32 {
-    let d = depth.clamp(-1.0, 1.0);
-    let blend = center_blend.clamp(0.0, 1.0);
-    let center_ratio = rear_ratio + (front_ratio - rear_ratio) * blend;
-    if d >= 0.0 {
-        let t = d;
-        let a = center_ratio - front_ratio;
-        let b = 2.0 * (front_ratio - center_ratio);
-        a * t * t * t + b * t * t + center_ratio * t
-    } else {
-        let t = -d;
-        let a = center_ratio - rear_ratio;
-        let b = 2.0 * (rear_ratio - center_ratio);
-        -(a * t * t * t + b * t * t + center_ratio * t)
-    }
-}
+use omniphony_geometry::f32::map_depth as map_depth_with_room_ratios;
 
 fn load_v1_tables(
     cursor: &mut std::io::Cursor<&[u8]>,

--- a/omniphony-renderer/renderer/src/render_backend/room_transform.rs
+++ b/omniphony-renderer/renderer/src/render_backend/room_transform.rs
@@ -3,53 +3,9 @@
 //! distance from). Previously each backend carried its own private copy of this
 //! transform.
 
-/// Non-linear depth warp applied to the Y (front/back) axis using the front,
-/// rear and centre-blend room ratios.
-#[inline]
-pub(crate) fn map_depth_with_room_ratios(
-    depth: f32,
-    front_ratio: f32,
-    rear_ratio: f32,
-    center_blend: f32,
-) -> f32 {
-    let d = depth.clamp(-1.0, 1.0);
-    let blend = center_blend.clamp(0.0, 1.0);
-    let center_ratio = rear_ratio + (front_ratio - rear_ratio) * blend;
-    if d >= 0.0 {
-        let t = d;
-        let a = center_ratio - front_ratio;
-        let b = 2.0 * (front_ratio - center_ratio);
-        a * t * t * t + b * t * t + center_ratio * t
-    } else {
-        let t = -d;
-        let a = center_ratio - rear_ratio;
-        let b = 2.0 * (rear_ratio - center_ratio);
-        -(a * t * t * t + b * t * t + center_ratio * t)
-    }
-}
-
 /// Scale an ADM position into room-relative effect space: the coordinates the
 /// gain models pan in and from which distance attenuation measures distance.
-#[inline]
-pub fn room_scaled_position(
-    position: [f32; 3],
-    room_ratio: [f32; 3],
-    room_ratio_rear: f32,
-    room_ratio_lower: f32,
-    room_ratio_center_blend: f32,
-) -> [f32; 3] {
-    [
-        position[0] * room_ratio[0],
-        map_depth_with_room_ratios(
-            position[1],
-            room_ratio[1],
-            room_ratio_rear,
-            room_ratio_center_blend,
-        ),
-        if position[2] >= 0.0 {
-            position[2] * room_ratio[2]
-        } else {
-            position[2] * room_ratio_lower
-        },
-    ]
-}
+///
+/// The depth warp it applies to the Y axis is
+/// `omniphony_geometry::f32::map_depth`.
+pub use omniphony_geometry::f32::room_scaled_position;

--- a/omniphony-renderer/renderer/src/spatial_vbap/coords.rs
+++ b/omniphony-renderer/renderer/src/spatial_vbap/coords.rs
@@ -1,42 +1,15 @@
+//! ADM coordinate conversions.
+//!
+//! The implementations live in `omniphony-geometry`, which the Studio backend
+//! shares, so both ends of the OSC link agree on what an azimuth means.
+//!
+//! ADM:
+//! - X: left(-) -> right(+)
+//! - Y: back(-) -> front(+)
+//! - Z: floor(-) -> ceiling(+)
+
 /// Convert ADM coordinates to spherical angles + distance.
-///
-/// ADM:
-/// - X: left(-) -> right(+)
-/// - Y: back(-) -> front(+)
-/// - Z: floor(-) -> ceiling(+)
-pub fn adm_to_spherical(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
-    let distance = (x * x + y * y + z * z).sqrt();
-    let r_horizontal = (x * x + y * y).sqrt();
-
-    let azimuth_deg = x.atan2(y).to_degrees();
-
-    // Keep exact vertical directions stable:
-    // (x,y) ~= (0,0), z>0 => +90°, z<0 => -90°, origin => 0°.
-    let elevation_deg = if r_horizontal < 1e-6 {
-        if z > 0.0 {
-            90.0
-        } else if z < 0.0 {
-            -90.0
-        } else {
-            0.0
-        }
-    } else {
-        z.atan2(r_horizontal).to_degrees()
-    };
-
-    (azimuth_deg, elevation_deg, distance)
-}
+pub use omniphony_geometry::f32::to_spherical as adm_to_spherical;
 
 /// Convert spherical angles + distance to ADM coordinates.
-pub fn spherical_to_adm(azimuth_deg: f32, elevation_deg: f32, distance: f32) -> (f32, f32, f32) {
-    let az_rad = azimuth_deg.to_radians();
-    let el_rad = elevation_deg.to_radians();
-
-    let r_horizontal = distance * el_rad.cos();
-
-    let x = r_horizontal * az_rad.sin();
-    let y = r_horizontal * az_rad.cos();
-    let z = distance * el_rad.sin();
-
-    (x, y, z)
-}
+pub use omniphony_geometry::f32::from_spherical as spherical_to_adm;

--- a/omniphony-renderer/renderer/src/speaker_layout.rs
+++ b/omniphony-renderer/renderer/src/speaker_layout.rs
@@ -36,33 +36,12 @@
 //! ```
 
 use anyhow::{Context, Result};
+use omniphony_geometry::f32 as geometry;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
-
-fn map_depth_with_room_ratios(
-    depth: f32,
-    front_ratio: f32,
-    rear_ratio: f32,
-    center_blend: f32,
-) -> f32 {
-    let d = depth.clamp(-1.0, 1.0);
-    let blend = center_blend.clamp(0.0, 1.0);
-    let center_ratio = rear_ratio + (front_ratio - rear_ratio) * blend;
-    if d >= 0.0 {
-        let t = d;
-        let a = center_ratio - front_ratio;
-        let b = 2.0 * (front_ratio - center_ratio);
-        a * t * t * t + b * t * t + center_ratio * t
-    } else {
-        let t = -d;
-        let a = center_ratio - rear_ratio;
-        let b = 2.0 * (rear_ratio - center_ratio);
-        -(a * t * t * t + b * t * t + center_ratio * t)
-    }
-}
 
 /// Legacy 0-9 bed id for a channel label. The renderer no longer routes by
 /// bed id — the only remaining consumer is the CLI file-export bed
@@ -145,29 +124,6 @@ fn default_radius_m() -> f32 {
     1.0
 }
 
-fn spherical_to_cartesian(azimuth: f32, elevation: f32, distance: f32) -> (f32, f32, f32) {
-    let az = azimuth.to_radians();
-    let el = elevation.to_radians();
-    // Keep speaker cartesian persistence aligned with the renderer ADM convention:
-    // x = right, y = front, z = up.
-    let horizontal = distance * el.cos();
-    let x = horizontal * az.sin();
-    let y = horizontal * az.cos();
-    let z = distance * el.sin();
-    (x.clamp(-1.0, 1.0), y.clamp(-1.0, 1.0), z.clamp(-1.0, 1.0))
-}
-
-fn cartesian_to_spherical(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
-    let dist = (x * x + y * y + z * z).sqrt();
-    let az = x.atan2(y).to_degrees();
-    let el = if dist > 0.0 {
-        z.atan2((x * x + y * y).sqrt()).to_degrees()
-    } else {
-        0.0
-    };
-    (az, el, dist.max(0.01))
-}
-
 fn speaker_with_distance(
     name: impl Into<String>,
     azimuth: f32,
@@ -216,7 +172,7 @@ impl<'de> Deserialize<'de> for Speaker {
                 let x = x.clamp(-1.0, 1.0);
                 let y = y.clamp(-1.0, 1.0);
                 let z = z.clamp(-1.0, 1.0);
-                let (az, el, dist) = cartesian_to_spherical(x, y, z);
+                let (az, el, dist) = geometry::to_spherical(x, y, z);
                 (
                     raw.azimuth.unwrap_or(az),
                     raw.elevation.unwrap_or(el),
@@ -229,7 +185,7 @@ impl<'de> Deserialize<'de> for Speaker {
                 let az = raw.azimuth.unwrap_or(0.0);
                 let el = raw.elevation.unwrap_or(0.0);
                 let dist = raw.distance.unwrap_or(1.0).max(0.01);
-                let (x, y, z) = spherical_to_cartesian(az, el, dist);
+                let (x, y, z) = geometry::hydrate_from_spherical(az, el, dist);
                 (az, el, dist, x, y, z)
             };
         Ok(Self {
@@ -294,7 +250,7 @@ impl Speaker {
         delay_ms: f32,
     ) -> Self {
         let distance = distance.max(0.01);
-        let (x, y, z) = spherical_to_cartesian(azimuth, elevation, distance);
+        let (x, y, z) = geometry::hydrate_from_spherical(azimuth, elevation, distance);
         Self {
             name: name.into(),
             azimuth,
@@ -326,7 +282,7 @@ impl Speaker {
         let x = x.clamp(-1.0, 1.0);
         let y = y.clamp(-1.0, 1.0);
         let z = z.clamp(-1.0, 1.0);
-        let (azimuth, elevation, distance) = cartesian_to_spherical(x, y, z);
+        let (azimuth, elevation, distance) = geometry::to_spherical(x, y, z);
         Self {
             name: name.into(),
             azimuth,
@@ -489,7 +445,7 @@ impl SpeakerLayout {
             }
             let pos = if speaker.coord_mode.eq_ignore_ascii_case("cartesian") {
                 let scaled_x = speaker.x * room_ratio[0];
-                let scaled_y = map_depth_with_room_ratios(
+                let scaled_y = geometry::map_depth(
                     speaker.y,
                     room_ratio[1],
                     room_ratio_rear,

--- a/omniphony-renderer/runtime_control/Cargo.toml
+++ b/omniphony-renderer/runtime_control/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "GPL-3.0-or-later"
 
 [dependencies]
+omniphony-geometry = { version = "0.1.0", path = "../omniphony-geometry" }
 anyhow = "1.0.99"
 log = "0.4.27"
 renderer = { path = "../renderer" }

--- a/omniphony-renderer/runtime_control/src/osc.rs
+++ b/omniphony-renderer/runtime_control/src/osc.rs
@@ -1,5 +1,6 @@
 use crate::context::RuntimeControlContext;
 use crate::osc_contract;
+use omniphony_geometry::f32 as geometry;
 use renderer::live_params::LiveEvaluationMode;
 use renderer::render_backend::canonical_builtin_backend_id;
 use rosc::{OscMessage, OscType};
@@ -305,27 +306,6 @@ pub fn parse_input_layout_arg(
     serde_yaml_ng::from_str::<renderer::speaker_layout::SpeakerLayout>(&raw).ok()
 }
 
-fn spherical_to_cartesian(azimuth: f32, elevation: f32, distance: f32) -> (f32, f32, f32) {
-    let az = azimuth.to_radians();
-    let el = elevation.to_radians();
-    let horizontal = distance * el.cos();
-    let x = horizontal * az.sin();
-    let y = horizontal * az.cos();
-    let z = distance * el.sin();
-    (x.clamp(-1.0, 1.0), y.clamp(-1.0, 1.0), z.clamp(-1.0, 1.0))
-}
-
-fn cartesian_to_spherical(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
-    let dist = (x * x + y * y + z * z).sqrt();
-    let az = x.atan2(y).to_degrees();
-    let el = if dist > 0.0 {
-        z.atan2((x * x + y * y).sqrt()).to_degrees()
-    } else {
-        0.0
-    };
-    (az, el, dist.max(0.01))
-}
-
 fn remap_live_speakers_remove(
     speakers: &mut std::collections::HashMap<usize, renderer::live_params::SpeakerLiveParams>,
     remove_idx: usize,
@@ -450,7 +430,7 @@ fn apply_layout_speaker_patch(
         let x = patch.x.unwrap_or(speaker.x).clamp(-1.0, 1.0);
         let y = patch.y.unwrap_or(speaker.y).clamp(-1.0, 1.0);
         let z = patch.z.unwrap_or(speaker.z).clamp(-1.0, 1.0);
-        let (azimuth, elevation, distance) = cartesian_to_spherical(x, y, z);
+        let (azimuth, elevation, distance) = geometry::hydrate_from_cartesian(x, y, z);
         if speaker.x != x
             || speaker.y != y
             || speaker.z != z
@@ -476,7 +456,7 @@ fn apply_layout_speaker_patch(
             .unwrap_or(speaker.elevation)
             .clamp(-90.0, 90.0);
         let distance = patch.distance.unwrap_or(speaker.distance).max(0.01);
-        let (x, y, z) = spherical_to_cartesian(azimuth, elevation, distance);
+        let (x, y, z) = geometry::hydrate_from_spherical(azimuth, elevation, distance);
         if speaker.azimuth != azimuth
             || speaker.elevation != elevation
             || speaker.distance != distance
@@ -540,7 +520,7 @@ fn build_layout_speaker_from_patch(
         let x = patch.x.unwrap_or(speaker.x).clamp(-1.0, 1.0);
         let y = patch.y.unwrap_or(speaker.y).clamp(-1.0, 1.0);
         let z = patch.z.unwrap_or(speaker.z).clamp(-1.0, 1.0);
-        let (azimuth, elevation, distance) = cartesian_to_spherical(x, y, z);
+        let (azimuth, elevation, distance) = geometry::hydrate_from_cartesian(x, y, z);
         speaker.x = x;
         speaker.y = y;
         speaker.z = z;


### PR DESCRIPTION
Re-lands the content of #294, which never reached `main`.

#294 was merged into `feat/shared-geometry-crate` rather than `main`, and #293 was then merged from a cached 2-commit state — so the crate landed but this did not. Same commit, cherry-picked onto current `main`, targeting `main` directly this time.

## What goes away

| Kind | Copies removed |
|---|---|
| Room depth warp | `renderer::speaker_layout`, `render_backend::room_transform`, `render_backend::file_loaded_evaluator`, `orender_engine::virtual_bed` (+ its 28-iteration bisection inverse and `inverse_room_ratio_map_for_virtual_object`) |
| Cartesian/polar | `renderer::speaker_layout`, `spatial_vbap::coords`, `runtime_control::osc` |
| Angle helpers | `render_backend::{wrap_degrees, wrapped_angle_distance}`, `orender_engine::spatial::normalize_azimuth_deg` |

**−291 / +40** across 11 files. The public names callers use are kept as re-exports, so no call site outside these files moves.

## Behaviour

The warp, its inverse and the room scaling are identical term for term. Two spots differ, only where the old code was less careful:

- **`speaker_layout::cartesian_to_spherical` had no pole guard.** A position within 1e-6 of the vertical axis got `atan2` noise rather than an exact ±90°. The crate special-cases it — which `spatial_vbap::coords` already did, so this makes the two agree. Identical *on* the axis; ~6e-8 degrees apart beside it.
- **`wrapped_angle_distance` took `(a - b).abs()` before `rem_euclid`.** `rem_euclid` is already non-negative, and for a negative delta returns `360 - |delta| mod 360`, which the following `min` folds back to the same value. Redundant for every input.

Every call site of the clamping variants already applied the clamps that `hydrate_from_cartesian`/`hydrate_from_spherical` fold in.

## Verification

- `cargo test --workspace`: **33 test binaries, 0 failures**, re-run on this branch against current `main` — including the 324-test renderer suite and the VBAP parity/conformance integration tests.
- `cargo fmt --all --check` clean.

## Not verified

No live audio check. Nothing here should be audible — the arithmetic is unchanged — but the warp feeds the VBAP pan space, so it deserves one listening pass before a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)