### PR TITLE
Compute meter peak-hold in the backend

### DIFF
--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod engine_deploy;
 mod layouts;
 mod osc_listener;
 mod osc_parser;
+mod peak_hold;
 mod runtime_env;
 mod timing_stats;
 

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -16,6 +16,7 @@ use crate::osc_parser::{
     is_heartbeat_address, parse_osc_message, CoordinateFormat, HeartbeatResponse, LogEntry,
     OscEvent,
 };
+use crate::peak_hold::PeakHolds;
 use crate::timing_stats::TimeWindow;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -1769,6 +1770,21 @@ thread_local! {
     // as EMIT_BATCH: recorded and flushed only from the OSC thread, so no lock.
     static TIMING_WINDOWS: std::cell::RefCell<TimingWindows> =
         std::cell::RefCell::new(TimingWindows::new());
+    // Per-meter peak-hold. Same ownership rule as EMIT_BATCH: only the OSC
+    // thread touches it, so no lock.
+    static PEAK_HOLDS: std::cell::RefCell<PeakHolds> =
+        std::cell::RefCell::new(PeakHolds::new());
+}
+
+/// Advance a meter's peak-hold and return the cursor value, in dBFS.
+fn peak_hold(key: &str, peak_dbfs: f64) -> f64 {
+    PEAK_HOLDS.with(|h| h.borrow_mut().update(key, peak_dbfs, Instant::now()))
+}
+
+/// Drop a meter's hold state — a removed object must not leave a cursor
+/// behind for the next object to inherit its id.
+fn forget_peak_hold(key: &str) {
+    PEAK_HOLDS.with(|h| h.borrow_mut().forget(key));
 }
 
 /// Span the raw-latency min/max markers cover. Mirrors what the frontend used
@@ -1937,7 +1953,11 @@ fn derived_master_meter(
         METER_DB_MIN
     };
     Some(serde_json::json!({
-        "meter": { "peakDbfs": peak_dbfs, "rmsDbfs": rms_dbfs },
+        "meter": {
+            "peakDbfs": peak_dbfs,
+            "rmsDbfs": rms_dbfs,
+            "peakHoldDbfs": peak_hold("master", peak_dbfs),
+        },
         // Lets the frontend tell a reconstructed meter from a reported one —
         // for display or diagnosis, not for choosing a code path.
         "derived": true,
@@ -2185,6 +2205,10 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
             }
 
             OscEvent::Remove { id } => {
+                // Drop the hold too: object ids are reused across tracks and
+                // seeks, and an inherited cursor would show a peak the new
+                // object never produced.
+                forget_peak_hold(&format!("src:{id}"));
                 s.sources.remove(&id);
                 s.source_levels.remove(&id);
                 s.object_speaker_gains.remove(&id);
@@ -2221,6 +2245,7 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                                 "peakDbfs": peak_dbfs,
                                 "rmsDbfs": rms_dbfs,
                                 "bandRmsDbfs": band_rms_dbfs,
+                                "peakHoldDbfs": peak_hold(&format!("src:{id}"), peak_dbfs),
                             }
                         }),
                     )),
@@ -2281,7 +2306,11 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                         "speaker:meter",
                         serde_json::json!({
                             "id": id,
-                            "meter": { "peakDbfs": peak_dbfs, "rmsDbfs": rms_dbfs }
+                            "meter": {
+                                "peakDbfs": peak_dbfs,
+                                "rmsDbfs": rms_dbfs,
+                                "peakHoldDbfs": peak_hold(&format!("spk:{id}"), peak_dbfs),
+                            }
                         }),
                     )),
                     removed_ids,
@@ -2297,7 +2326,11 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                     "ear:meter",
                     serde_json::json!({
                         "id": id,
-                        "meter": { "peakDbfs": peak_dbfs, "rmsDbfs": rms_dbfs }
+                        "meter": {
+                            "peakDbfs": peak_dbfs,
+                            "rmsDbfs": rms_dbfs,
+                            "peakHoldDbfs": peak_hold(&format!("ear:{id}"), peak_dbfs),
+                        }
                     }),
                 )),
                 removed_ids,
@@ -2315,7 +2348,11 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                     Some((
                         "master:meter",
                         serde_json::json!({
-                            "meter": { "peakDbfs": peak_dbfs, "rmsDbfs": rms_dbfs }
+                            "meter": {
+                                "peakDbfs": peak_dbfs,
+                                "rmsDbfs": rms_dbfs,
+                                "peakHoldDbfs": peak_hold("master", peak_dbfs),
+                            }
                         }),
                     )),
                     removed_ids,
@@ -3319,6 +3356,9 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
     }; // mutex released here, before any emit
 
     for id in removed_ids {
+        // Same reason as the single-object removal above: a bulk wipe (reset,
+        // seek, track change) must not leave holds for ids that come back.
+        forget_peak_hold(&format!("src:{id}"));
         let _ = app.emit("source:remove", serde_json::json!({ "id": id }));
     }
 

--- a/omniphony-studio/src-tauri/src/peak_hold.rs
+++ b/omniphony-studio/src-tauri/src/peak_hold.rs
@@ -1,0 +1,294 @@
+//! Peak-hold for the level meters.
+//!
+//! The bar follows the instantaneous peak; a cursor holds the loudest recent
+//! value so a transient stays readable after it has passed. The frontend had
+//! two copies of this — one for object and speaker meters, one inlined for the
+//! master meter — each keeping its own hold state per meter.
+//!
+//! # Decay is per-second here, not per-frame
+//!
+//! The JS decayed by a fixed 2 dB **each time it repainted**, so the fall rate
+//! was whatever the UI render loop happened to be running at, and a browser
+//! that throttled the tab slowed the meters down with it. This decays by
+//! elapsed time instead. [`DECAY_DB_PER_SEC`] is set so the two agree at the
+//! 60 Hz the loop normally runs at; away from that they deliberately differ,
+//! because tying a physical fall rate to repaint cadence was the bug.
+//!
+//! # The re-arm
+//!
+//! Decay does not simply run to the floor. Once the held value falls back to
+//! the bar, the hold re-arms for another second — otherwise a cursor sitting on
+//! a sustained level would keep sliding down through it. The comparison is made
+//! in *bar percent*, not dB, because that is where the frontend made it and the
+//! scale clamps at both ends: two different dB values can share a percent, and
+//! at the rails they do.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Bottom of the meter scale, in dBFS (`METER_DB_MIN` in `src/mute-solo.js`).
+pub const METER_DB_MIN: f64 = -60.0;
+/// Top of the meter scale, in dBFS (`METER_DB_MAX` in `src/mute-solo.js`).
+pub const METER_DB_MAX: f64 = 6.0;
+
+/// How long the cursor sits still before it starts falling.
+const HOLD: Duration = Duration::from_millis(1000);
+
+/// Fall rate once the hold expires.
+///
+/// The frontend used 2 dB per repaint at ~60 Hz; 2 × 60 = 120 dB/s is the same
+/// slope expressed in a unit that does not depend on the render loop.
+const DECAY_DB_PER_SEC: f64 = 120.0;
+
+/// How close, in bar percent, the held value must come to the bar to re-arm the
+/// hold. Mirrors the frontend's `peak.value <= levelPercent + 0.1`.
+const REARM_PERCENT_EPSILON: f64 = 0.1;
+
+/// Position of a level on the meter bar, 0-100.
+///
+/// Mirrors `dbToMeterPercent` in `src/mute-solo.js`: linear in dB between the
+/// scale's ends, clamped at both. 0 dBFS lands near 90.9%, leaving the headroom
+/// zone above it where clipping stays visible.
+pub fn db_to_meter_percent(db: f64) -> f64 {
+    let v = if db.is_finite() { db } else { METER_DB_MIN };
+    (((v - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN)) * 100.0).clamp(0.0, 100.0)
+}
+
+#[derive(Clone, Copy)]
+struct Hold {
+    db: f64,
+    /// When the cursor may start falling.
+    falls_after: Instant,
+    /// Last time this hold was advanced, so decay can be time-based.
+    updated_at: Instant,
+}
+
+/// Per-meter hold state, keyed by the caller's meter id.
+#[derive(Default)]
+pub struct PeakHolds {
+    holds: HashMap<String, Hold>,
+}
+
+impl PeakHolds {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold in a new instantaneous peak and return the value the cursor should
+    /// now show, in dBFS.
+    ///
+    /// `now` is passed rather than read so the behaviour is testable; callers
+    /// use [`Instant::now`].
+    pub fn update(&mut self, key: &str, peak_db: f64, now: Instant) -> f64 {
+        let peak_db = if peak_db.is_finite() {
+            peak_db
+        } else {
+            METER_DB_MIN
+        };
+
+        let hold = match self.holds.get(key).copied() {
+            // A new peak at or above the held one re-arms from scratch. `>=`
+            // rather than `>` matches the frontend, and means a sustained level
+            // keeps the cursor pinned instead of letting it creep down.
+            Some(h) if peak_db < h.db => h,
+            _ => {
+                let fresh = Hold {
+                    db: peak_db,
+                    falls_after: now + HOLD,
+                    updated_at: now,
+                };
+                self.holds.insert(key.to_string(), fresh);
+                return fresh.db;
+            }
+        };
+
+        if now <= hold.falls_after {
+            // Still holding: the cursor does not move, but the clock does, so
+            // the first decay step after the hold measures from here.
+            let held = Hold {
+                updated_at: now,
+                ..hold
+            };
+            self.holds.insert(key.to_string(), held);
+            return held.db;
+        }
+
+        let elapsed = now.saturating_duration_since(hold.updated_at).as_secs_f64();
+        let decayed = (hold.db - DECAY_DB_PER_SEC * elapsed).max(peak_db);
+        let mut next = Hold {
+            db: decayed,
+            falls_after: hold.falls_after,
+            updated_at: now,
+        };
+        // Landed back on the bar: hold again rather than sliding through it.
+        if db_to_meter_percent(decayed) <= db_to_meter_percent(peak_db) + REARM_PERCENT_EPSILON {
+            next.falls_after = now + HOLD;
+        }
+        self.holds.insert(key.to_string(), next);
+        next.db
+    }
+
+    /// Forget a meter, so a removed object does not leave state behind.
+    pub fn forget(&mut self, key: &str) {
+        self.holds.remove(key);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.holds.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(base: Instant, ms: u64) -> Instant {
+        base + Duration::from_millis(ms)
+    }
+
+    #[test]
+    fn the_first_peak_is_held_as_is() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        assert_eq!(holds.update("a", -12.0, t0), -12.0);
+    }
+
+    #[test]
+    fn a_louder_peak_takes_over_immediately() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", -30.0, t0);
+        assert_eq!(holds.update("a", -6.0, at(t0, 10)), -6.0);
+    }
+
+    #[test]
+    fn a_quieter_peak_does_not_move_the_cursor_during_the_hold() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", -6.0, t0);
+        // Well inside the 1 s hold.
+        assert_eq!(holds.update("a", -40.0, at(t0, 500)), -6.0);
+        assert_eq!(holds.update("a", -40.0, at(t0, 999)), -6.0);
+    }
+
+    #[test]
+    fn the_cursor_falls_once_the_hold_expires() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", -6.0, t0);
+        holds.update("a", -40.0, at(t0, 1000));
+        // 100 ms past the hold at 120 dB/s would be 12 dB, but the value is
+        // measured from the previous update, which was at t=1000.
+        let value = holds.update("a", -40.0, at(t0, 1100));
+        assert!(
+            (value - (-18.0)).abs() < 1e-6,
+            "expected -18 after 100 ms of decay, got {value}"
+        );
+    }
+
+    /// The frontend fell 2 dB per repaint at ~60 Hz. One 16.67 ms step here
+    /// must move the cursor by the same 2 dB, or every meter in the app decays
+    /// at a visibly different rate than before.
+    #[test]
+    fn one_frame_of_decay_matches_the_frontend_step() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", 0.0, t0);
+        holds.update("a", -60.0, at(t0, 1000));
+        let after_one_frame = holds.update("a", -60.0, at(t0, 1000 + 17));
+        // 17 ms at 120 dB/s = 2.04 dB.
+        assert!(
+            (after_one_frame - (-2.04)).abs() < 0.01,
+            "one frame moved the cursor to {after_one_frame}, expected about -2.04"
+        );
+    }
+
+    #[test]
+    fn the_cursor_never_falls_below_the_current_peak() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", 0.0, t0);
+        holds.update("a", -20.0, at(t0, 1000));
+        // A full second of decay would be 120 dB; the live peak stops it.
+        let value = holds.update("a", -20.0, at(t0, 2000));
+        assert_eq!(value, -20.0);
+    }
+
+    /// Once the cursor lands on the bar the hold re-arms, so a sustained level
+    /// keeps its cursor instead of letting it slide away.
+    #[test]
+    fn landing_on_the_bar_re_arms_the_hold() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", 0.0, t0);
+        // Decay all the way down to the sustained level.
+        holds.update("a", -20.0, at(t0, 1000));
+        let landed = holds.update("a", -20.0, at(t0, 2000));
+        assert_eq!(landed, -20.0);
+        // Re-armed: a further second must not move it, because the hold
+        // restarted when it landed.
+        let still = holds.update("a", -20.0, at(t0, 2500));
+        assert_eq!(still, -20.0);
+    }
+
+    #[test]
+    fn holds_are_independent_per_meter() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", -6.0, t0);
+        holds.update("b", -40.0, t0);
+        assert_eq!(holds.update("a", -50.0, at(t0, 100)), -6.0);
+        assert_eq!(holds.update("b", -50.0, at(t0, 100)), -40.0);
+    }
+
+    #[test]
+    fn a_non_finite_peak_reads_as_the_floor() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        assert_eq!(holds.update("a", f64::NAN, t0), METER_DB_MIN);
+    }
+
+    #[test]
+    fn forgetting_a_meter_drops_its_state() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", -6.0, t0);
+        assert_eq!(holds.len(), 1);
+        holds.forget("a");
+        assert_eq!(holds.len(), 0);
+        // And it starts clean rather than resuming the old hold.
+        assert_eq!(holds.update("a", -40.0, at(t0, 10)), -40.0);
+    }
+
+    // ── the percent mapping the re-arm depends on ───────────────────────────
+
+    #[test]
+    fn the_meter_scale_matches_the_frontend() {
+        assert_eq!(db_to_meter_percent(METER_DB_MIN), 0.0);
+        assert_eq!(db_to_meter_percent(METER_DB_MAX), 100.0);
+        // 0 dBFS sits near 90.9%, leaving the headroom zone above it.
+        assert!((db_to_meter_percent(0.0) - 90.909).abs() < 0.01);
+    }
+
+    #[test]
+    fn the_meter_scale_clamps_at_both_ends() {
+        assert_eq!(db_to_meter_percent(-200.0), 0.0);
+        assert_eq!(db_to_meter_percent(60.0), 100.0);
+        assert_eq!(db_to_meter_percent(f64::NAN), 0.0);
+    }
+
+    /// Both ends of the scale clamp, so two different dB values share a
+    /// percent there. That is why the re-arm compares percent and not dB.
+    #[test]
+    fn the_re_arm_triggers_at_the_rail_where_db_would_still_differ() {
+        let mut holds = PeakHolds::new();
+        let t0 = Instant::now();
+        holds.update("a", -50.0, t0);
+        // Decay past the bottom of the scale: -70 and -200 are different dB
+        // values but both read as 0%.
+        let value = holds.update("a", -200.0, at(t0, 2000));
+        assert!(value <= METER_DB_MIN, "cursor was {value}");
+        assert_eq!(db_to_meter_percent(value), 0.0);
+    }
+}

--- a/omniphony-studio/src/audio-math.js
+++ b/omniphony-studio/src/audio-math.js
@@ -1,0 +1,26 @@
+/**
+ * Numeric audio-level conversions.
+ *
+ * Separate from the *formatting* helpers in `mute-solo.js`: `formatLinearAsDb`
+ * returns a display string like `"-12.3 dB"`, which is why several call sites
+ * had grown their own inline `20 * Math.log10(x)` — the existing helper could
+ * not give them a number to compute with.
+ *
+ * Anything that needs the value rather than the label belongs here. (A
+ * `dbToLinear` counterpart lived in `mute-solo.js` with no callers at all; it
+ * is gone rather than moved.)
+ */
+
+/**
+ * Amplitude ratio → dBFS.
+ *
+ * Zero and negative ratios have no logarithm, so they return `floorDb` rather
+ * than `-Infinity`, which would saturate any scale it reached.
+ */
+export function linearToDb(value, floorDb = -100) {
+  const v = Number(value);
+  if (!Number.isFinite(v) || v <= 0) {
+    return floorDb;
+  }
+  return 20 * Math.log10(v);
+}

--- a/omniphony-studio/src/controls/drc.js
+++ b/omniphony-studio/src/controls/drc.js
@@ -1,3 +1,4 @@
+import { linearToDb } from '../audio-math.js';
 import { app } from '../state.js';
 import { invoke } from '@tauri-apps/api/core';
 import { t } from '../i18n.js';
@@ -112,7 +113,7 @@ export function updateDrcMeterUI(gain) {
 
     if (!drcGaugeFillEl || !drcGainValueEl) return;
 
-    const gainDb = gain > 0 ? 20 * Math.log10(gain) : -100;
+    const gainDb = linearToDb(gain);
     const displayedDb = Number.isFinite(gainDb) ? gainDb : -100;
 
     // Max absolute delta for gauge display (e.g. +/-20dB).

--- a/omniphony-studio/src/controls/master.js
+++ b/omniphony-studio/src/controls/master.js
@@ -4,16 +4,16 @@
  * Extracted from app.js (lines 4547-4590).
  */
 
+import { linearToDb } from '../audio-math.js';
 import {
   app,
   dirty,
   supportsRealtimeKey,
-  masterPeak,
   masterLevel
 } from '../state.js';
 import { t, tf } from '../i18n.js';
 import { formatNumber } from '../coordinates.js';
-import { linearToDb, dbToMeterPercent, METER_DB_MIN } from '../mute-solo.js';
+import { formatLinearAsDb, dbToMeterPercent, METER_DB_MIN } from '../mute-solo.js';
 import { scheduleUIFlush } from '../flush.js';
 import { inAudioPanel, inRendererPanel, inDrcPanel } from '../ui/panel-roots.js';
 
@@ -36,7 +36,7 @@ export function renderMasterGainUI() {
   }
   if (masterGainBoxEl) {
     const hasValue = Number.isFinite(app.masterGain) && app.masterGain > 0;
-    masterGainBoxEl.textContent = hasValue ? linearToDb(app.masterGain) : '—';
+    masterGainBoxEl.textContent = hasValue ? formatLinearAsDb(app.masterGain) : '—';
   }
 }
 
@@ -114,9 +114,11 @@ function getMasterMeter() {
     return null;
   }
   const rmsDb = masterLevel.rmsDbfs;
+  const peakDb = typeof masterLevel.peakDbfs === 'number' ? masterLevel.peakDbfs : rmsDb;
   return {
     rmsDb,
-    peakDb: typeof masterLevel.peakDbfs === 'number' ? masterLevel.peakDbfs : rmsDb
+    peakDb,
+    holdDb: typeof masterLevel.peakHoldDbfs === 'number' ? masterLevel.peakHoldDbfs : peakDb
   };
 }
 
@@ -145,23 +147,14 @@ export function updateMasterMeterUI() {
   const levelPercent = dbToMeterPercent(peakDb);
   masterMeterFillEl.style.setProperty('--level', `${levelPercent.toFixed(1)}%`);
 
-  const now = Date.now();
-  if (peakDb >= (masterPeak.db ?? METER_DB_MIN)) {
-    masterPeak.db = peakDb;
-    masterPeak.value = dbToMeterPercent(peakDb);
-    masterPeak.expires = now + 1000;
-  } else if (now > masterPeak.expires) {
-    masterPeak.db = Math.max(peakDb, masterPeak.db - 2.0);
-    masterPeak.value = dbToMeterPercent(masterPeak.db);
-    if (masterPeak.value <= levelPercent + 0.1) masterPeak.expires = now + 1000;
-  }
-
   masterMeterTextEl.textContent = `${formatNumber(rmsDb, 1)} dB`;
 
   if (masterMeterPeakEl) {
-    masterMeterPeakEl.style.setProperty('--level', `${masterPeak.value.toFixed(1)}%`);
-    masterMeterPeakEl.style.opacity = masterPeak.value > 0.1 ? '1' : '0';
-    masterMeterPeakEl.classList.toggle('over', (masterPeak.db ?? METER_DB_MIN) >= 0);
+    // Hold and decay come from the backend, same as every other meter.
+    const holdPercent = dbToMeterPercent(level.holdDb);
+    masterMeterPeakEl.style.setProperty('--level', `${holdPercent.toFixed(1)}%`);
+    masterMeterPeakEl.style.opacity = holdPercent > 0.1 ? '1' : '0';
+    masterMeterPeakEl.classList.toggle('over', level.holdDb >= 0);
   }
 }
 
@@ -179,7 +172,7 @@ export function renderLoudnessDisplay() {
   const correctionDbValue =
     app.loudnessGain === null || Number(app.loudnessGain) <= 0
       ? null
-      : 20 * Math.log10(Number(app.loudnessGain));
+      : linearToDb(app.loudnessGain);
   const targetValue =
     app.loudnessSource !== null && correctionDbValue !== null
       ? app.loudnessSource + correctionDbValue
@@ -188,7 +181,7 @@ export function renderLoudnessDisplay() {
   const gainText =
     app.loudnessGain === null
       ? '—'
-      : `${formatNumber(app.loudnessGain, 2)} (${linearToDb(app.loudnessGain)})`;
+      : `${formatNumber(app.loudnessGain, 2)} (${formatLinearAsDb(app.loudnessGain)})`;
   loudnessInfoEl.innerHTML = [
     `source loudness: ${sourceText}`,
     `target loudness: ${targetText}`,

--- a/omniphony-studio/src/mute-solo.js
+++ b/omniphony-studio/src/mute-solo.js
@@ -1,7 +1,7 @@
 /**
  * Audio level utilities and mute/solo/gain logic.
  *
- * Extracted from app.js — formatLevel, meterToPercent, linearToDb, dbToLinear,
+ * Extracted from app.js — formatLevel, meterToPercent, formatLinearAsDb,
  * updateMeterUI, send*Gain, send*Mute, solo helpers, applyGroupGains,
  * getBaseGain, toggleMute, toggleSolo.
  */
@@ -10,6 +10,7 @@ import { OBJECT_TEST_SOURCE_ID } from './object-test-id.js';
 import { setObjectTestMuted } from './controls/object-test.js';
 import { invoke } from '@tauri-apps/api/core';
 import { formatNumber } from './coordinates.js';
+import { linearToDb } from './audio-math.js';
 import {
   speakerMuted,
   objectMuted,
@@ -17,8 +18,6 @@ import {
   objectManualMuted,
   speakerGainCache,
   speakerBaseGains,
-  speakerPeaks,
-  sourcePeaks,
   speakerItems,
   objectItems,
   sourceMeshes,
@@ -64,42 +63,29 @@ export function meterToPercent(meter) {
   return dbToMeterPercent(db);
 }
 
-export function linearToDb(value) {
+/**
+ * Amplitude ratio → display string, e.g. `"-12.3 dB"`.
+ *
+ * Named for what it returns: a label, not a number. For the value, use
+ * `linearToDb` in `audio-math.js`.
+ */
+export function formatLinearAsDb(value) {
   const v = Number(value);
   if (!Number.isFinite(v) || v <= 0) {
     return '-∞ dB';
   }
-  return `${(20 * Math.log10(v)).toFixed(1)} dB`;
-}
-
-export function dbToLinear(db) {
-  const v = Number(db);
-  if (!Number.isFinite(v)) {
-    return 0;
-  }
-  return Math.pow(10, v / 20);
+  return `${linearToDb(v).toFixed(1)} dB`;
 }
 
 // ---------------------------------------------------------------------------
 // Meter UI
 // ---------------------------------------------------------------------------
 
-// Shared peak-hold for the level meters: the bar (meterFill) follows the RMS,
-// while the cursor holds the engine-reported true sample peak (peakDbfs) with a
-// 1 s hold then decay. The cursor turns red (`.over`) once the held peak crosses
-// 0 dBFS, into the headroom zone.
-export function updatePeakHold(peaksMap, id, peakDb, levelPercent, now) {
-  let peak = id !== null ? peaksMap.get(id) : null;
-  if (!peak || peakDb >= (peak.db ?? METER_DB_MIN)) {
-    peak = { value: dbToMeterPercent(peakDb), db: peakDb, expires: now + 1000 };
-    if (id !== null) peaksMap.set(id, peak);
-  } else if (now > peak.expires) {
-    peak.db = Math.max(peakDb, peak.db - 2.0); // Decay DB value
-    peak.value = dbToMeterPercent(peak.db);
-    if (peak.value <= levelPercent + 0.1) peak.expires = now + 1000;
-  }
-  return peak;
-}
+// The peak cursor holds the engine-reported true sample peak so a transient
+// stays readable after it has passed. The hold and its decay are computed in
+// the backend (`src-tauri/src/peak_hold.rs`) and arrive as `peakHoldDbfs` on
+// every meter payload; the cursor turns red (`.over`) once the held peak
+// crosses 0 dBFS, into the headroom zone.
 
 export function updateMeterUI(entry, meter, type = null, id = null) {
   if (!entry) return;
@@ -111,15 +97,14 @@ export function updateMeterUI(entry, meter, type = null, id = null) {
   const levelPercent = dbToMeterPercent(peakDb);
 
   if (entry.peakCursor) {
-    const now = Date.now();
-    const peaksMap = type === 'speaker' ? speakerPeaks : sourcePeaks;
-    const peak = updatePeakHold(peaksMap, id, peakDb, levelPercent, now);
+    const holdDb = typeof meter?.peakHoldDbfs === 'number' ? meter.peakHoldDbfs : peakDb;
+    const holdPercent = dbToMeterPercent(holdDb);
 
     entry.levelText.textContent = `${formatNumber(rmsDb, 1)} dB`;
     entry.meterFill.style.setProperty('--level', `${levelPercent.toFixed(1)}%`);
-    entry.peakCursor.style.setProperty('--level', `${peak.value.toFixed(1)}%`);
-    entry.peakCursor.style.opacity = peak.value > 0.1 ? '1' : '0';
-    entry.peakCursor.classList.toggle('over', (peak.db ?? METER_DB_MIN) >= 0);
+    entry.peakCursor.style.setProperty('--level', `${holdPercent.toFixed(1)}%`);
+    entry.peakCursor.style.opacity = holdPercent > 0.1 ? '1' : '0';
+    entry.peakCursor.classList.toggle('over', holdDb >= 0);
   } else {
     entry.levelText.textContent = formatLevel(meter);
     entry.meterFill.style.setProperty('--level', `${levelPercent.toFixed(1)}%`);

--- a/omniphony-studio/src/sources.js
+++ b/omniphony-studio/src/sources.js
@@ -13,6 +13,7 @@
  * getObjectDisplayName, formatObjectLabel.
  */
 
+import { linearToDb } from './audio-math.js';
 import * as THREE from 'three';
 import {
   sourceMeshes,
@@ -75,7 +76,7 @@ import { disposeSpeakerBandBar, bandColor } from './scene/speaker-band-bars.js';
 import { createTrailRenderable } from './trails.js';
 import { shouldAppendTrailPoint, recordTrailPoint, shouldRebuildTrailGeometry } from './trails.js';
 import {
-  linearToDb,
+  formatLinearAsDb,
   meterToPercent,
   getSoloTarget,
   sendObjectMute
@@ -608,11 +609,11 @@ export function getSelectedSourceContribution(index) {
     if (!Number.isFinite(sourceRms) || rawGain <= 0) {
       return null;
     }
-    return sourceRms + (20 * Math.log10(rawGain));
+    return sourceRms + linearToDb(rawGain);
   })();
   return {
     gain: rawGain,
-    gainDb: linearToDb(rawGain),
+    gainDb: formatLinearAsDb(rawGain),
     resultDbfs,
     resultText: resultDbfs === null ? '\u2014 dBFS' : `${formatNumber(resultDbfs, 1)} dBFS`,
     percent: resultDbfs === null ? 0 : meterToPercent({ rmsDbfs: resultDbfs })
@@ -656,10 +657,10 @@ export function getSelectedSpeakerContributionForObject(id) {
   const sourceRms = Number(sourceMeter?.rmsDbfs);
   const resultDbfs = (!Number.isFinite(sourceRms) || rawGain <= 0)
     ? null
-    : sourceRms + (20 * Math.log10(rawGain));
+    : sourceRms + linearToDb(rawGain);
   return {
     gain: rawGain,
-    gainDb: linearToDb(rawGain),
+    gainDb: formatLinearAsDb(rawGain),
     resultDbfs,
     resultText: resultDbfs === null ? '\u2014 dBFS' : `${formatNumber(resultDbfs, 1)} dBFS`,
     percent: resultDbfs === null ? 0 : meterToPercent({ rmsDbfs: resultDbfs })
@@ -727,7 +728,7 @@ function updateObjectBandBars(entry, id) {
       // of crossover bands gets a colour. Same palette as the 3D speaker gauges.
       bar.style.setProperty('--band-color', bandColor(b, contributions.length));
     }
-    if (dbEl) dbEl.textContent = linearToDb(gain);
+    if (dbEl) dbEl.textContent = formatLinearAsDb(gain);
   });
 
   for (let b = 0; b < entry.bandBarsContainer.children.length; b += 1) {

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -127,7 +127,7 @@ import { computeCrossoverBandLabels, computeCrossoverBandEdges } from './crossov
 import { onSpeakerSelectionChanged } from './controls/speaker-test.js';
 
 import {
-  linearToDb,
+  formatLinearAsDb,
   meterToPercent,
   formatLevel,
   getBaseGain,
@@ -561,7 +561,7 @@ export function getObjectDominantSpeakerText(id) {
   }
   const speaker = currentLayoutSpeakers[bestIndex];
   const name = String(speaker?.id ?? bestIndex);
-  return `${name} ${linearToDb(bestGain)}`;
+  return `${name} ${formatLinearAsDb(bestGain)}`;
 }
 
 export function objectHasActiveTrail(id) {
@@ -963,7 +963,7 @@ export function updateSpeakerBandBars(entry, speakerIndex) {
       // of crossover bands. Same palette as the object band bars and 3D gauges.
       bar.style.setProperty('--band-color', bandColor(b, contributions.length));
     }
-    if (dbEl) dbEl.textContent = linearToDb(gain);
+    if (dbEl) dbEl.textContent = formatLinearAsDb(gain);
   });
 
   for (let b = 0; b < entry.bandBarsContainer.children.length; b += 1) {
@@ -1241,7 +1241,7 @@ export function renderSpeakerEditor() {
   const rMeters = Math.hypot(speakerMeters.x, speakerMeters.y, speakerMeters.z);
   syncInputValueUnlessEditing(speakerEditRMetersInputEl, formatNumber(rMeters, 2));
   if (speakerEditGainSliderEl) speakerEditGainSliderEl.value = String(gain);
-  if (speakerEditGainBoxEl) speakerEditGainBoxEl.textContent = linearToDb(gain);
+  if (speakerEditGainBoxEl) speakerEditGainBoxEl.textContent = formatLinearAsDb(gain);
   if (speakerEditDelayMsInputEl) speakerEditDelayMsInputEl.value = String(Math.max(0, delayMs));
   if (speakerEditDelaySamplesInputEl) speakerEditDelaySamplesInputEl.value = String(delayMsToSamples(delayMs));
   if (speakerEditSpatializeToggleEl) speakerEditSpatializeToggleEl.checked = getSpeakerSpatializeValue(speaker) !== 0;

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -17,9 +17,6 @@ export const sourceLabels = new Map();
 export const sourceOutlines = new Map();
 export const sourceLevels = new Map();
 export const speakerLevels = new Map();
-export const sourcePeaks = new Map(); // { value: number, expires: number }
-export const speakerPeaks = new Map(); // { value: number, expires: number }
-export let masterPeak = { value: 0, expires: 0 };
 // Engine-reported master output meter { peakDbfs, rmsDbfs }, or null until the
 // first /omniphony/meter/master is received. Live ESM binding read by master.js.
 export let masterLevel = null;


### PR DESCRIPTION
Second half of Phase 3.2. **Stacked on #299** — it edits the same meter files, so basing it on `main` would guarantee a conflict. Retarget to `main` once #299 lands.

## What moved

The peak cursor's hold and decay lived in the frontend in **two copies**: `updatePeakHold` for object and speaker meters, and an inlined version in `master.js`. Each kept its own per-meter state — `sourcePeaks`, `speakerPeaks`, `masterPeak` — and re-derived the cursor on every repaint.

Now every meter payload carries `peakHoldDbfs` and the frontend maps it to a percent and draws it. All three state maps and both copies of the algorithm are gone.

## Decay is per-second, not per-repaint

The JS fell a fixed **2 dB each time it repainted**. The physical fall rate was therefore whatever the render loop happened to be doing — a throttled or busy window slowed every meter in the app with it.

This decays by elapsed time. 120 dB/s is the same slope at the 60 Hz the loop normally runs at, and `one_frame_of_decay_matches_the_frontend_step` pins a 17 ms step to the 2.04 dB the frontend produced. So the visible rate is unchanged where it used to be right, and no longer wrong where it wasn't.

## The re-arm, and why percent

Decay does not run to the floor: once the cursor falls back to the bar the hold restarts, or a sustained level would let it slide away.

That comparison is made in **bar percent**, not dB — because that is where the frontend made it, and the scale clamps at both ends. At the rails two different dB values share a percent, so comparing in dB would fail to re-arm exactly where the frontend did. `db_to_meter_percent` is ported alongside for that reason, and a test covers the clamped case specifically.

## Hold lifetime

Holds are dropped when an object is removed — individually, and on the bulk wipe a reset, seek or track change performs. Object ids are reused across tracks, so an inherited cursor would show a peak the new object never produced.

## The dB helpers

The plan groups a "five copies of dB↔linear" deduplication here. What was actually in the tree:

- `linearToDb` returns a **display string** (`"-12.3 dB"`) — which is precisely why four call sites had grown their own inline `20 * Math.log10(x)`: the helper could not give them a number to compute with.
- `dbToLinear` had **no callers at all**.

So rather than consolidate five copies that weren't there: `audio-math.js` gets a numeric `linearToDb(value, floorDb)` adopted at those four sites, the formatter is renamed `formatLinearAsDb` for what it actually returns, and the dead `dbToLinear` is deleted rather than moved.

## Also in here: a fix to #299

While porting `db_to_meter_percent` I found the derived-master floor in #299 was wrong — it used −100 for the initial peak and the silence floor, where the JS used `METER_DB_MIN` = **−60**. The −100 was the default for a *missing* `rmsDbfs` field, a different number doing a different job (and unreachable in Rust, since the OSC parser already clamps into [−100, 0]). Visible as a wrong figure in the master readout whenever the room is quiet. Fixed on #299's branch, so it is in this PR's history too.

Two of that PR's tests also asserted the floor without reaching it — `10^(-400/20)` is 1e-20, not an underflow. Split into a quiet-level case and a true-zero case.

## Verification

- **14 new tests** in `peak_hold`, plus the corrected master-meter ones. Full src-tauri suite: **50 passed**. (src-tauri is not in CI.)
- `npm run build` green, knip clean, `cargo fmt --check` divergence back to baseline, zero build warnings.

## Not verified

Not run against a live renderer, and this one is visual by nature. Worth watching during playback: cursors holding for a second then falling at the same rate as before, cursors turning red above 0 dBFS, and — the case the hold-lifetime work is about — no cursor inherited from a previous object after a seek or track change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)