### PR TITLE
Serve the VBAP snap grid from the backend

### DIFF
--- a/omniphony-renderer/omniphony-geometry/src/lib.rs
+++ b/omniphony-renderer/omniphony-geometry/src/lib.rs
@@ -312,6 +312,46 @@ macro_rules! geometry_for {
             }
 
             // ---------------------------------------------------------------
+            // Sampling grids
+            // ---------------------------------------------------------------
+
+            /// `count` positions spread evenly from `min` to `max`, inclusive.
+            ///
+            /// A count of one or zero collapses to `min` rather than dividing
+            /// by zero.
+            pub fn evenly_spaced_axis(count: usize, min: $f, max: $f) -> Vec<$f> {
+                if count <= 1 {
+                    return vec![min];
+                }
+                let step = (max - min) / (count.saturating_sub(1) as $f);
+                (0..count).map(|index| min + step * index as $f).collect()
+            }
+
+            /// Node positions of the cartesian gain table's height axis.
+            ///
+            /// Not symmetric, which is the whole reason this is a function and
+            /// not a step size. The positive half is a plain even spread over
+            /// `[0, 1]`, but the space below the listener is optional and gets
+            /// its own resolution: `z_neg_size` nodes covering `[-1, 0)`,
+            /// stopping short of zero so the two halves do not both land on it.
+            ///
+            /// Both counts are **node counts**, not intervals. The live
+            /// parameter is an interval count and is converted before it gets
+            /// here (`live_params.rs`: `z_size.max(1) + 1`) — a distinction
+            /// that has to survive every hop of the protocol, and the reason
+            /// the Studio asks for these positions instead of rebuilding them.
+            pub fn cartesian_z_axis(z_size: usize, z_neg_size: usize) -> Vec<$f> {
+                let mut values = Vec::with_capacity(z_neg_size + z_size);
+                if z_neg_size > 0 {
+                    for index in 0..z_neg_size {
+                        values.push(-1.0 + index as $f / z_neg_size as $f);
+                    }
+                }
+                values.extend(evenly_spaced_axis(z_size.max(2), 0.0, 1.0));
+                values
+            }
+
+            // ---------------------------------------------------------------
             // Coordinate hydration
             // ---------------------------------------------------------------
 
@@ -570,6 +610,66 @@ mod tests {
     fn hydration_clamps_out_of_range_cartesian() {
         let (az, _, _) = hydrate_from_cartesian(5.0, 0.0, 0.0);
         close(az, 90.0);
+    }
+
+    // ── Sampling grids ──────────────────────────────────────────────────────
+
+    #[test]
+    fn an_even_axis_spans_its_ends_inclusively() {
+        assert_eq!(evenly_spaced_axis(2, -1.0, 1.0), vec![-1.0, 1.0]);
+        assert_eq!(evenly_spaced_axis(3, -1.0, 1.0), vec![-1.0, 0.0, 1.0]);
+        assert_eq!(
+            evenly_spaced_axis(5, 0.0, 1.0),
+            vec![0.0, 0.25, 0.5, 0.75, 1.0]
+        );
+    }
+
+    #[test]
+    fn a_degenerate_axis_collapses_to_its_start() {
+        assert_eq!(evenly_spaced_axis(1, -1.0, 1.0), vec![-1.0]);
+        assert_eq!(evenly_spaced_axis(0, -1.0, 1.0), vec![-1.0]);
+    }
+
+    /// With no space below the listener the height axis is just the upper half.
+    #[test]
+    fn the_height_axis_without_a_negative_half_starts_at_zero() {
+        assert_eq!(cartesian_z_axis(3, 0), vec![0.0, 0.5, 1.0]);
+    }
+
+    /// The asymmetric case, and the reason this is a function rather than a
+    /// step: the two halves have independent resolutions, and the negative one
+    /// stops short of zero so they do not both claim it.
+    #[test]
+    fn the_height_axis_halves_are_independent_and_meet_once() {
+        let axis = cartesian_z_axis(3, 2);
+        assert_eq!(axis, vec![-1.0, -0.5, 0.0, 0.5, 1.0]);
+        assert_eq!(axis.iter().filter(|v| **v == 0.0).count(), 1);
+    }
+
+    #[test]
+    fn the_height_axis_is_ascending_for_any_split() {
+        for z_size in 2..8usize {
+            for z_neg in 0..8usize {
+                let axis = cartesian_z_axis(z_size, z_neg);
+                assert_eq!(axis.len(), z_neg + z_size.max(2));
+                for pair in axis.windows(2) {
+                    assert!(
+                        pair[1] > pair[0],
+                        "not ascending at z_size={z_size} z_neg={z_neg}: {axis:?}"
+                    );
+                }
+                assert_eq!(*axis.first().unwrap(), if z_neg > 0 { -1.0 } else { 0.0 });
+                assert_eq!(*axis.last().unwrap(), 1.0);
+            }
+        }
+    }
+
+    /// A single-node request is widened to two, because a table axis with one
+    /// position cannot interpolate.
+    #[test]
+    fn the_height_axis_never_degenerates_to_one_node() {
+        assert_eq!(cartesian_z_axis(1, 0), vec![0.0, 1.0]);
+        assert_eq!(cartesian_z_axis(0, 0), vec![0.0, 1.0]);
     }
 
     // ── Precision parity ────────────────────────────────────────────────────

--- a/omniphony-renderer/renderer/src/render_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend.rs
@@ -912,25 +912,11 @@ struct AxisSample {
     fraction: f32,
 }
 
-pub(crate) fn evenly_spaced_axis(count: usize, min: f32, max: f32) -> Vec<f32> {
-    if count <= 1 {
-        return vec![min];
-    }
-    let step = (max - min) / (count.saturating_sub(1) as f32);
-    (0..count).map(|index| min + step * index as f32).collect()
-}
-
-pub(crate) fn cartesian_z_axis(z_size: usize, z_neg_size: usize) -> Vec<f32> {
-    let mut values = Vec::with_capacity(z_neg_size + z_size);
-    if z_neg_size > 0 {
-        for index in 0..z_neg_size {
-            let t = (index + 1) as f32 / z_neg_size as f32;
-            values.push(-1.0 + (t - 1.0 / z_neg_size as f32));
-        }
-    }
-    values.extend(evenly_spaced_axis(z_size.max(2), 0.0, 1.0));
-    values
-}
+// The cartesian table's axis geometry lives in `omniphony-geometry`, shared
+// with the Studio: its snap-to-grid has to land on the same nodes the table is
+// sampled at, and re-deriving them from the published interval counts is what
+// made that fragile.
+pub(crate) use omniphony_geometry::f32::{cartesian_z_axis, evenly_spaced_axis};
 
 fn polar_azimuth_axis(count: usize) -> Vec<f32> {
     let count = count.max(2);

--- a/omniphony-studio/src-tauri/src/commands/render.rs
+++ b/omniphony-studio/src-tauri/src/commands/render.rs
@@ -4,6 +4,8 @@
 //!
 //! Each command forwards a value to the renderer over OSC.
 
+use omniphony_geometry::f64 as geometry;
+
 use crate::osc_listener::OscControlMsg;
 use crate::{send_control, send_distance_metric, SharedState};
 use tauri::State;
@@ -513,4 +515,39 @@ pub fn control_render_input_pipe(state: State<SharedState>, value: String) {
             value: value.trim().to_string(),
         },
     );
+}
+
+/// Node positions of the cartesian gain table, per axis, or `null` when no
+/// cartesian grid is configured.
+///
+/// The Studio's snap-to-grid has to land on the nodes the renderer actually
+/// samples at. The frontend used to rebuild them from the published interval
+/// counts, which meant re-implementing two protocol conventions: that the
+/// counts are intervals rather than nodes, and that the height axis is
+/// asymmetric (an optional negative half at its own resolution, stopping short
+/// of zero so both halves do not claim it). Both now come from
+/// `omniphony-geometry`, which is also what the renderer builds the table with.
+#[tauri::command]
+pub fn get_vbap_grid_nodes(state: State<SharedState>) -> Option<serde_json::Value> {
+    let cartesian = {
+        let s = state.inner.lock().unwrap();
+        s.vbap_cartesian.clone()
+    };
+
+    // Intervals, as published. Anything under one interval is not a grid.
+    let x_intervals = cartesian.x_size.unwrap_or(0);
+    let y_intervals = cartesian.y_size.unwrap_or(0);
+    let z_intervals = cartesian.z_size.unwrap_or(0);
+    if x_intervals < 1 || y_intervals < 1 || z_intervals < 1 {
+        return None;
+    }
+    let z_neg_nodes = cartesian.z_neg_size.unwrap_or(0) as usize;
+
+    // Intervals -> nodes, the same conversion `live_params.rs` applies before
+    // handing the counts to the table builder.
+    let x = geometry::evenly_spaced_axis(x_intervals as usize + 1, -1.0, 1.0);
+    let y = geometry::evenly_spaced_axis(y_intervals as usize + 1, -1.0, 1.0);
+    let z = geometry::cartesian_z_axis(z_intervals as usize + 1, z_neg_nodes);
+
+    Some(serde_json::json!({ "x": x, "y": y, "z": z }))
 }

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -205,6 +205,7 @@ fn main() {
             debug_state_sizes,
             debug_write_memory_csv,
             get_state,
+            get_vbap_grid_nodes,
             get_osc_config,
             renderer_is_local,
             expected_orender_path,

--- a/omniphony-studio/src/controls/object-test.js
+++ b/omniphony-studio/src/controls/object-test.js
@@ -355,26 +355,36 @@ function send() {
 // half), its positive half is `z_size + 1` nodes from zero. Hence an explicit
 // list of nodes rather than a step.
 
+// The node list comes from the backend (`get_vbap_grid_nodes`), which builds it
+// with `omniphony-geometry` — the same code the renderer samples the table
+// with. Rebuilding it here from the published interval counts meant
+// re-implementing the conventions described above, and being silently wrong if
+// either ever changed.
+//
+// Cached because snapping happens inside a drag and cannot await: the command
+// is re-issued whenever the VBAP cartesian state changes.
+let cachedGridAxes = null;
+
 /** The grid the renderer is actually sampling on, or null when there is none. */
 function gridAxes() {
-  const g = app.vbapCartesianState || {};
-  const n = (v) => (Number.isFinite(Number(v)) ? Math.round(Number(v)) : 0);
-  // Intervals, as published.
-  const xI = n(g.xSize);
-  const yI = n(g.ySize);
-  const zI = n(g.zSize);
-  const zNegNodes = Math.max(0, n(g.zNegSize));
-  if (xI < 1 || yI < 1 || zI < 1) return null;
+  return cachedGridAxes;
+}
 
-  const evenly = (count, min, max) => {
-    if (count <= 1) return [min];
-    const step = (max - min) / (count - 1);
-    return Array.from({ length: count }, (_, i) => min + step * i);
-  };
-  const zAxis = [];
-  for (let i = 0; i < zNegNodes; i += 1) zAxis.push(-1 + i / zNegNodes);
-  zAxis.push(...evenly(zI + 1, 0, 1));
-  return [evenly(xI + 1, -1, 1), evenly(yI + 1, -1, 1), zAxis];
+/** Re-fetch the grid. Called on connect and whenever `vbap:cartesian` moves. */
+export function refreshVbapGridNodes() {
+  return invoke('get_vbap_grid_nodes')
+    .then((nodes) => {
+      cachedGridAxes = nodes && Array.isArray(nodes.x) && nodes.x.length > 0
+        ? [nodes.x, nodes.y, nodes.z]
+        : null;
+    })
+    .catch(() => {
+      cachedGridAxes = null;
+    })
+    // Separate hop so a render error cannot discard a grid that arrived fine.
+    // The snap toggle is offered-but-inert without a grid, so its disabled
+    // state follows the cache.
+    .then(() => renderObjectTestUI());
 }
 
 /** Nearest node on one axis. */

--- a/omniphony-studio/src/controls/vbap.js
+++ b/omniphony-studio/src/controls/vbap.js
@@ -4,6 +4,7 @@
  * Extracted from app.js (lines 3711-3852).
  */
 
+import { refreshVbapGridNodes } from './object-test.js';
 import { invoke } from '@tauri-apps/api/core';
 import { app, dirty } from '../state.js';
 import { t, tf, i18nState } from '../i18n.js';
@@ -801,6 +802,9 @@ export function renderVbapCartesian() {
 
 export function updateVbapCartesian() {
   dirty.vbapCartesian = true;
+  // The snap grid is served by the backend and cached, so it has to be
+  // re-fetched whenever the grid's shape changes.
+  refreshVbapGridNodes();
   scheduleUIFlush();
 }
 


### PR DESCRIPTION
Phase 3.5 of the Studio Rust/Web rebalancing plan. Targets `main` directly; independent of the other open PRs.

## Why this one matters more than it looks

Snap-to-grid has to land on the nodes the renderer actually samples the cartesian gain table at. The frontend rebuilt them from the published interval counts, which meant re-implementing two protocol conventions by hand:

- the published counts are **intervals, not nodes** — `live_params.rs` adds the `+1` before the table is built;
- the height axis **is not one axis**. Its negative half is optional, carries its own resolution, and stops short of zero so both halves do not claim it.

Get either wrong and the snap lands *between* cells — precisely the failure the feature exists to prevent. The default grid mirrors the OAMD position quantisation (x/y on 6 bits at 1/62, z a sign bit plus 4 bits at 1/15), so every position an Atmos stream can express is a node of it. A grid built from the wrong count misses all of them.

I checked the existing JS against the renderer before changing anything: it was **correct**. But it was correct by having been written carefully once, against conventions nothing enforces.

## What changed

`evenly_spaced_axis` and `cartesian_z_axis` move into `omniphony-geometry`. `renderer::render_backend` now re-exports them — they were its own functions, moved verbatim — and a new `get_vbap_grid_nodes` command serves them to the Studio.

Studio and renderer therefore build the grid with **the same code**, not with two descriptions of it. That is the same move as #296, for the same reason.

The frontend caches the node list and re-fetches whenever the cartesian state changes: snapping happens inside a drag and cannot await a command. The initial fetch comes free — snapshot hydration already calls `updateVbapCartesian`, which is the hook.

## Tests

Six in the crate: the even spread, the degenerate counts (1 and 0 nodes), the height axis with no negative half, **the asymmetric case with an assertion that the two halves meet exactly once at zero**, that a single-node request widens to two, and a sweep asserting the axis is strictly ascending and correctly sized for every split of `z_size × z_neg_size` in `2..8 × 0..8`.

- **Workspace suite: 666 passed, 0 failed** — including the renderer's own `cartesian_z_axis(15, 15)` test, so the migration is a no-op.
- src-tauri: **38 passed**. `npm run build` green, knip clean, `npm run test:math` 588/588, `cargo fmt --check` clean.

## Not verified

Not exercised against a live renderer, and this is the acceptance criterion for the phase: snap positions identical to the renderer's grid for several grid sizes, **including the asymmetric z case** (a layout with height speakers below the listener). Worth dragging the test object with snap on and confirming it lands on cell centres rather than near them — and that the snap toggle greys out when no cartesian grid is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)