### PR TITLE
Sample the hybrid blend curve in the backend

### DIFF
--- a/omniphony-renderer/omniphony-geometry/src/lib.rs
+++ b/omniphony-renderer/omniphony-geometry/src/lib.rs
@@ -352,6 +352,124 @@ macro_rules! geometry_for {
             }
 
             // ---------------------------------------------------------------
+            // Blend curve
+            // ---------------------------------------------------------------
+
+            /// Piecewise-linear interpolation through sorted control points.
+            fn linear_y(points: &[[$f; 2]], x: $f) -> $f {
+                let last = points.len() - 1;
+                for i in 0..last {
+                    let [x0, y0] = points[i];
+                    let [x1, y1] = points[i + 1];
+                    if x <= x1 {
+                        let span = (x1 - x0).max(1e-6);
+                        let t = ((x - x0) / span).clamp(0.0, 1.0);
+                        return y0 + (y1 - y0) * t;
+                    }
+                }
+                points[last][1]
+            }
+
+            #[inline]
+            fn midpoint(a: [$f; 2], b: [$f; 2]) -> [$f; 2] {
+                [0.5 * (a[0] + b[0]), 0.5 * (a[1] + b[1])]
+            }
+
+            /// Quadratic Bézier (`start`, `control`, `end`) as `y` at a given
+            /// `x`, by solving `Bx(u) = x` for `u` in `[0, 1]`.
+            fn quadratic_bezier_y_at_x(
+                start: [$f; 2],
+                control: [$f; 2],
+                end: [$f; 2],
+                x: $f,
+            ) -> $f {
+                let a = start[0] - 2.0 * control[0] + end[0];
+                let b = 2.0 * (control[0] - start[0]);
+                let c = start[0] - x;
+                let u = if a.abs() < 1e-6 {
+                    if b.abs() < 1e-9 { 0.0 } else { -c / b }
+                } else {
+                    let disc = (b * b - 4.0 * a * c).max(0.0).sqrt();
+                    let u1 = (-b + disc) / (2.0 * a);
+                    if (0.0..=1.0).contains(&u1) {
+                        u1
+                    } else {
+                        (-b - disc) / (2.0 * a)
+                    }
+                }
+                .clamp(0.0, 1.0);
+                let omu = 1.0 - u;
+                omu * omu * start[1] + 2.0 * omu * u * control[1] + u * u * end[1]
+            }
+
+            /// Approximating uniform quadratic B-spline as `y(x)`: straight
+            /// from the first point to the first segment midpoint, a quadratic
+            /// Bézier around each interior point (control = the point,
+            /// endpoints = the adjacent midpoints), then straight from the last
+            /// midpoint to the last point. Passes through the endpoints and the
+            /// segment midpoints, tangent to every segment at its midpoint.
+            fn bspline_y(points: &[[$f; 2]], x: $f) -> $f {
+                let last = points.len() - 1;
+                if last <= 1 {
+                    // Fewer than three points: no corner to cut.
+                    return linear_y(points, x);
+                }
+                let m_first = midpoint(points[0], points[1]);
+                if x <= m_first[0] {
+                    let span = (m_first[0] - points[0][0]).max(1e-6);
+                    let t = ((x - points[0][0]) / span).clamp(0.0, 1.0);
+                    return points[0][1] + (m_first[1] - points[0][1]) * t;
+                }
+                let m_last = midpoint(points[last - 1], points[last]);
+                if x >= m_last[0] {
+                    let span = (points[last][0] - m_last[0]).max(1e-6);
+                    let t = ((x - m_last[0]) / span).clamp(0.0, 1.0);
+                    return m_last[1] + (points[last][1] - m_last[1]) * t;
+                }
+                for i in 1..last {
+                    let end = midpoint(points[i], points[i + 1]);
+                    if x <= end[0] {
+                        let start = midpoint(points[i - 1], points[i]);
+                        return quadratic_bezier_y_at_x(start, points[i], end, x);
+                    }
+                }
+                points[last][1]
+            }
+
+            /// Evaluate the hybrid backend's blend curve at normalised `x`.
+            ///
+            /// `smoothing` blends the piecewise-linear curve (0 — passes
+            /// through the control points) with the approximating B-spline
+            /// (1 — corner cutting). Anything outside the point range holds the
+            /// nearest endpoint.
+            ///
+            /// This decides how the hybrid backend crossfades between its two
+            /// inner backends, so the Studio's preview and the audio path must
+            /// be the same function — a preview drawn by a second
+            /// implementation is a preview that can lie.
+            ///
+            /// An empty point set evaluates to 0.
+            pub fn blend_curve_y(points: &[[$f; 2]], smoothing: $f, x: $f) -> $f {
+                if points.is_empty() {
+                    return 0.0;
+                }
+                if x <= points[0][0] {
+                    return points[0][1];
+                }
+                let last = points.len() - 1;
+                if x >= points[last][0] {
+                    return points[last][1];
+                }
+                let linear = linear_y(points, x);
+                let smoothing = smoothing.clamp(0.0, 1.0);
+                if smoothing <= 0.0 {
+                    return linear;
+                }
+                let spline = bspline_y(points, x);
+                (linear + (spline - linear) * smoothing).clamp(0.0, 1.0)
+            }
+
+            // ---------------------------------------------------------------
             // Coordinate hydration
             // ---------------------------------------------------------------
 
@@ -670,6 +788,92 @@ mod tests {
     fn the_height_axis_never_degenerates_to_one_node() {
         assert_eq!(cartesian_z_axis(1, 0), vec![0.0, 1.0]);
         assert_eq!(cartesian_z_axis(0, 0), vec![0.0, 1.0]);
+    }
+
+    // ── Blend curve ─────────────────────────────────────────────────────────
+
+    const RAMP: [[f64; 2]; 2] = [[0.0, 0.0], [1.0, 1.0]];
+
+    #[test]
+    fn the_curve_holds_its_endpoints_outside_the_range() {
+        assert_eq!(blend_curve_y(&RAMP, 0.0, -0.5), 0.0);
+        assert_eq!(blend_curve_y(&RAMP, 0.0, 1.5), 1.0);
+        assert_eq!(blend_curve_y(&RAMP, 1.0, -0.5), 0.0);
+    }
+
+    #[test]
+    fn an_empty_curve_is_zero() {
+        assert_eq!(blend_curve_y(&[], 0.0, 0.5), 0.0);
+    }
+
+    #[test]
+    fn zero_smoothing_is_piecewise_linear() {
+        for i in 0..=10 {
+            let x = i as f64 / 10.0;
+            assert!((blend_curve_y(&RAMP, 0.0, x) - x).abs() < 1e-9);
+        }
+    }
+
+    /// Two points have no corner to cut, so smoothing must be a no-op there —
+    /// otherwise the simplest curve would move when the slider does.
+    #[test]
+    fn smoothing_does_nothing_without_an_interior_point() {
+        for smoothing in [0.0, 0.5, 1.0] {
+            assert!((blend_curve_y(&RAMP, smoothing, 0.3) - 0.3).abs() < 1e-9);
+        }
+    }
+
+    /// Corner cutting pulls the curve off a sharp interior point, but must
+    /// leave the endpoints alone.
+    #[test]
+    fn smoothing_cuts_the_corner_and_keeps_the_endpoints() {
+        let knee = [[0.0, 0.0], [0.5, 1.0], [1.0, 1.0]];
+        let linear = blend_curve_y(&knee, 0.0, 0.5);
+        let smooth = blend_curve_y(&knee, 1.0, 0.5);
+        assert!(
+            (linear - 1.0).abs() < 1e-9,
+            "linear passes through the point"
+        );
+        assert!(
+            smooth < linear,
+            "smoothing should cut the corner, got {smooth}"
+        );
+        assert_eq!(blend_curve_y(&knee, 1.0, 0.0), 0.0);
+        assert_eq!(blend_curve_y(&knee, 1.0, 1.0), 1.0);
+    }
+
+    #[test]
+    fn smoothing_interpolates_between_linear_and_spline() {
+        let knee = [[0.0, 0.0], [0.5, 1.0], [1.0, 1.0]];
+        let x = 0.4;
+        let linear = blend_curve_y(&knee, 0.0, x);
+        let spline = blend_curve_y(&knee, 1.0, x);
+        let half = blend_curve_y(&knee, 0.5, x);
+        assert!((half - (linear + spline) * 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn smoothing_is_clamped_to_its_range() {
+        let knee = [[0.0, 0.0], [0.5, 1.0], [1.0, 1.0]];
+        assert_eq!(
+            blend_curve_y(&knee, -1.0, 0.4),
+            blend_curve_y(&knee, 0.0, 0.4)
+        );
+        assert_eq!(
+            blend_curve_y(&knee, 2.0, 0.4),
+            blend_curve_y(&knee, 1.0, 0.4)
+        );
+    }
+
+    /// The blend weight drives a crossfade, so it can never leave [0, 1] no
+    /// matter what the spline overshoot does.
+    #[test]
+    fn the_curve_stays_in_range_for_awkward_point_sets() {
+        let spiky = [[0.0, 1.0], [0.2, 0.0], [0.4, 1.0], [0.6, 0.0], [1.0, 1.0]];
+        for i in 0..=100 {
+            let y = blend_curve_y(&spiky, 1.0, i as f64 / 100.0);
+            assert!((0.0..=1.0).contains(&y), "y was {y}");
+        }
     }
 
     // ── Precision parity ────────────────────────────────────────────────────

--- a/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
+++ b/omniphony-renderer/renderer/src/render_backend/hybrid_backend.rs
@@ -194,93 +194,12 @@ impl BlendCurve {
         if x >= points[last][0] {
             return points[last][1];
         }
-        let linear = linear_y(points, x);
-        if self.smoothing <= 0.0 {
-            return linear;
-        }
-        let spline = bspline_y(points, x);
-        (linear + (spline - linear) * self.smoothing).clamp(0.0, 1.0)
+        omniphony_geometry::f32::blend_curve_y(points, self.smoothing, x)
     }
 
     pub fn points(&self) -> &[[f32; 2]] {
         &self.points
     }
-}
-
-/// Piecewise-linear interpolation through the (sorted, in-range) control points.
-fn linear_y(points: &[[f32; 2]], x: f32) -> f32 {
-    let last = points.len() - 1;
-    for i in 0..last {
-        let [x0, y0] = points[i];
-        let [x1, y1] = points[i + 1];
-        if x <= x1 {
-            let span = (x1 - x0).max(1e-6);
-            let t = ((x - x0) / span).clamp(0.0, 1.0);
-            return y0 + (y1 - y0) * t;
-        }
-    }
-    points[last][1]
-}
-
-#[inline]
-fn midpoint(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
-    [0.5 * (a[0] + b[0]), 0.5 * (a[1] + b[1])]
-}
-
-/// Approximating uniform quadratic B-spline as a function `y(x)`: straight from
-/// the first point to the first segment midpoint, a quadratic Bézier around each
-/// interior point (control = the point, endpoints = the adjacent segment
-/// midpoints), then straight from the last midpoint to the last point. The curve
-/// passes through the endpoints and the segment midpoints, and is tangent to
-/// every segment at its midpoint.
-fn bspline_y(points: &[[f32; 2]], x: f32) -> f32 {
-    let last = points.len() - 1;
-    if last <= 1 {
-        // Fewer than three points: no corner to cut, so it is just the line.
-        return linear_y(points, x);
-    }
-    let m_first = midpoint(points[0], points[1]);
-    if x <= m_first[0] {
-        let span = (m_first[0] - points[0][0]).max(1e-6);
-        let t = ((x - points[0][0]) / span).clamp(0.0, 1.0);
-        return points[0][1] + (m_first[1] - points[0][1]) * t;
-    }
-    let m_last = midpoint(points[last - 1], points[last]);
-    if x >= m_last[0] {
-        let span = (points[last][0] - m_last[0]).max(1e-6);
-        let t = ((x - m_last[0]) / span).clamp(0.0, 1.0);
-        return m_last[1] + (points[last][1] - m_last[1]) * t;
-    }
-    for i in 1..last {
-        let end = midpoint(points[i], points[i + 1]);
-        if x <= end[0] {
-            let start = midpoint(points[i - 1], points[i]);
-            return quadratic_bezier_y_at_x(start, points[i], end, x);
-        }
-    }
-    points[last][1]
-}
-
-/// Evaluate the quadratic Bézier (`start`, `control`, `end`) as `y` at the given
-/// `x` by solving `Bx(u) = x` for `u ∈ [0, 1]`.
-fn quadratic_bezier_y_at_x(start: [f32; 2], control: [f32; 2], end: [f32; 2], x: f32) -> f32 {
-    let a = start[0] - 2.0 * control[0] + end[0];
-    let b = 2.0 * (control[0] - start[0]);
-    let c = start[0] - x;
-    let u = if a.abs() < 1e-6 {
-        if b.abs() < 1e-9 { 0.0 } else { -c / b }
-    } else {
-        let disc = (b * b - 4.0 * a * c).max(0.0).sqrt();
-        let u1 = (-b + disc) / (2.0 * a);
-        if (0.0..=1.0).contains(&u1) {
-            u1
-        } else {
-            (-b - disc) / (2.0 * a)
-        }
-    }
-    .clamp(0.0, 1.0);
-    let omu = 1.0 - u;
-    omu * omu * start[1] + 2.0 * omu * u * control[1] + u * u * end[1]
 }
 
 impl Default for BlendCurve {

--- a/omniphony-studio/src-tauri/src/commands/render.rs
+++ b/omniphony-studio/src-tauri/src/commands/render.rs
@@ -551,3 +551,22 @@ pub fn get_vbap_grid_nodes(state: State<SharedState>) -> Option<serde_json::Valu
 
     Some(serde_json::json!({ "x": x, "y": y, "z": z }))
 }
+
+/// Sample the hybrid backend's blend curve at `count + 1` evenly spaced
+/// positions across `[0, 1]`, for the editor's preview.
+///
+/// The preview used to be drawn by a second implementation of the curve living
+/// in the frontend. Two implementations of the same function is two chances to
+/// disagree, and a preview that disagrees with the audio path is worse than no
+/// preview: it says the crossfade is somewhere it is not. This calls the same
+/// `blend_curve_y` the renderer's `BlendCurve::eval` does.
+#[tauri::command]
+pub fn sample_hybrid_curve(points: Vec<[f64; 2]>, smoothing: f64, count: usize) -> Vec<f64> {
+    let count = count.clamp(1, 4096);
+    (0..=count)
+        .map(|i| {
+            let x = i as f64 / count as f64;
+            geometry::blend_curve_y(&points, smoothing, x)
+        })
+        .collect()
+}

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -207,6 +207,7 @@ fn main() {
             debug_write_memory_csv,
             get_state,
             get_vbap_grid_nodes,
+            sample_hybrid_curve,
             get_osc_config,
             renderer_is_local,
             expected_orender_path,

--- a/omniphony-studio/src/controls/hybrid-curve.js
+++ b/omniphony-studio/src/controls/hybrid-curve.js
@@ -37,79 +37,48 @@ function clamp01(value) {
   return Math.min(1, Math.max(0, value));
 }
 
-/** Piecewise-linear interpolation through the control points. */
-function linearY(points, x) {
-  const last = points.length - 1;
-  for (let i = 0; i < last; i += 1) {
-    const [x0, y0] = points[i];
-    const [x1, y1] = points[i + 1];
-    if (x <= x1) {
-      const span = Math.max(x1 - x0, 1e-6);
-      return y0 + (y1 - y0) * clamp01((x - x0) / span);
-    }
-  }
-  return points[last][1];
+// The curve is sampled by the backend (`sample_hybrid_curve`), which evaluates
+// it with the same `blend_curve_y` the renderer's `BlendCurve::eval` uses. The
+// preview used to be drawn by a second implementation living here; two
+// implementations of one function is two chances to disagree, and a preview
+// that disagrees with the audio path is worse than none — it says the crossfade
+// is somewhere it is not.
+//
+// Samples are cached because drawing is synchronous. A drag changes the curve
+// per mousemove, so the redraw trails the fetch by one round-trip and then
+// catches up; `pendingKey` drops responses that a newer edit has already
+// superseded, which is what keeps an out-of-order reply from flashing a stale
+// curve back onto the canvas.
+const CURVE_SAMPLES = 96;
+let cachedSamples = null;
+let cachedKey = null;
+let pendingKey = null;
+
+function curveKey(points, smoothing) {
+  return `${smoothing}|${points.map((p) => `${p[0]},${p[1]}`).join(';')}`;
 }
 
-function midpoint(a, b) {
-  return [0.5 * (a[0] + b[0]), 0.5 * (a[1] + b[1])];
-}
-
-/** Quadratic Bézier (start, control, end) evaluated as y at the given x. */
-function bezierYatX(start, control, end, x) {
-  const a = start[0] - 2 * control[0] + end[0];
-  const b = 2 * (control[0] - start[0]);
-  const c = start[0] - x;
-  let u;
-  if (Math.abs(a) < 1e-6) {
-    u = Math.abs(b) < 1e-9 ? 0 : -c / b;
-  } else {
-    const disc = Math.sqrt(Math.max(0, b * b - 4 * a * c));
-    const u1 = (-b + disc) / (2 * a);
-    u = u1 >= 0 && u1 <= 1 ? u1 : (-b - disc) / (2 * a);
-  }
-  u = clamp01(u);
-  const omu = 1 - u;
-  return omu * omu * start[1] + 2 * omu * u * control[1] + u * u * end[1];
-}
-
-/** Approximating quadratic B-spline (corner cutting), as y(x). */
-function bsplineY(points, x) {
-  const last = points.length - 1;
-  if (last <= 1) return linearY(points, x);
-  const mFirst = midpoint(points[0], points[1]);
-  if (x <= mFirst[0]) {
-    const span = Math.max(mFirst[0] - points[0][0], 1e-6);
-    return points[0][1] + (mFirst[1] - points[0][1]) * clamp01((x - points[0][0]) / span);
-  }
-  const mLast = midpoint(points[last - 1], points[last]);
-  if (x >= mLast[0]) {
-    const span = Math.max(points[last][0] - mLast[0], 1e-6);
-    return mLast[1] + (points[last][1] - mLast[1]) * clamp01((x - mLast[0]) / span);
-  }
-  for (let i = 1; i < last; i += 1) {
-    const end = midpoint(points[i], points[i + 1]);
-    if (x <= end[0]) {
-      return bezierYatX(midpoint(points[i - 1], points[i]), points[i], end, x);
-    }
-  }
-  return points[last][1];
-}
-
-/**
- * Evaluate the blend curve at normalised x — mirror of the renderer's
- * BlendCurve::eval so the displayed curve matches the audio. `smoothing` blends
- * piecewise-linear (0, through the points) with an approximating quadratic
- * B-spline (1, corner cutting / tangent to segment midpoints).
- */
-function evalCurve(points, smoothing, x) {
-  if (!points.length) return 0;
-  if (x <= points[0][0]) return points[0][1];
-  const last = points.length - 1;
-  if (x >= points[last][0]) return points[last][1];
-  const linear = linearY(points, x);
-  if (smoothing <= 0) return linear;
-  return clamp01(linear + (bsplineY(points, x) - linear) * smoothing);
+/** Fetch samples for this curve unless they are already cached or in flight. */
+function ensureCurveSamples(points, smoothing, redraw) {
+  const key = curveKey(points, smoothing);
+  if (key === cachedKey || key === pendingKey) return;
+  pendingKey = key;
+  invoke('sample_hybrid_curve', {
+    points: points.map((p) => [p[0], p[1]]),
+    smoothing,
+    count: CURVE_SAMPLES
+  })
+    .then((samples) => {
+      // A newer edit already asked for something else: this answer is stale.
+      if (pendingKey !== key) return;
+      cachedSamples = Array.isArray(samples) ? samples : null;
+      cachedKey = key;
+      pendingKey = null;
+      redraw();
+    })
+    .catch(() => {
+      if (pendingKey === key) pendingKey = null;
+    });
 }
 
 function currentCurve() {
@@ -421,21 +390,25 @@ export function renderHybridCurve() {
   const curve = currentCurve();
   const smoothing = Math.min(1, Math.max(0, app.renderBackendState.hybrid?.curveSmoothing || 0));
 
-  // Curve (sampled so the spline smoothing is visible).
-  ctx.strokeStyle = '#9fdcff';
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  const samples = 96;
-  for (let s = 0; s <= samples; s += 1) {
-    const x = s / samples;
-    const pixel = toPixel([x, evalCurve(curve, smoothing, x)]);
-    if (s === 0) {
-      ctx.moveTo(pixel.x, pixel.y);
-    } else {
-      ctx.lineTo(pixel.x, pixel.y);
+  // Curve (sampled so the spline smoothing is visible). Samples come from the
+  // backend; until the first answer arrives there is nothing to draw, which is
+  // a blank curve for one round-trip rather than a wrong one.
+  ensureCurveSamples(curve, smoothing, renderHybridCurve);
+  if (cachedSamples && cachedSamples.length > 1) {
+    ctx.strokeStyle = '#9fdcff';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    const last = cachedSamples.length - 1;
+    for (let s = 0; s <= last; s += 1) {
+      const pixel = toPixel([s / last, clamp01(cachedSamples[s])]);
+      if (s === 0) {
+        ctx.moveTo(pixel.x, pixel.y);
+      } else {
+        ctx.lineTo(pixel.x, pixel.y);
+      }
     }
+    ctx.stroke();
   }
-  ctx.stroke();
 
   // Control points.
   curve.forEach((point, index) => {


### PR DESCRIPTION
Phase 3.6 of the Studio Rust/Web rebalancing plan. Targets `main` directly.

## Why

The curve editor drew its preview with **its own implementation** of the blend curve — piecewise-linear, quadratic Bézier and approximating B-spline, ~60 lines mirroring `BlendCurve::eval` line for line.

Two implementations of one function is two chances to disagree, and this particular preview disagreeing is worse than having none: the curve decides how the hybrid backend crossfades between its two inner backends, so a preview that drifts says the crossfade is somewhere it is not. You would tune against a lie.

I checked the JS against the renderer first — it was a faithful mirror, epsilons included. As with #302, correct by having been written carefully once, against nothing that enforces it.

## What changed

`blend_curve_y` moves into `omniphony-geometry`; `BlendCurve::eval` delegates to it (its private helpers moved verbatim, −76 lines); a `sample_hybrid_curve` command serves the preview. The editor only draws.

**Drag interaction stays in JS** — hit testing, clamping a point between its neighbours — as the plan intends. Only the evaluation moved.

## The async/synchronous seam

Drawing is synchronous; the command is not. A drag changes the curve per mousemove, so samples are cached and the redraw trails by one round-trip, then catches up.

A `pendingKey` guard drops answers that a newer edit has already superseded. Without it, an out-of-order reply flashes a stale curve back onto the canvas — the standard failure of caching an async result behind a synchronous paint, and the part of this change most worth reviewing.

Before the first answer arrives the curve is simply not drawn: blank for one round-trip rather than wrong.

## Tests

Eight in the crate, chosen for the ways this can quietly break:

- endpoints hold outside the range; empty point set is 0;
- **zero smoothing is exactly linear** and **smoothing is a no-op with no interior point to cut** — otherwise the simplest two-point curve would move when the slider does;
- corner cutting pulls the curve off a sharp point while leaving the endpoints alone;
- half smoothing lands exactly between linear and spline;
- smoothing is clamped;
- an awkward zig-zag point set cannot push the blend weight outside `[0, 1]` — it drives a crossfade, so overshoot is not an option.

**Workspace suite: 660 passed, 0 failed.** src-tauri: 57 passed. `npm run build` green, knip clean, `test:math` 588/588, `cargo fmt --check` clean across the workspace.

One flake to flag: `orender_engine`'s `display_changes_bump_the_generation_and_reach_the_published_state` failed once under parallel execution, then passed in isolation twice and on a full re-run. Pre-existing, unrelated to this change, but worth knowing it exists.

## Not verified

Not exercised in the editor. The acceptance criterion has two halves — the curve matching the renderer is now true *by construction*, but **editing latency being imperceptible is not something I can judge without dragging a point**. If the trailing redraw is visible during a drag, the fix is a local optimistic draw rather than a debounce; say so and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)