### PR TITLE
Port the auto-tune detectors, with the JS as reference

### DIFF
--- a/omniphony-studio/scripts/dump-auto-tune-goldens.mjs
+++ b/omniphony-studio/scripts/dump-auto-tune-goldens.mjs
@@ -1,0 +1,254 @@
+/**
+ * Record what the frontend's auto-tune detectors decide, so the Rust port can
+ * be asserted against them.
+ *
+ * The direction matters: here the **JS is the reference**. It is the
+ * implementation that has been driving real tuning runs, so the port is
+ * correct exactly insofar as it agrees with it. (The geometry crate runs the
+ * other way — there Rust is canonical and the JS mirror is checked against it.)
+ *
+ * These verdicts change kp/ki on a live audio path, so "looks equivalent" is
+ * not good enough: a detector that fires one palier earlier retunes the loop
+ * differently, and nothing in a diff would show it.
+ *
+ * Regenerate after any change to `src/auto-tune/detectors.js`:
+ *
+ *   node scripts/dump-auto-tune-goldens.mjs > scripts/golden/auto-tune.json
+ *
+ * Note `JSON.stringify` writes a non-finite number as `null`; the Rust side
+ * reads a null jump ratio as infinity, which is what a flat baseline produces.
+ */
+
+import {
+  computePalierStats,
+  detectOscillationAbsolute,
+  detectOscillationByJump,
+  detectSaturation,
+  detectConvergence,
+  detectSourceLoss,
+  computeRateStats
+} from '../src/auto-tune/detectors.js';
+
+/** Deterministic pseudo-random, so the vectors are reproducible. */
+function makeRng(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+/**
+ * A telemetry window. `ppm(i, t)` returns the resampler correction in ppm.
+ */
+function series({ count, stepMs = 250, ppm, target = 200, error = () => 0, phase = () => 'stable' }) {
+  const out = [];
+  for (let i = 0; i < count; i += 1) {
+    const t = i * stepMs;
+    const value = ppm(i, t);
+    out.push({
+      t,
+      latencySmoothedMs: target + error(i, t),
+      latencyTargetMs: target,
+      resampleRatio: value === null ? null : 1 + value / 1e6,
+      phase: phase(i, t)
+    });
+  }
+  return out;
+}
+
+const rng = makeRng(12345);
+
+// Quasi-flat noise: the regime a low-kp palier sits in.
+const flat = series({ count: 120, ppm: () => (rng() - 0.5) * 100 });
+// A clear oscillation: what a too-high kp produces.
+const oscillating = series({ count: 120, ppm: (i) => 4000 * Math.sin(i / 3) });
+// Pinned at the adjustment limit.
+const saturated = series({ count: 80, ppm: () => 9900 });
+// Saturated only recently, so the hold is not yet satisfied.
+const brieflySaturated = series({ count: 80, ppm: (i) => (i > 76 ? 9900 : 100) });
+// Converged: error far inside 0.02% of a 200 ms target (= 0.04 ms).
+const converged = series({ count: 120, ppm: () => 50, error: () => 0.001 });
+// Error too large to count as converged.
+const notConverged = series({ count: 120, ppm: () => 50, error: () => 5 });
+// Two separate dips into low-recover.
+const flapping = series({
+  count: 80,
+  ppm: () => 100,
+  phase: (i) => ((i > 20 && i < 26) || (i > 60 && i < 66) ? 'low-recover' : 'stable')
+});
+// One long low-recover stretch: one event, not many.
+const oneLongDip = series({
+  count: 80,
+  ppm: () => 100,
+  phase: (i) => (i > 20 && i < 70 ? 'low-recover' : 'stable')
+});
+// Gaps: samples with no usable ratio must be skipped, not treated as zero.
+const withGaps = series({ count: 120, ppm: (i) => (i % 7 === 0 ? null : 500) });
+// Too few samples past the warm-up to say anything.
+const tooShort = series({ count: 6, ppm: () => 100 });
+
+// ── Fixtures that sit ON the decision boundaries ────────────────────────────
+//
+// The windows above are all comfortably far from every threshold, so they
+// confirm the port on easy cases and would miss a discrepancy near an edge —
+// which is exactly where a port goes wrong. These pin the boundaries
+// themselves: one fixture just inside each, one just outside.
+
+const STEP_MS = 250;
+const WARMUP_SAMPLES = 10000 / STEP_MS; // discarded by palierWarmupMs
+
+/** Warm-up filler, then an explicit list of post-warmup ppm values. */
+function afterWarmup(values, { target = 200, error = () => 0, phase = () => 'stable' } = {}) {
+  const all = [...Array.from({ length: WARMUP_SAMPLES }, () => 0), ...values];
+  return series({
+    count: all.length,
+    stepMs: STEP_MS,
+    ppm: (i) => all[i],
+    target,
+    error,
+    phase
+  });
+}
+
+/** `halfPeriods` alternating blocks of ±amplitude: yields halfPeriods-1 crossings. */
+function squareWave(halfPeriods, amplitude, samplesPerHalf = 6) {
+  const values = [];
+  for (let h = 0; h < halfPeriods; h += 1) {
+    const v = h % 2 === 0 ? amplitude : -amplitude;
+    for (let i = 0; i < samplesPerHalf; i += 1) values.push(v);
+  }
+  return values;
+}
+
+// Crossing floor is 4. Amplitude ±750 gives a peak-to-peak of exactly 1500,
+// the amplitude floor, so these also sit on that edge.
+const atCrossingFloor = afterWarmup(squareWave(5, 750));   // 4 crossings
+const belowCrossingFloor = afterWarmup(squareWave(4, 750)); // 3 crossings
+
+// Amplitude floor is 1500 peak-to-peak, with crossings well clear of theirs.
+const atAmplitudeFloor = afterWarmup(squareWave(11, 750));
+const belowAmplitudeFloor = afterWarmup(squareWave(11, 749.5)); // p-p 1499
+
+// Hysteresis is a 200 ppm dead-band around the mean: ±199 registers no state
+// change at all, ±201 registers every one. An EVEN number of half-periods so
+// the mean is exactly zero — with an odd count the mean shifts by one block
+// and the band moves off the values being tested.
+const insideHysteresis = afterWarmup(squareWave(10, 199));
+const outsideHysteresis = afterWarmup(squareWave(10, 201));
+
+// Saturation hold is 3000 ms. The run is measured from the oldest pinned
+// sample to the newest, so N pinned samples span (N-1) * STEP_MS.
+const atSaturationHold = afterWarmup([
+  ...Array.from({ length: 20 }, () => 100),
+  ...Array.from({ length: 3000 / STEP_MS + 1 }, () => 9900)
+]);
+const belowSaturationHold = afterWarmup([
+  ...Array.from({ length: 20 }, () => 100),
+  ...Array.from({ length: 3000 / STEP_MS }, () => 9900)
+]);
+
+// Convergence hold is 10000 ms, tolerance 0.02% of a 200 ms target = 0.04 ms.
+const atConvergenceHold = afterWarmup(
+  Array.from({ length: 10000 / STEP_MS + 21 }, () => 50),
+  { error: (i) => (i >= WARMUP_SAMPLES + 20 ? 0.001 : 5) }
+);
+// Error exactly at the limit must NOT count: the test is `>= limit` breaks.
+const errorAtConvergenceLimit = afterWarmup(
+  Array.from({ length: 80 }, () => 50),
+  { error: () => 0.04 }
+);
+// A hair inside it must.
+const errorInsideConvergenceLimit = afterWarmup(
+  Array.from({ length: 400 }, () => 50),
+  { error: () => 0.0399 }
+);
+
+// Source loss fires at 2 events inside a 10 s window.
+const atSourceLossFloor = afterWarmup(Array.from({ length: 80 }, () => 100), {
+  phase: (i) => {
+    const k = i - WARMUP_SAMPLES;
+    return (k > 40 && k < 44) || (k > 60 && k < 64) ? 'low-recover' : 'stable';
+  }
+});
+const belowSourceLossFloor = afterWarmup(Array.from({ length: 400 }, () => 100), {
+  phase: (i) => {
+    const k = i - WARMUP_SAMPLES;
+    return k > 60 && k < 64 ? 'low-recover' : 'stable';
+  }
+});
+
+const windows = {
+  flat,
+  oscillating,
+  saturated,
+  brieflySaturated,
+  converged,
+  notConverged,
+  flapping,
+  oneLongDip,
+  withGaps,
+  tooShort,
+  empty: [],
+  atCrossingFloor,
+  belowCrossingFloor,
+  atAmplitudeFloor,
+  belowAmplitudeFloor,
+  insideHysteresis,
+  outsideHysteresis,
+  atSaturationHold,
+  belowSaturationHold,
+  atConvergenceHold,
+  errorAtConvergenceLimit,
+  errorInsideConvergenceLimit,
+  atSourceLossFloor,
+  belowSourceLossFloor
+};
+
+const palierStats = {};
+for (const [name, samples] of Object.entries(windows)) {
+  palierStats[name] = computePalierStats(samples, 0);
+}
+
+const out = {
+  _comment:
+    'GENERATED from src/auto-tune/detectors.js — do not edit. ' +
+    'node scripts/dump-auto-tune-goldens.mjs > this file. ' +
+    'The JS is the reference; src-tauri/src/auto_tune/detectors.rs is asserted against it.',
+  windows,
+  palierStats,
+  oscillationAbsolute: Object.fromEntries(
+    Object.entries(windows).map(([name, s]) => [name, detectOscillationAbsolute(s, 0)])
+  ),
+  oscillationByJump: {
+    // A real oscillation against a flat baseline.
+    jumpOverFlat: detectOscillationByJump(palierStats.oscillating, [palierStats.flat]),
+    // The same palier compared against itself: no jump.
+    noJump: detectOscillationByJump(palierStats.oscillating, [palierStats.oscillating]),
+    // Nothing to compare against yet.
+    noBaseline: detectOscillationByJump(palierStats.oscillating, []),
+    // Baseline present but all null.
+    nullBaseline: detectOscillationByJump(palierStats.oscillating, [null, null]),
+    // Current palier below the absolute floors.
+    quietCurrent: detectOscillationByJump(palierStats.flat, [palierStats.flat]),
+    noCurrent: detectOscillationByJump(null, [palierStats.flat])
+  },
+  saturation: Object.fromEntries(
+    Object.entries(windows).map(([name, s]) => [name, detectSaturation(s, 0.01)])
+  ),
+  saturationNoLimit: detectSaturation(saturated, 0),
+  convergence: Object.fromEntries(
+    Object.entries(windows).map(([name, s]) => [name, detectConvergence(s)])
+  ),
+  sourceLoss: Object.fromEntries(
+    Object.entries(windows).map(([name, s]) => [name, detectSourceLoss(s)])
+  ),
+  rateStatsAll: Object.fromEntries(
+    Object.entries(windows).map(([name, s]) => [name, computeRateStats(s, null)])
+  ),
+  rateStatsWindowed: Object.fromEntries(
+    Object.entries(windows).map(([name, s]) => [name, computeRateStats(s, 5000)])
+  )
+};
+
+process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);

--- a/omniphony-studio/scripts/golden/auto-tune.json
+++ b/omniphony-studio/scripts/golden/auto-tune.json
@@ -1,0 +1,21063 @@
+{
+  "_comment": "GENERATED from src/auto-tune/detectors.js — do not edit. node scripts/dump-auto-tune-goldens.mjs > this file. The JS is the reference; src-tauri/src/auto_tune/detectors.rs is asserted against it.",
+  "windows": {
+    "flat": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999520402685739,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999516547848237,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000043155794498,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000134904056088,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000410029513762,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999612461669137,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999995889405254,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000048348844284,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000009610011708,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000283450416056,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999539854317437,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000243801222415,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000465809367598,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999573667540913,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000019960692944,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999960294174264,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999896483515389,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000459521286889,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999906125301029,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000452764156507,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000493678333238,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000163700567326,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999922895579133,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999999924633884,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999978728507366,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999923302407143,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000175318736118,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999655303676845,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999588769238442,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000352685946738,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999811562620569,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999507070621708,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999962667160668,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999791678008391,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000072984320578,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000462276793318,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999951546539925,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000279755225172,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999802247839514,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99998211352902,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000454987945966,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000046827732352,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000167262084316,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000156964832219,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000123416244984,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999661249421304,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000429064166267,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000267422670732,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999957067024894,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000022567975591,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999831773014274,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000212651561247,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000076052943245,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000261422151466,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999942738300654,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999705965798581,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999956951043568,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000171863916096,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000021009679418,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000037270131451,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999891604024916,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000042564275465,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000024225133704,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999642854837933,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000185179323888,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999850164835108,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999858226855751,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000293137117522,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000296611009165,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999676099417498,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999618979389313,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999904065206879,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000374549488538,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000223475045291,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000035832151304,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99997477188122,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999891944028437,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000370002299315,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000313334215898,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999871785702417,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000332383085972,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000192248114153,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000028276631143,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000395521181868,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000131317453458,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000420286657057,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999883903844747,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000283246625448,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000325291215442,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999959645176935,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000011744544236,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000011101207626,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999961230551824,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000078815970337,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000389093198347,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999592047905782,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999776440151967,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000280021023704,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000230548439082,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999876630536514,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999967985794507,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999782085066429,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000381264718714,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999891987227136,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000275316971354,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000217811300187,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999590510807466,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000237864920172,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000034231556952,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000059423245258,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999713378992398,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000403388152133,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999989999517519,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999705051556929,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00001788636907,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000320831026184,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000499925965443,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999503697404405,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0000158135375474,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999521928247297,
+        "phase": "stable"
+      }
+    ],
+    "oscillating": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0013087787871846,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.002473479212279,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0033658839392317,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0038877516054532,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.003981631831007,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0036371897073026,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0028923435269532,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0018290905065432,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005644800322395,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992377281484981,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9979948918056466,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9969727900187683,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.996283941994917,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960041803316083,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9961643029013475,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9967466824337297,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9976872070330227,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9988823380072043,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0002005080395286,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0014966049222849,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.002627946394875,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0034699874784752,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039300311479455,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039574329864935,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0035491764323787,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0027502048604522,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.001648473940967,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0003652689422189,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9990418529074787,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9978239155564426,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.996845534871107,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9962144169726476,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960000391737972,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9962260014919381,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9968674286150536,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9978537083279982,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9990762649363953,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0004005119421864,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0016806681473065,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0027758061383083,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0035653664367283,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039624294227796,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039232839779464,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0034522394718721,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0026011513606286,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0014637126214117,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001651394573947,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9988483867333398,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9976584106310077,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9967262109873682,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9961544100324817,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960059551076625,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9962971890377039,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9969960510129133,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9980256060388507,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992725144103869,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000599508838652,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0018605056725354,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0029166866791885,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0036517810029104,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039848649710523,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.003879270666134,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0033466225541443,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0024455577923304,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.001275271092809,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9999645947628384,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9986578160576073,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9974987931579695,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9966151183832993,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9961040720497217,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960219132587864,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9963776865519735,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9971322262323298,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9982024679635881,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9994705929996089,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007969983915175,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0020356653329232,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0030502338019185,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0037290139050903,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039972813831204,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0038255037136181,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0032325912315518,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0022838153640843,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0010836231532314,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9997641390875829,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9984706200316632,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9973454644631481,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9965125363787618,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960635295890339,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960478735036286,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9964672916400447,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9972756118882835,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9983838494187077,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9996700026755511,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0009924840532858,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0022057067249668,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0031761117292952,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0037968709567717,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039996474404291,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.003762118306515,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0031104322127695,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00211633074448,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0008892506626224,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99956427643684,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9982872693220154,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9971988100605043,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9964187228954376,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960328845862275,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9960837705704092,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9965657790080644,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.997425847466572,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9985692943572626,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9998702420629553,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0011854743148376,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0023702023140117,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0032940039667555,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0038551815451364,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0039919571940064,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0036892738145984,
+        "phase": "stable"
+      }
+    ],
+    "saturated": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      }
+    ],
+    "brieflySaturated": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      }
+    ],
+    "converged": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      }
+    ],
+    "notConverged": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      }
+    ],
+    "flapping": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      }
+    ],
+    "oneLongDip": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      }
+    ],
+    "withGaps": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0005,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": null,
+        "phase": "stable"
+      }
+    ],
+    "tooShort": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      }
+    ],
+    "empty": [],
+    "atCrossingFloor": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      }
+    ],
+    "belowCrossingFloor": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      }
+    ],
+    "atAmplitudeFloor": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.99925,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00075,
+        "phase": "stable"
+      }
+    ],
+    "belowAmplitudeFloor": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.9992505,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0007495,
+        "phase": "stable"
+      }
+    ],
+    "insideHysteresis": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000199,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999801,
+        "phase": "stable"
+      }
+    ],
+    "outsideHysteresis": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.000201,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 0.999799,
+        "phase": "stable"
+      }
+    ],
+    "atSaturationHold": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      }
+    ],
+    "belowSaturationHold": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0099,
+        "phase": "stable"
+      }
+    ],
+    "atConvergenceHold": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 205,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200.001,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      }
+    ],
+    "errorAtConvergenceLimit": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200.04,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      }
+    ],
+    "errorInsideConvergenceLimit": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 30000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 30250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 30500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 30750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 31000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 31250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 31500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 31750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 32000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 32250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 32500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 32750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 33000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 33250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 33500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 33750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 34000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 34250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 34500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 34750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 35000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 35250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 35500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 35750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 36000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 36250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 36500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 36750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 37000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 37250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 37500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 37750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 38000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 38250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 38500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 38750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 39000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 39250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 39500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 39750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 40000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 40250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 40500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 40750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 41000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 41250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 41500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 41750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 42000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 42250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 42500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 42750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 43000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 43250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 43500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 43750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 44000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 44250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 44500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 44750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 45000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 45250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 45500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 45750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 46000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 46250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 46500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 46750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 47000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 47250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 47500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 47750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 48000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 48250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 48500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 48750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 49000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 49250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 49500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 49750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 50000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 50250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 50500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 50750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 51000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 51250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 51500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 51750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 52000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 52250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 52500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 52750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 53000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 53250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 53500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 53750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 54000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 54250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 54500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 54750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 55000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 55250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 55500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 55750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 56000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 56250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 56500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 56750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 57000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 57250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 57500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 57750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 58000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 58250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 58500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 58750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 59000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 59250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 59500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 59750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 60000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 60250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 60500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 60750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 61000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 61250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 61500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 61750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 62000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 62250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 62500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 62750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 63000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 63250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 63500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 63750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 64000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 64250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 64500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 64750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 65000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 65250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 65500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 65750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 66000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 66250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 66500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 66750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 67000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 67250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 67500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 67750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 68000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 68250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 68500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 68750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 69000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 69250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 69500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 69750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 70000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 70250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 70500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 70750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 71000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 71250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 71500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 71750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 72000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 72250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 72500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 72750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 73000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 73250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 73500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 73750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 74000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 74250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 74500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 74750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 75000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 75250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 75500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 75750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 76000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 76250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 76500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 76750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 77000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 77250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 77500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 77750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 78000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 78250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 78500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 78750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 79000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 79250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 79500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 79750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 80000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 80250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 80500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 80750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 81000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 81250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 81500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 81750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 82000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 82250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 82500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 82750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 83000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 83250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 83500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 83750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 84000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 84250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 84500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 84750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 85000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 85250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 85500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 85750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 86000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 86250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 86500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 86750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 87000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 87250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 87500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 87750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 88000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 88250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 88500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 88750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 89000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 89250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 89500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 89750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 90000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 90250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 90500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 90750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 91000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 91250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 91500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 91750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 92000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 92250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 92500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 92750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 93000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 93250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 93500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 93750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 94000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 94250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 94500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 94750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 95000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 95250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 95500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 95750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 96000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 96250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 96500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 96750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 97000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 97250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 97500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 97750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 98000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 98250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 98500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 98750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 99000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 99250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 99500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 99750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 100000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 100250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 100500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 100750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 101000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 101250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 101500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 101750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 102000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 102250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 102500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 102750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 103000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 103250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 103500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 103750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 104000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 104250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 104500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 104750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 105000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 105250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 105500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 105750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 106000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 106250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 106500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 106750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 107000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 107250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 107500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 107750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 108000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 108250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 108500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 108750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 109000,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 109250,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 109500,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      },
+      {
+        "t": 109750,
+        "latencySmoothedMs": 200.0399,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.00005,
+        "phase": "stable"
+      }
+    ],
+    "atSourceLossFloor": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      }
+    ],
+    "belowSourceLossFloor": [
+      {
+        "t": 0,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 1750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 2750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 3750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 4750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 5750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 6750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 7750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 8750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 9750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1,
+        "phase": "stable"
+      },
+      {
+        "t": 10000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 10750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 11750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 12750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 13750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 14750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 15750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 16750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 17750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 18750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 19750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 20000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 20250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 20500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 20750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 21750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 22750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 23750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 24750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 25000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 25250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 25500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 25750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "low-recover"
+      },
+      {
+        "t": 26000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 26250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 26500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 26750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 27750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 28750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 29750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 30000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 30250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 30500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 30750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 31000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 31250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 31500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 31750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 32000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 32250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 32500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 32750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 33000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 33250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 33500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 33750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 34000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 34250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 34500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 34750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 35000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 35250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 35500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 35750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 36000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 36250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 36500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 36750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 37000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 37250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 37500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 37750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 38000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 38250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 38500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 38750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 39000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 39250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 39500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 39750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 40000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 40250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 40500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 40750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 41000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 41250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 41500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 41750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 42000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 42250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 42500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 42750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 43000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 43250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 43500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 43750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 44000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 44250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 44500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 44750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 45000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 45250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 45500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 45750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 46000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 46250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 46500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 46750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 47000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 47250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 47500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 47750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 48000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 48250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 48500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 48750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 49000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 49250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 49500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 49750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 50000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 50250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 50500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 50750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 51000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 51250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 51500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 51750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 52000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 52250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 52500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 52750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 53000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 53250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 53500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 53750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 54000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 54250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 54500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 54750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 55000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 55250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 55500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 55750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 56000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 56250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 56500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 56750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 57000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 57250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 57500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 57750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 58000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 58250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 58500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 58750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 59000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 59250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 59500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 59750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 60000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 60250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 60500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 60750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 61000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 61250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 61500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 61750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 62000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 62250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 62500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 62750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 63000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 63250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 63500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 63750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 64000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 64250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 64500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 64750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 65000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 65250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 65500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 65750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 66000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 66250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 66500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 66750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 67000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 67250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 67500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 67750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 68000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 68250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 68500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 68750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 69000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 69250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 69500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 69750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 70000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 70250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 70500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 70750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 71000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 71250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 71500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 71750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 72000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 72250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 72500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 72750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 73000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 73250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 73500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 73750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 74000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 74250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 74500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 74750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 75000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 75250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 75500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 75750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 76000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 76250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 76500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 76750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 77000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 77250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 77500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 77750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 78000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 78250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 78500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 78750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 79000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 79250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 79500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 79750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 80000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 80250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 80500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 80750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 81000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 81250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 81500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 81750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 82000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 82250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 82500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 82750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 83000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 83250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 83500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 83750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 84000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 84250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 84500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 84750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 85000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 85250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 85500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 85750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 86000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 86250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 86500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 86750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 87000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 87250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 87500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 87750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 88000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 88250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 88500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 88750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 89000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 89250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 89500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 89750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 90000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 90250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 90500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 90750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 91000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 91250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 91500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 91750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 92000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 92250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 92500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 92750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 93000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 93250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 93500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 93750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 94000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 94250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 94500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 94750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 95000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 95250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 95500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 95750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 96000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 96250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 96500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 96750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 97000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 97250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 97500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 97750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 98000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 98250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 98500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 98750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 99000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 99250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 99500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 99750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 100000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 100250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 100500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 100750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 101000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 101250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 101500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 101750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 102000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 102250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 102500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 102750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 103000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 103250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 103500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 103750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 104000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 104250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 104500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 104750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 105000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 105250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 105500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 105750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 106000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 106250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 106500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 106750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 107000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 107250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 107500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 107750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 108000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 108250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 108500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 108750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 109000,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 109250,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 109500,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      },
+      {
+        "t": 109750,
+        "latencySmoothedMs": 200,
+        "latencyTargetMs": 200,
+        "resampleRatio": 1.0001,
+        "phase": "stable"
+      }
+    ]
+  },
+  "palierStats": {
+    "flat": {
+      "peakToPeakPpm": 99.62285610376486,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 5.966812067194346,
+      "samples": 80,
+      "stableDurationMs": 19750
+    },
+    "oscillating": {
+      "peakToPeakPpm": 7993.692332766588,
+      "crossings": 8,
+      "crossingRate": 0.40506329113924056,
+      "meanPpm": 204.83501583117996,
+      "samples": 80,
+      "stableDurationMs": 19750
+    },
+    "saturated": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 9900.000000000016,
+      "samples": 40,
+      "stableDurationMs": 9750
+    },
+    "brieflySaturated": {
+      "peakToPeakPpm": 9800.000000000031,
+      "crossings": 1,
+      "crossingRate": 0.10256410256410256,
+      "meanPpm": 834.9999999999915,
+      "samples": 40,
+      "stableDurationMs": 9750
+    },
+    "converged": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 50.00000000010551,
+      "samples": 80,
+      "stableDurationMs": 19750
+    },
+    "notConverged": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 50.00000000010551,
+      "samples": 80,
+      "stableDurationMs": 19750
+    },
+    "flapping": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 99.99999999998906,
+      "samples": 40,
+      "stableDurationMs": 9750
+    },
+    "oneLongDip": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 99.99999999998906,
+      "samples": 40,
+      "stableDurationMs": 9750
+    },
+    "withGaps": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 499.9999999999451,
+      "samples": 68,
+      "stableDurationMs": 19500
+    },
+    "tooShort": null,
+    "empty": null,
+    "atCrossingFloor": {
+      "peakToPeakPpm": 1500.0000000000568,
+      "crossings": 4,
+      "crossingRate": 0.5517241379310345,
+      "meanPpm": 150.00000000000566,
+      "samples": 30,
+      "stableDurationMs": 7250
+    },
+    "belowCrossingFloor": {
+      "peakToPeakPpm": 1500.0000000000568,
+      "crossings": 3,
+      "crossingRate": 0.5217391304347826,
+      "meanPpm": 9.473903143468002e-15,
+      "samples": 24,
+      "stableDurationMs": 5750
+    },
+    "atAmplitudeFloor": {
+      "peakToPeakPpm": 1500.0000000000568,
+      "crossings": 10,
+      "crossingRate": 0.6153846153846154,
+      "meanPpm": 68.18181818182076,
+      "samples": 66,
+      "stableDurationMs": 16250
+    },
+    "belowAmplitudeFloor": {
+      "peakToPeakPpm": 1498.999999999917,
+      "crossings": 10,
+      "crossingRate": 0.6153846153846154,
+      "meanPpm": 68.13636363635986,
+      "samples": 66,
+      "stableDurationMs": 16250
+    },
+    "insideHysteresis": {
+      "peakToPeakPpm": 398.00000000000944,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 5.5535072836695085e-11,
+      "samples": 60,
+      "stableDurationMs": 14750
+    },
+    "outsideHysteresis": {
+      "peakToPeakPpm": 401.99999999990246,
+      "crossings": 9,
+      "crossingRate": 0.6101694915254237,
+      "meanPpm": -5.551801981103684e-11,
+      "samples": 60,
+      "stableDurationMs": 14750
+    },
+    "atSaturationHold": {
+      "peakToPeakPpm": 9800.000000000031,
+      "crossings": 1,
+      "crossingRate": 0.125,
+      "meanPpm": 3960.606060606061,
+      "samples": 33,
+      "stableDurationMs": 8000
+    },
+    "belowSaturationHold": {
+      "peakToPeakPpm": 9800.000000000031,
+      "crossings": 1,
+      "crossingRate": 0.12903225806451613,
+      "meanPpm": 3775,
+      "samples": 32,
+      "stableDurationMs": 7750
+    },
+    "atConvergenceHold": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 50.00000000010551,
+      "samples": 61,
+      "stableDurationMs": 15000
+    },
+    "errorAtConvergenceLimit": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 50.00000000010551,
+      "samples": 80,
+      "stableDurationMs": 19750
+    },
+    "errorInsideConvergenceLimit": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 50.00000000010551,
+      "samples": 400,
+      "stableDurationMs": 99750
+    },
+    "atSourceLossFloor": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 99.99999999998906,
+      "samples": 80,
+      "stableDurationMs": 19750
+    },
+    "belowSourceLossFloor": {
+      "peakToPeakPpm": 0,
+      "crossings": 0,
+      "crossingRate": 0,
+      "meanPpm": 99.99999999998842,
+      "samples": 400,
+      "stableDurationMs": 99750
+    }
+  },
+  "oscillationAbsolute": {
+    "flat": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 99.62285610376486,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 5.966812067194346,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "oscillating": {
+      "oscillating": true,
+      "reason": null,
+      "stats": {
+        "peakToPeakPpm": 7993.692332766588,
+        "crossings": 8,
+        "crossingRate": 0.40506329113924056,
+        "meanPpm": 204.83501583117996,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "saturated": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 9900.000000000016,
+        "samples": 40,
+        "stableDurationMs": 9750
+      }
+    },
+    "brieflySaturated": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 9800.000000000031,
+        "crossings": 1,
+        "crossingRate": 0.10256410256410256,
+        "meanPpm": 834.9999999999915,
+        "samples": 40,
+        "stableDurationMs": 9750
+      }
+    },
+    "converged": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 50.00000000010551,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "notConverged": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 50.00000000010551,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "flapping": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 99.99999999998906,
+        "samples": 40,
+        "stableDurationMs": 9750
+      }
+    },
+    "oneLongDip": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 99.99999999998906,
+        "samples": 40,
+        "stableDurationMs": 9750
+      }
+    },
+    "withGaps": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 499.9999999999451,
+        "samples": 68,
+        "stableDurationMs": 19500
+      }
+    },
+    "tooShort": {
+      "oscillating": false,
+      "reason": "insufficient-samples",
+      "stats": null
+    },
+    "empty": {
+      "oscillating": false,
+      "reason": "insufficient-samples",
+      "stats": null
+    },
+    "atCrossingFloor": {
+      "oscillating": true,
+      "reason": null,
+      "stats": {
+        "peakToPeakPpm": 1500.0000000000568,
+        "crossings": 4,
+        "crossingRate": 0.5517241379310345,
+        "meanPpm": 150.00000000000566,
+        "samples": 30,
+        "stableDurationMs": 7250
+      }
+    },
+    "belowCrossingFloor": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 1500.0000000000568,
+        "crossings": 3,
+        "crossingRate": 0.5217391304347826,
+        "meanPpm": 9.473903143468002e-15,
+        "samples": 24,
+        "stableDurationMs": 5750
+      }
+    },
+    "atAmplitudeFloor": {
+      "oscillating": true,
+      "reason": null,
+      "stats": {
+        "peakToPeakPpm": 1500.0000000000568,
+        "crossings": 10,
+        "crossingRate": 0.6153846153846154,
+        "meanPpm": 68.18181818182076,
+        "samples": 66,
+        "stableDurationMs": 16250
+      }
+    },
+    "belowAmplitudeFloor": {
+      "oscillating": false,
+      "reason": "amplitude-below-floor",
+      "stats": {
+        "peakToPeakPpm": 1498.999999999917,
+        "crossings": 10,
+        "crossingRate": 0.6153846153846154,
+        "meanPpm": 68.13636363635986,
+        "samples": 66,
+        "stableDurationMs": 16250
+      }
+    },
+    "insideHysteresis": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 398.00000000000944,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 5.5535072836695085e-11,
+        "samples": 60,
+        "stableDurationMs": 14750
+      }
+    },
+    "outsideHysteresis": {
+      "oscillating": false,
+      "reason": "amplitude-below-floor",
+      "stats": {
+        "peakToPeakPpm": 401.99999999990246,
+        "crossings": 9,
+        "crossingRate": 0.6101694915254237,
+        "meanPpm": -5.551801981103684e-11,
+        "samples": 60,
+        "stableDurationMs": 14750
+      }
+    },
+    "atSaturationHold": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 9800.000000000031,
+        "crossings": 1,
+        "crossingRate": 0.125,
+        "meanPpm": 3960.606060606061,
+        "samples": 33,
+        "stableDurationMs": 8000
+      }
+    },
+    "belowSaturationHold": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 9800.000000000031,
+        "crossings": 1,
+        "crossingRate": 0.12903225806451613,
+        "meanPpm": 3775,
+        "samples": 32,
+        "stableDurationMs": 7750
+      }
+    },
+    "atConvergenceHold": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 50.00000000010551,
+        "samples": 61,
+        "stableDurationMs": 15000
+      }
+    },
+    "errorAtConvergenceLimit": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 50.00000000010551,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "errorInsideConvergenceLimit": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 50.00000000010551,
+        "samples": 400,
+        "stableDurationMs": 99750
+      }
+    },
+    "atSourceLossFloor": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 99.99999999998906,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "belowSourceLossFloor": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "stats": {
+        "peakToPeakPpm": 0,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 99.99999999998842,
+        "samples": 400,
+        "stableDurationMs": 99750
+      }
+    }
+  },
+  "oscillationByJump": {
+    "jumpOverFlat": {
+      "oscillating": true,
+      "reason": null,
+      "currentStats": {
+        "peakToPeakPpm": 7993.692332766588,
+        "crossings": 8,
+        "crossingRate": 0.40506329113924056,
+        "meanPpm": 204.83501583117996,
+        "samples": 80,
+        "stableDurationMs": 19750
+      },
+      "maxBaselinePeakToPeakPpm": 99.62285610376486,
+      "maxBaselineCrossingRate": 0,
+      "peakToPeakJump": 80.23954186216608,
+      "crossingJump": null
+    },
+    "noJump": {
+      "oscillating": false,
+      "reason": "jump-below-ratio",
+      "currentStats": {
+        "peakToPeakPpm": 7993.692332766588,
+        "crossings": 8,
+        "crossingRate": 0.40506329113924056,
+        "meanPpm": 204.83501583117996,
+        "samples": 80,
+        "stableDurationMs": 19750
+      },
+      "maxBaselinePeakToPeakPpm": 7993.692332766588,
+      "maxBaselineCrossingRate": 0.40506329113924056,
+      "peakToPeakJump": 1,
+      "crossingJump": 1
+    },
+    "noBaseline": {
+      "oscillating": false,
+      "reason": "baseline-too-short",
+      "currentStats": {
+        "peakToPeakPpm": 7993.692332766588,
+        "crossings": 8,
+        "crossingRate": 0.40506329113924056,
+        "meanPpm": 204.83501583117996,
+        "samples": 80,
+        "stableDurationMs": 19750
+      },
+      "baselines": []
+    },
+    "nullBaseline": {
+      "oscillating": false,
+      "reason": "baseline-too-short",
+      "currentStats": {
+        "peakToPeakPpm": 7993.692332766588,
+        "crossings": 8,
+        "crossingRate": 0.40506329113924056,
+        "meanPpm": 204.83501583117996,
+        "samples": 80,
+        "stableDurationMs": 19750
+      },
+      "baselines": []
+    },
+    "quietCurrent": {
+      "oscillating": false,
+      "reason": "crossings-below-floor",
+      "currentStats": {
+        "peakToPeakPpm": 99.62285610376486,
+        "crossings": 0,
+        "crossingRate": 0,
+        "meanPpm": 5.966812067194346,
+        "samples": 80,
+        "stableDurationMs": 19750
+      }
+    },
+    "noCurrent": {
+      "oscillating": false,
+      "reason": "no-current-stats"
+    }
+  },
+  "saturation": {
+    "flat": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "oscillating": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "saturated": {
+      "saturated": true,
+      "durationMs": 19750
+    },
+    "brieflySaturated": {
+      "saturated": false,
+      "durationMs": 500
+    },
+    "converged": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "notConverged": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "flapping": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "oneLongDip": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "withGaps": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "tooShort": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "empty": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "atCrossingFloor": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "belowCrossingFloor": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "atAmplitudeFloor": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "belowAmplitudeFloor": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "insideHysteresis": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "outsideHysteresis": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "atSaturationHold": {
+      "saturated": true,
+      "durationMs": 3000
+    },
+    "belowSaturationHold": {
+      "saturated": false,
+      "durationMs": 2750
+    },
+    "atConvergenceHold": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "errorAtConvergenceLimit": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "errorInsideConvergenceLimit": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "atSourceLossFloor": {
+      "saturated": false,
+      "durationMs": 0
+    },
+    "belowSourceLossFloor": {
+      "saturated": false,
+      "durationMs": 0
+    }
+  },
+  "saturationNoLimit": {
+    "saturated": false,
+    "durationMs": 0
+  },
+  "convergence": {
+    "flat": {
+      "converged": true,
+      "durationMs": 29750,
+      "limitMs": 0.04
+    },
+    "oscillating": {
+      "converged": true,
+      "durationMs": 29750,
+      "limitMs": 0.04
+    },
+    "saturated": {
+      "converged": true,
+      "durationMs": 19750,
+      "limitMs": 0.04
+    },
+    "brieflySaturated": {
+      "converged": true,
+      "durationMs": 19750,
+      "limitMs": 0.04
+    },
+    "converged": {
+      "converged": true,
+      "durationMs": 29750,
+      "limitMs": 0.04
+    },
+    "notConverged": {
+      "converged": false,
+      "durationMs": 0,
+      "limitMs": null
+    },
+    "flapping": {
+      "converged": true,
+      "durationMs": 19750,
+      "limitMs": 0.04
+    },
+    "oneLongDip": {
+      "converged": true,
+      "durationMs": 19750,
+      "limitMs": 0.04
+    },
+    "withGaps": {
+      "converged": true,
+      "durationMs": 29750,
+      "limitMs": 0.04
+    },
+    "tooShort": {
+      "converged": false,
+      "durationMs": 1250,
+      "limitMs": 0.04
+    },
+    "empty": {
+      "converged": false,
+      "durationMs": 0
+    },
+    "atCrossingFloor": {
+      "converged": true,
+      "durationMs": 17250,
+      "limitMs": 0.04
+    },
+    "belowCrossingFloor": {
+      "converged": true,
+      "durationMs": 15750,
+      "limitMs": 0.04
+    },
+    "atAmplitudeFloor": {
+      "converged": true,
+      "durationMs": 26250,
+      "limitMs": 0.04
+    },
+    "belowAmplitudeFloor": {
+      "converged": true,
+      "durationMs": 26250,
+      "limitMs": 0.04
+    },
+    "insideHysteresis": {
+      "converged": true,
+      "durationMs": 24750,
+      "limitMs": 0.04
+    },
+    "outsideHysteresis": {
+      "converged": true,
+      "durationMs": 24750,
+      "limitMs": 0.04
+    },
+    "atSaturationHold": {
+      "converged": true,
+      "durationMs": 18000,
+      "limitMs": 0.04
+    },
+    "belowSaturationHold": {
+      "converged": true,
+      "durationMs": 17750,
+      "limitMs": 0.04
+    },
+    "atConvergenceHold": {
+      "converged": true,
+      "durationMs": 10000,
+      "limitMs": 0.04
+    },
+    "errorAtConvergenceLimit": {
+      "converged": true,
+      "durationMs": 29750,
+      "limitMs": 0.04
+    },
+    "errorInsideConvergenceLimit": {
+      "converged": true,
+      "durationMs": 109750,
+      "limitMs": 0.04
+    },
+    "atSourceLossFloor": {
+      "converged": true,
+      "durationMs": 29750,
+      "limitMs": 0.04
+    },
+    "belowSourceLossFloor": {
+      "converged": true,
+      "durationMs": 109750,
+      "limitMs": 0.04
+    }
+  },
+  "sourceLoss": {
+    "flat": {
+      "lost": false,
+      "events": 0
+    },
+    "oscillating": {
+      "lost": false,
+      "events": 0
+    },
+    "saturated": {
+      "lost": false,
+      "events": 0
+    },
+    "brieflySaturated": {
+      "lost": false,
+      "events": 0
+    },
+    "converged": {
+      "lost": false,
+      "events": 0
+    },
+    "notConverged": {
+      "lost": false,
+      "events": 0
+    },
+    "flapping": {
+      "lost": false,
+      "events": 1
+    },
+    "oneLongDip": {
+      "lost": false,
+      "events": 1
+    },
+    "withGaps": {
+      "lost": false,
+      "events": 0
+    },
+    "tooShort": {
+      "lost": false,
+      "events": 0
+    },
+    "empty": {
+      "lost": false,
+      "events": 0
+    },
+    "atCrossingFloor": {
+      "lost": false,
+      "events": 0
+    },
+    "belowCrossingFloor": {
+      "lost": false,
+      "events": 0
+    },
+    "atAmplitudeFloor": {
+      "lost": false,
+      "events": 0
+    },
+    "belowAmplitudeFloor": {
+      "lost": false,
+      "events": 0
+    },
+    "insideHysteresis": {
+      "lost": false,
+      "events": 0
+    },
+    "outsideHysteresis": {
+      "lost": false,
+      "events": 0
+    },
+    "atSaturationHold": {
+      "lost": false,
+      "events": 0
+    },
+    "belowSaturationHold": {
+      "lost": false,
+      "events": 0
+    },
+    "atConvergenceHold": {
+      "lost": false,
+      "events": 0
+    },
+    "errorAtConvergenceLimit": {
+      "lost": false,
+      "events": 0
+    },
+    "errorInsideConvergenceLimit": {
+      "lost": false,
+      "events": 0
+    },
+    "atSourceLossFloor": {
+      "lost": true,
+      "events": 2
+    },
+    "belowSourceLossFloor": {
+      "lost": false,
+      "events": 0
+    }
+  },
+  "rateStatsAll": {
+    "flat": {
+      "peakAbsPpm": 49.99259654425714,
+      "meanPpm": 3.5186460730575906,
+      "stdPpm": 28.38045401196962,
+      "samples": 120
+    },
+    "oscillating": {
+      "peakAbsPpm": 3999.9608262027973,
+      "meanPpm": 152.72892647834792,
+      "stdPpm": 2834.6677414169926,
+      "samples": 120
+    },
+    "saturated": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 9900.00000000001,
+      "stdPpm": 0.0002729575167846423,
+      "samples": 80
+    },
+    "brieflySaturated": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 467.4999999999903,
+      "stdPpm": 1861.8388088124123,
+      "samples": 80
+    },
+    "converged": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.00000000010551,
+      "stdPpm": 0.0000019073486328125,
+      "samples": 120
+    },
+    "notConverged": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.00000000010551,
+      "stdPpm": 0.0000019073486328125,
+      "samples": 120
+    },
+    "flapping": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998906,
+      "stdPpm": 0,
+      "samples": 80
+    },
+    "oneLongDip": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998906,
+      "stdPpm": 0,
+      "samples": 80
+    },
+    "withGaps": {
+      "peakAbsPpm": 499.9999999999449,
+      "meanPpm": 499.999999999944,
+      "stdPpm": 0.000020185480583683706,
+      "samples": 102
+    },
+    "tooShort": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998899,
+      "stdPpm": 0,
+      "samples": 6
+    },
+    "empty": {
+      "peakAbsPpm": 0,
+      "meanPpm": 0,
+      "stdPpm": 0,
+      "samples": 0
+    },
+    "atCrossingFloor": {
+      "peakAbsPpm": 750.0000000000284,
+      "meanPpm": 64.28571428571672,
+      "stdPpm": 486.7635724971848,
+      "samples": 70
+    },
+    "belowCrossingFloor": {
+      "peakAbsPpm": 750.0000000000284,
+      "meanPpm": 3.552713678800501e-15,
+      "stdPpm": 459.27932677186334,
+      "samples": 64
+    },
+    "atAmplitudeFloor": {
+      "peakAbsPpm": 750.0000000000284,
+      "meanPpm": 42.45283018868085,
+      "stdPpm": 590.2826494702356,
+      "samples": 106
+    },
+    "belowAmplitudeFloor": {
+      "peakAbsPpm": 749.4999999999585,
+      "meanPpm": 42.42452830188444,
+      "stdPpm": 589.8891277038673,
+      "samples": 106
+    },
+    "insideHysteresis": {
+      "peakAbsPpm": 199.00000000006025,
+      "meanPpm": 3.3321043702017053e-11,
+      "stdPpm": 154.1447371790589,
+      "samples": 100
+    },
+    "outsideHysteresis": {
+      "peakAbsPpm": 201.00000000000674,
+      "meanPpm": -3.3310811886622104e-11,
+      "stdPpm": 155.6939305175004,
+      "samples": 100
+    },
+    "atSaturationHold": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 1790.4109589041097,
+      "stdPpm": 3775.0501904877888,
+      "samples": 73
+    },
+    "belowSaturationHold": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 1677.7777777777778,
+      "stdPpm": 3677.341363835142,
+      "samples": 72
+    },
+    "atConvergenceHold": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 30.19801980204392,
+      "stdPpm": 24.45364165396938,
+      "samples": 101
+    },
+    "errorAtConvergenceLimit": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 33.33333333340367,
+      "stdPpm": 23.570226039601383,
+      "samples": 120
+    },
+    "errorInsideConvergenceLimit": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 45.45454545464138,
+      "stdPpm": 14.373989364432612,
+      "samples": 440
+    },
+    "atSourceLossFloor": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 66.66666666665938,
+      "stdPpm": 47.14045207909785,
+      "samples": 120
+    },
+    "belowSourceLossFloor": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 90.90909090908038,
+      "stdPpm": 28.747978728801414,
+      "samples": 440
+    }
+  },
+  "rateStatsWindowed": {
+    "flat": {
+      "peakAbsPpm": 49.99259654425714,
+      "meanPpm": 1.144113780810713,
+      "stdPpm": 30.97070407343961,
+      "samples": 21
+    },
+    "oscillating": {
+      "peakAbsPpm": 3999.6474404291325,
+      "meanPpm": 394.322346783356,
+      "stdPpm": 2923.359547833057,
+      "samples": 21
+    },
+    "saturated": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 9900.000000000022,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "brieflySaturated": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 1499.9999999999934,
+      "stdPpm": 3429.28563989646,
+      "samples": 21
+    },
+    "converged": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.000000000105516,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "notConverged": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.000000000105516,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "flapping": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998902,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "oneLongDip": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998902,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "withGaps": {
+      "peakAbsPpm": 499.9999999999449,
+      "meanPpm": 499.9999999999448,
+      "stdPpm": 0.000010789593218788873,
+      "samples": 18
+    },
+    "tooShort": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998899,
+      "stdPpm": 0,
+      "samples": 6
+    },
+    "empty": {
+      "peakAbsPpm": 0,
+      "meanPpm": 0,
+      "stdPpm": 0,
+      "samples": 0
+    },
+    "atCrossingFloor": {
+      "peakAbsPpm": 750.0000000000284,
+      "meanPpm": 107.14285714286119,
+      "stdPpm": 742.3074889581185,
+      "samples": 21
+    },
+    "belowCrossingFloor": {
+      "peakAbsPpm": 750.0000000000284,
+      "meanPpm": -107.14285714286119,
+      "stdPpm": 742.3074889581185,
+      "samples": 21
+    },
+    "atAmplitudeFloor": {
+      "peakAbsPpm": 750.0000000000284,
+      "meanPpm": 107.14285714286119,
+      "stdPpm": 742.3074889581185,
+      "samples": 21
+    },
+    "belowAmplitudeFloor": {
+      "peakAbsPpm": 749.4999999999585,
+      "meanPpm": 107.07142857142266,
+      "stdPpm": 741.8126172987439,
+      "samples": 21
+    },
+    "insideHysteresis": {
+      "peakAbsPpm": 199.00000000006025,
+      "meanPpm": -28.428571428516577,
+      "stdPpm": 196.95892040355128,
+      "samples": 21
+    },
+    "outsideHysteresis": {
+      "peakAbsPpm": 201.00000000000674,
+      "meanPpm": -28.71428571433426,
+      "stdPpm": 198.93840704071988,
+      "samples": 21
+    },
+    "atSaturationHold": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 6166.666666666673,
+      "stdPpm": 4759.084879353284,
+      "samples": 21
+    },
+    "belowSaturationHold": {
+      "peakAbsPpm": 9900.00000000002,
+      "meanPpm": 5700.0000000000055,
+      "stdPpm": 4849.742261192873,
+      "samples": 21
+    },
+    "atConvergenceHold": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.000000000105516,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "errorAtConvergenceLimit": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.000000000105516,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "errorInsideConvergenceLimit": {
+      "peakAbsPpm": 50.000000000105516,
+      "meanPpm": 50.000000000105516,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "atSourceLossFloor": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998902,
+      "stdPpm": 0,
+      "samples": 21
+    },
+    "belowSourceLossFloor": {
+      "peakAbsPpm": 99.99999999998899,
+      "meanPpm": 99.99999999998902,
+      "stdPpm": 0,
+      "samples": 21
+    }
+  }
+}

--- a/omniphony-studio/src-tauri/src/auto_tune/detectors.rs
+++ b/omniphony-studio/src-tauri/src/auto_tune/detectors.rs
@@ -1,0 +1,799 @@
+//! Detectors for the PI auto-tune state machine.
+//!
+//! A faithful port of `src/auto-tune/detectors.js`. These decide when the
+//! resampler's control loop is oscillating, saturated, converged, or has lost
+//! its source — and those verdicts drive kp/ki changes on a running audio
+//! path. A detector that fires a little differently here than it did in the
+//! frontend would retune the loop differently, which is not something a reader
+//! would catch by eye.
+//!
+//! So the port is asserted against the frontend rather than against my reading
+//! of it: `scripts/dump-auto-tune-goldens.mjs` runs the JS detectors over a set
+//! of synthetic telemetry windows and records their verdicts, and
+//! `golden_vectors_match_the_frontend` replays every one through this module.
+//! The JS is the reference here — it is the implementation that works — which
+//! is the opposite direction from the geometry crate, where Rust is canonical.
+//!
+//! Nothing in this module is wired to the running state machine yet; the FSM
+//! that consumes these is a separate step.
+
+/// Thresholds for the oscillation detectors.
+#[derive(Debug, Clone, Copy)]
+pub struct OscillationThresholds {
+    /// Discard this much of each palier — the transient response to the kp
+    /// patch is not representative of the steady state.
+    pub palier_warmup_ms: f64,
+    /// Dead-band around the mean, so noise does not count as a crossing.
+    pub hysteresis_ppm: f64,
+    pub min_crossings_absolute: u32,
+    pub min_absolute_peak_to_peak_ppm: f64,
+    /// Current peak-to-peak must reach this multiple of the baseline's.
+    pub peak_to_peak_jump_ratio: f64,
+    /// And the crossing rate this multiple of the baseline's.
+    pub crossing_jump_ratio: f64,
+    pub baseline_paliers: usize,
+    pub min_baseline_paliers: usize,
+}
+
+impl Default for OscillationThresholds {
+    fn default() -> Self {
+        Self {
+            palier_warmup_ms: 10_000.0,
+            hysteresis_ppm: 200.0,
+            min_crossings_absolute: 4,
+            min_absolute_peak_to_peak_ppm: 1500.0,
+            peak_to_peak_jump_ratio: 3.0,
+            crossing_jump_ratio: 2.0,
+            baseline_paliers: 3,
+            min_baseline_paliers: 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SaturationThresholds {
+    pub hold_ms: f64,
+    pub threshold: f64,
+}
+
+impl Default for SaturationThresholds {
+    fn default() -> Self {
+        Self {
+            hold_ms: 3000.0,
+            threshold: 0.98,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ConvergenceThresholds {
+    /// `|smoothed - target| < |target| * err_fraction`.
+    pub err_fraction: f64,
+    /// Absolute floor; zero trusts the fraction entirely.
+    pub err_floor_ms: f64,
+    pub hold_ms: f64,
+}
+
+impl Default for ConvergenceThresholds {
+    fn default() -> Self {
+        Self {
+            err_fraction: 0.0002,
+            err_floor_ms: 0.0,
+            hold_ms: 10_000.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SourceLossThresholds {
+    pub window_ms: f64,
+    pub min_low_recover_events: u32,
+}
+
+impl Default for SourceLossThresholds {
+    fn default() -> Self {
+        Self {
+            window_ms: 10_000.0,
+            min_low_recover_events: 2,
+        }
+    }
+}
+
+/// One telemetry sample, as the runner polls it.
+#[derive(Debug, Clone, Default)]
+pub struct Sample {
+    pub t: f64,
+    pub latency_smoothed_ms: Option<f64>,
+    pub latency_target_ms: Option<f64>,
+    pub resample_ratio: Option<f64>,
+    pub phase: Option<String>,
+}
+
+/// Resampler correction in parts per million, or `None` when the sample does
+/// not carry a usable ratio.
+pub fn rate_adjust_ppm(sample: &Sample) -> Option<f64> {
+    match sample.resample_ratio {
+        Some(ratio) if ratio.is_finite() => Some((ratio - 1.0) * 1e6),
+        _ => None,
+    }
+}
+
+/// Signed latency error against the target.
+pub fn error_ms(sample: &Sample) -> Option<f64> {
+    match (sample.latency_smoothed_ms, sample.latency_target_ms) {
+        (Some(smoothed), Some(target)) => Some(smoothed - target),
+        _ => None,
+    }
+}
+
+/// Trailing `window_ms` of samples.
+///
+/// The cutoff is measured from the newest sample, not from wall-clock, so a
+/// stalled feed keeps its window rather than emptying it.
+fn slice_by_window(samples: &[Sample], window_ms: f64) -> &[Sample] {
+    if samples.is_empty() {
+        return samples;
+    }
+    let cutoff = samples[samples.len() - 1].t - window_ms;
+    let mut i = 0;
+    while i < samples.len() && samples[i].t < cutoff {
+        i += 1;
+    }
+    &samples[i..]
+}
+
+/// Descriptive statistics for one kp palier, on `rate_adjust_ppm`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PalierStats {
+    pub peak_to_peak_ppm: f64,
+    pub crossings: u32,
+    /// Crossings per second over the stable part of the palier.
+    pub crossing_rate: f64,
+    pub mean_ppm: f64,
+    pub samples: usize,
+    pub stable_duration_ms: f64,
+}
+
+/// Statistics for the settled part of a palier, or `None` when too little of
+/// it survived the warm-up to say anything.
+pub fn compute_palier_stats(
+    samples: &[Sample],
+    palier_start_ms: f64,
+    cfg: &OscillationThresholds,
+) -> Option<PalierStats> {
+    if samples.is_empty() {
+        return None;
+    }
+    let from_ms = palier_start_ms + cfg.palier_warmup_ms;
+    let mut min = f64::INFINITY;
+    let mut max = f64::NEG_INFINITY;
+    let mut sum = 0.0;
+    let mut n = 0usize;
+    let mut first_stable_t: Option<f64> = None;
+    let mut last_t = 0.0;
+
+    for s in samples {
+        if s.t < from_ms {
+            continue;
+        }
+        let Some(v) = rate_adjust_ppm(s) else {
+            continue;
+        };
+        if first_stable_t.is_none() {
+            first_stable_t = Some(s.t);
+        }
+        last_t = s.t;
+        if v < min {
+            min = v;
+        }
+        if v > max {
+            max = v;
+        }
+        sum += v;
+        n += 1;
+    }
+
+    let first_stable_t = first_stable_t?;
+    if n < 4 {
+        return None;
+    }
+    let mean = sum / n as f64;
+
+    // Second pass: count mean crossings outside the dead-band. A crossing is
+    // only counted on a sign change of the band state, so noise sitting inside
+    // the band contributes nothing.
+    let mut state = 0i8;
+    let mut crossings = 0u32;
+    for s in samples {
+        if s.t < from_ms {
+            continue;
+        }
+        let Some(v) = rate_adjust_ppm(s) else {
+            continue;
+        };
+        if v > mean + cfg.hysteresis_ppm {
+            if state == -1 {
+                crossings += 1;
+            }
+            state = 1;
+        } else if v < mean - cfg.hysteresis_ppm {
+            if state == 1 {
+                crossings += 1;
+            }
+            state = -1;
+        }
+    }
+
+    let stable_duration_ms = last_t - first_stable_t;
+    let crossing_rate = if stable_duration_ms > 0.0 {
+        (crossings as f64 / stable_duration_ms) * 1000.0
+    } else {
+        0.0
+    };
+
+    Some(PalierStats {
+        peak_to_peak_ppm: max - min,
+        crossings,
+        crossing_rate,
+        mean_ppm: mean,
+        samples: n,
+        stable_duration_ms,
+    })
+}
+
+/// Why a detector declined to fire. Kept as a string to match the frontend's
+/// vocabulary exactly — these end up in the wizard's log.
+pub type Reason = Option<&'static str>;
+
+#[derive(Debug, Clone)]
+pub struct OscillationVerdict {
+    pub oscillating: bool,
+    pub reason: Reason,
+    pub stats: Option<PalierStats>,
+}
+
+/// "Is this palier oscillating?" on absolute floors alone.
+///
+/// Used where there is no kp-sweep baseline to compare against — recovery
+/// after a perturbation, and the tightening palier.
+pub fn detect_oscillation_absolute(
+    samples: &[Sample],
+    palier_start_ms: f64,
+    cfg: &OscillationThresholds,
+) -> OscillationVerdict {
+    let Some(stats) = compute_palier_stats(samples, palier_start_ms, cfg) else {
+        return OscillationVerdict {
+            oscillating: false,
+            reason: Some("insufficient-samples"),
+            stats: None,
+        };
+    };
+    if stats.crossings < cfg.min_crossings_absolute {
+        return OscillationVerdict {
+            oscillating: false,
+            reason: Some("crossings-below-floor"),
+            stats: Some(stats),
+        };
+    }
+    if stats.peak_to_peak_ppm < cfg.min_absolute_peak_to_peak_ppm {
+        return OscillationVerdict {
+            oscillating: false,
+            reason: Some("amplitude-below-floor"),
+            stats: Some(stats),
+        };
+    }
+    OscillationVerdict {
+        oscillating: true,
+        reason: None,
+        stats: Some(stats),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct JumpVerdict {
+    pub oscillating: bool,
+    pub reason: Reason,
+    pub max_baseline_peak_to_peak_ppm: Option<f64>,
+    pub max_baseline_crossing_rate: Option<f64>,
+    /// Infinite when the baseline is flat, which is a jump by any measure.
+    pub peak_to_peak_jump: Option<f64>,
+    pub crossing_jump: Option<f64>,
+}
+
+impl JumpVerdict {
+    fn rejected(reason: &'static str) -> Self {
+        Self {
+            oscillating: false,
+            reason: Some(reason),
+            max_baseline_peak_to_peak_ppm: None,
+            max_baseline_crossing_rate: None,
+            peak_to_peak_jump: None,
+            crossing_jump: None,
+        }
+    }
+}
+
+/// Declare oscillation by comparing a palier against the previous
+/// non-saturated ones.
+///
+/// The transition from quasi-flat noise to real oscillation shows up as a
+/// sharp jump in **both** amplitude and crossing rate. Comparing ratios rather
+/// than absolute levels is what keeps the detector portable between machines
+/// whose noise floors differ.
+pub fn detect_oscillation_by_jump(
+    current: Option<&PalierStats>,
+    baselines: &[Option<PalierStats>],
+    cfg: &OscillationThresholds,
+) -> JumpVerdict {
+    let Some(current) = current else {
+        return JumpVerdict::rejected("no-current-stats");
+    };
+    if current.crossings < cfg.min_crossings_absolute {
+        return JumpVerdict::rejected("crossings-below-floor");
+    }
+    if current.peak_to_peak_ppm < cfg.min_absolute_peak_to_peak_ppm {
+        return JumpVerdict::rejected("amplitude-below-floor");
+    }
+    let present: Vec<&PalierStats> = baselines.iter().flatten().collect();
+    if present.len() < cfg.min_baseline_paliers {
+        return JumpVerdict::rejected("baseline-too-short");
+    }
+
+    let max_pp = present
+        .iter()
+        .map(|s| s.peak_to_peak_ppm)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let max_cr = present
+        .iter()
+        .map(|s| s.crossing_rate)
+        .fold(f64::NEG_INFINITY, f64::max);
+    // A flat baseline divides to infinity rather than to a finite ratio: any
+    // movement at all is an infinite jump from nothing.
+    let pp_jump = if max_pp > 0.0 {
+        current.peak_to_peak_ppm / max_pp
+    } else {
+        f64::INFINITY
+    };
+    let cr_jump = if max_cr > 0.0 {
+        current.crossing_rate / max_cr
+    } else {
+        f64::INFINITY
+    };
+    let oscillating = pp_jump >= cfg.peak_to_peak_jump_ratio && cr_jump >= cfg.crossing_jump_ratio;
+
+    JumpVerdict {
+        oscillating,
+        reason: if oscillating {
+            None
+        } else {
+            Some("jump-below-ratio")
+        },
+        max_baseline_peak_to_peak_ppm: Some(max_pp),
+        max_baseline_crossing_rate: Some(max_cr),
+        peak_to_peak_jump: Some(pp_jump),
+        crossing_jump: Some(cr_jump),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SaturationVerdict {
+    pub saturated: bool,
+    pub duration_ms: f64,
+}
+
+/// Saturation: `|rate_adjust_ppm|` has stayed at the adjustment limit for the
+/// whole trailing `hold_ms`.
+pub fn detect_saturation(
+    samples: &[Sample],
+    max_adjust_ratio: f64,
+    cfg: &SaturationThresholds,
+) -> SaturationVerdict {
+    if samples.is_empty() || max_adjust_ratio == 0.0 {
+        return SaturationVerdict {
+            saturated: false,
+            duration_ms: 0.0,
+        };
+    }
+    let limit = cfg.threshold * max_adjust_ratio.abs() * 1e6;
+    let now_ms = samples[samples.len() - 1].t;
+    let mut start_time: Option<f64> = None;
+    // Walk back from the newest sample and stop at the first that is not
+    // pinned: saturation has to be unbroken to count.
+    for s in samples.iter().rev() {
+        match rate_adjust_ppm(s) {
+            Some(v) if v.abs() >= limit => start_time = Some(s.t),
+            _ => break,
+        }
+    }
+    let Some(start_time) = start_time else {
+        return SaturationVerdict {
+            saturated: false,
+            duration_ms: 0.0,
+        };
+    };
+    let duration_ms = now_ms - start_time;
+    SaturationVerdict {
+        saturated: duration_ms >= cfg.hold_ms,
+        duration_ms,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConvergenceVerdict {
+    pub converged: bool,
+    pub duration_ms: f64,
+    pub limit_ms: Option<f64>,
+}
+
+/// Convergence: the latency error has stayed inside the tolerance for the
+/// whole trailing `hold_ms`.
+///
+/// The tolerance is a fraction of the target rather than an absolute figure,
+/// so it scales with the operating point — 0.02% is 0.04 ms at a 200 ms target
+/// and 0.10 ms at 500 ms.
+pub fn detect_convergence(samples: &[Sample], cfg: &ConvergenceThresholds) -> ConvergenceVerdict {
+    if samples.is_empty() {
+        return ConvergenceVerdict {
+            converged: false,
+            duration_ms: 0.0,
+            limit_ms: None,
+        };
+    }
+    let now_ms = samples[samples.len() - 1].t;
+    let mut start_time = now_ms;
+    let mut limit_used: Option<f64> = None;
+
+    for s in samples.iter().rev() {
+        let Some(err) = error_ms(s) else { break };
+        let limit = match s.latency_target_ms {
+            Some(target) => cfg.err_floor_ms.max(target.abs() * cfg.err_fraction),
+            None => cfg.err_floor_ms,
+        };
+        // A non-positive limit can never be met, so it ends the run rather
+        // than counting as converged-with-zero-tolerance.
+        if limit <= 0.0 || err.abs() >= limit {
+            break;
+        }
+        limit_used = Some(limit);
+        start_time = s.t;
+    }
+
+    let duration_ms = now_ms - start_time;
+    ConvergenceVerdict {
+        converged: duration_ms >= cfg.hold_ms,
+        duration_ms,
+        limit_ms: limit_used,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SourceLossVerdict {
+    pub lost: bool,
+    pub events: u32,
+}
+
+/// Source loss: repeated entries into the low-recover phase inside the
+/// trailing window.
+///
+/// Counted per *transition*, so one long low-recover stretch is one event and
+/// not one per sample.
+pub fn detect_source_loss(samples: &[Sample], cfg: &SourceLossThresholds) -> SourceLossVerdict {
+    if samples.is_empty() {
+        return SourceLossVerdict {
+            lost: false,
+            events: 0,
+        };
+    }
+    let window = slice_by_window(samples, cfg.window_ms);
+    let mut events = 0u32;
+    let mut in_low_recover = false;
+    for s in window {
+        let lr = s.phase.as_deref() == Some("low-recover");
+        if lr && !in_low_recover {
+            events += 1;
+        }
+        in_low_recover = lr;
+    }
+    SourceLossVerdict {
+        lost: events >= cfg.min_low_recover_events,
+        events,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RateStats {
+    pub peak_abs_ppm: f64,
+    pub mean_ppm: f64,
+    pub std_ppm: f64,
+    pub samples: usize,
+}
+
+/// Long-run statistics on `rate_adjust_ppm`, used to size `max_adjust_final`.
+///
+/// `window_ms` of `None` uses the whole series.
+pub fn compute_rate_stats(samples: &[Sample], window_ms: Option<f64>) -> RateStats {
+    let window = match window_ms {
+        Some(ms) => slice_by_window(samples, ms),
+        None => samples,
+    };
+    let mut peak_abs = 0.0f64;
+    let mut sum = 0.0;
+    let mut sum_sq = 0.0;
+    let mut n = 0usize;
+    for s in window {
+        let Some(v) = rate_adjust_ppm(s) else {
+            continue;
+        };
+        if v.abs() > peak_abs {
+            peak_abs = v.abs();
+        }
+        sum += v;
+        sum_sq += v * v;
+        n += 1;
+    }
+    if n == 0 {
+        return RateStats {
+            peak_abs_ppm: 0.0,
+            mean_ppm: 0.0,
+            std_ppm: 0.0,
+            samples: 0,
+        };
+    }
+    let mean = sum / n as f64;
+    // Clamped at zero: the sum-of-squares form can go slightly negative on
+    // near-constant input, and a negative variance has no square root.
+    let variance = (sum_sq / n as f64 - mean * mean).max(0.0);
+    RateStats {
+        peak_abs_ppm: peak_abs,
+        mean_ppm: mean,
+        std_ppm: variance.sqrt(),
+        samples: n,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Load the verdicts recorded from the frontend.
+    fn goldens() -> Value {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../scripts/golden/auto-tune.json"
+        );
+        let text = std::fs::read_to_string(path).expect(
+            "auto-tune goldens missing — regenerate with \
+             `node scripts/dump-auto-tune-goldens.mjs > scripts/golden/auto-tune.json`",
+        );
+        serde_json::from_str(&text).expect("goldens must be valid JSON")
+    }
+
+    fn samples_from(value: &Value) -> Vec<Sample> {
+        value
+            .as_array()
+            .expect("a window is an array")
+            .iter()
+            .map(|s| Sample {
+                t: s["t"].as_f64().unwrap(),
+                latency_smoothed_ms: s["latencySmoothedMs"].as_f64(),
+                latency_target_ms: s["latencyTargetMs"].as_f64(),
+                resample_ratio: s["resampleRatio"].as_f64(),
+                phase: s["phase"].as_str().map(str::to_string),
+            })
+            .collect()
+    }
+
+    fn close(actual: f64, expected: f64, what: &str) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "{what}: expected {expected}, got {actual}"
+        );
+    }
+
+    /// `JSON.stringify` writes a non-finite number as `null`, which is how a
+    /// flat baseline's infinite jump ratio arrives.
+    fn close_or_infinite(actual: Option<f64>, expected: &Value, what: &str) {
+        match (actual, expected.as_f64()) {
+            (Some(a), Some(e)) => close(a, e, what),
+            (Some(a), None) => assert!(a.is_infinite(), "{what}: expected infinity, got {a}"),
+            (None, _) => assert!(expected.is_null(), "{what}: expected a value, got none"),
+        }
+    }
+
+    /// Replay every recorded verdict.
+    ///
+    /// Verified to bite: changing the hysteresis band, the crossings floor, or
+    /// a hold comparison from `>=` to `>` each fails this test.
+    ///
+    /// One edge is deliberately *not* covered: `>=` versus `>` on the
+    /// convergence error test. Distinguishing them needs `|err|` to equal the
+    /// tolerance to the last bit, which no realistic sample does — the fixture
+    /// would be pinning a float coincidence rather than a behaviour.
+    #[test]
+    fn golden_vectors_match_the_frontend() {
+        let g = goldens();
+        let osc = OscillationThresholds::default();
+        let sat = SaturationThresholds::default();
+        let conv = ConvergenceThresholds::default();
+        let loss = SourceLossThresholds::default();
+
+        let windows: Vec<(String, Vec<Sample>)> = g["windows"]
+            .as_object()
+            .unwrap()
+            .iter()
+            .map(|(name, v)| (name.clone(), samples_from(v)))
+            .collect();
+        assert!(windows.len() >= 10, "goldens look truncated");
+
+        for (name, samples) in &windows {
+            // ── palier stats ────────────────────────────────────────────────
+            let stats = compute_palier_stats(samples, 0.0, &osc);
+            let expected = &g["palierStats"][name];
+            if expected.is_null() {
+                assert!(stats.is_none(), "{name}: expected no palier stats");
+            } else {
+                let s = stats.expect(&format!("{name}: expected palier stats"));
+                close(
+                    s.peak_to_peak_ppm,
+                    expected["peakToPeakPpm"].as_f64().unwrap(),
+                    &format!("{name}.peakToPeak"),
+                );
+                assert_eq!(
+                    s.crossings as u64,
+                    expected["crossings"].as_u64().unwrap(),
+                    "{name}.crossings"
+                );
+                close(
+                    s.crossing_rate,
+                    expected["crossingRate"].as_f64().unwrap(),
+                    &format!("{name}.crossingRate"),
+                );
+                close(
+                    s.mean_ppm,
+                    expected["meanPpm"].as_f64().unwrap(),
+                    &format!("{name}.meanPpm"),
+                );
+                assert_eq!(
+                    s.samples as u64,
+                    expected["samples"].as_u64().unwrap(),
+                    "{name}.samples"
+                );
+            }
+
+            // ── oscillation, absolute ───────────────────────────────────────
+            let verdict = detect_oscillation_absolute(samples, 0.0, &osc);
+            let expected = &g["oscillationAbsolute"][name];
+            assert_eq!(
+                verdict.oscillating,
+                expected["oscillating"].as_bool().unwrap(),
+                "{name}.oscillating"
+            );
+            assert_eq!(verdict.reason, expected["reason"].as_str(), "{name}.reason");
+
+            // ── saturation ──────────────────────────────────────────────────
+            let verdict = detect_saturation(samples, 0.01, &sat);
+            let expected = &g["saturation"][name];
+            assert_eq!(
+                verdict.saturated,
+                expected["saturated"].as_bool().unwrap(),
+                "{name}.saturated"
+            );
+            close(
+                verdict.duration_ms,
+                expected["durationMs"].as_f64().unwrap(),
+                &format!("{name}.satDuration"),
+            );
+
+            // ── convergence ─────────────────────────────────────────────────
+            let verdict = detect_convergence(samples, &conv);
+            let expected = &g["convergence"][name];
+            assert_eq!(
+                verdict.converged,
+                expected["converged"].as_bool().unwrap(),
+                "{name}.converged"
+            );
+            close(
+                verdict.duration_ms,
+                expected["durationMs"].as_f64().unwrap(),
+                &format!("{name}.convDuration"),
+            );
+
+            // ── source loss ─────────────────────────────────────────────────
+            let verdict = detect_source_loss(samples, &loss);
+            let expected = &g["sourceLoss"][name];
+            assert_eq!(
+                verdict.lost,
+                expected["lost"].as_bool().unwrap(),
+                "{name}.lost"
+            );
+            assert_eq!(
+                verdict.events as u64,
+                expected["events"].as_u64().unwrap(),
+                "{name}.events"
+            );
+
+            // ── rate stats, whole series and windowed ───────────────────────
+            for (key, window) in [("rateStatsAll", None), ("rateStatsWindowed", Some(5000.0))] {
+                let stats = compute_rate_stats(samples, window);
+                let expected = &g[key][name];
+                close(
+                    stats.peak_abs_ppm,
+                    expected["peakAbsPpm"].as_f64().unwrap(),
+                    &format!("{name}.{key}.peak"),
+                );
+                close(
+                    stats.mean_ppm,
+                    expected["meanPpm"].as_f64().unwrap(),
+                    &format!("{name}.{key}.mean"),
+                );
+                close(
+                    stats.std_ppm,
+                    expected["stdPpm"].as_f64().unwrap(),
+                    &format!("{name}.{key}.std"),
+                );
+                assert_eq!(
+                    stats.samples as u64,
+                    expected["samples"].as_u64().unwrap(),
+                    "{name}.{key}.samples"
+                );
+            }
+        }
+
+        // Saturation with no configured limit never fires.
+        let saturated = samples_from(&g["windows"]["saturated"]);
+        let verdict = detect_saturation(&saturated, 0.0, &sat);
+        assert_eq!(
+            verdict.saturated,
+            g["saturationNoLimit"]["saturated"].as_bool().unwrap()
+        );
+    }
+
+    #[test]
+    fn oscillation_by_jump_matches_the_frontend() {
+        let g = goldens();
+        let osc = OscillationThresholds::default();
+        let stats_for = |name: &str| -> Option<PalierStats> {
+            let samples = samples_from(&g["windows"][name]);
+            compute_palier_stats(&samples, 0.0, &osc)
+        };
+        let oscillating = stats_for("oscillating");
+        let flat = stats_for("flat");
+        assert!(
+            oscillating.is_some() && flat.is_some(),
+            "fixtures must produce stats"
+        );
+
+        let cases: Vec<(&str, Option<PalierStats>, Vec<Option<PalierStats>>)> = vec![
+            ("jumpOverFlat", oscillating, vec![flat]),
+            ("noJump", oscillating, vec![oscillating]),
+            ("noBaseline", oscillating, vec![]),
+            ("nullBaseline", oscillating, vec![None, None]),
+            ("quietCurrent", flat, vec![flat]),
+            ("noCurrent", None, vec![flat]),
+        ];
+
+        for (name, current, baselines) in cases {
+            let verdict = detect_oscillation_by_jump(current.as_ref(), &baselines, &osc);
+            let expected = &g["oscillationByJump"][name];
+            assert_eq!(
+                verdict.oscillating,
+                expected["oscillating"].as_bool().unwrap(),
+                "{name}.oscillating"
+            );
+            assert_eq!(verdict.reason, expected["reason"].as_str(), "{name}.reason");
+            if expected.get("peakToPeakJump").is_some() {
+                close_or_infinite(
+                    verdict.peak_to_peak_jump,
+                    &expected["peakToPeakJump"],
+                    &format!("{name}.ppJump"),
+                );
+                close_or_infinite(
+                    verdict.crossing_jump,
+                    &expected["crossingJump"],
+                    &format!("{name}.crJump"),
+                );
+            }
+        }
+    }
+}

--- a/omniphony-studio/src-tauri/src/auto_tune/mod.rs
+++ b/omniphony-studio/src-tauri/src/auto_tune/mod.rs
@@ -1,0 +1,9 @@
+//! PI auto-tune.
+//!
+//! The detectors are ported and pinned against the frontend; the state machine
+//! that consumes them is the next step. Until it lands nothing outside the
+//! tests calls into here, which is deliberate — the port is landing with its
+//! safety net first, before anything is deleted or wired to a live audio path.
+#![allow(dead_code)]
+
+pub mod detectors;

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app_state;
+mod auto_tune;
 mod commands;
 mod config;
 mod engine_deploy;


### PR DESCRIPTION
First step of Phase 3.7 — and deliberately the safe one.

Phase 3.7 is the riskiest item in the plan: ~920 lines that change kp/ki on a **running audio path**. The plan itself says to write the Rust tests from recorded JS behaviour *before* deleting anything. This PR is that safety net, plus the nine pure detector functions it protects. **Nothing is deleted, nothing is wired up.** The state machine (482 lines) and the runner are separate steps.

## Direction matters

Here the **JS is the reference**. It is the implementation that has been driving real tuning runs, so the port is correct exactly insofar as it agrees with it.

That is the opposite of the geometry crate (#295), where Rust is canonical and the JS mirror is checked against it. Worth being explicit, because the two golden-vector setups now in the tree run in opposite directions.

`scripts/dump-auto-tune-goldens.mjs` records what the JS decides over 24 telemetry windows; `golden_vectors_match_the_frontend` replays every one.

## The first fixtures did not bite

They passed immediately, which was the warning sign, so I checked whether they *could* fail. Perturbing the hysteresis band and the crossings floor **both still passed** — every window sat comfortably far from every threshold. The vectors confirmed the port on easy cases and would have missed a discrepancy at an edge, which is exactly where a port goes wrong.

Added thirteen fixtures sitting **on** the boundaries, one just inside and one just outside each:

| Boundary | Inside / outside |
|---|---|
| Crossings floor | 4 vs 3 |
| Amplitude floor | 1500 vs 1499 ppm peak-to-peak |
| Hysteresis dead-band | ±201 vs ±199 |
| Saturation hold | exactly 3000 ms vs one sample short |
| Convergence hold | exactly 10000 ms |
| Source-loss floor | 2 events vs 1 |

The hysteresis pair needed an **even** number of half-periods so the mean is exactly zero — with an odd count the mean shifts by one block and the dead-band moves off the values being tested, which is how my first attempt at that fixture silently tested nothing.

**Now verified to bite:** changing the hysteresis band, the crossings floor, or a hold comparison from `>=` to `>` each fails the test.

One edge stays uncovered on purpose: `>=` versus `>` on the convergence *error* test needs `|err|` to equal the tolerance to the last bit, which no realistic sample does. A fixture for it would pin a float coincidence, not a behaviour. It is noted in the test.

## Fixture size

The first generated file was 1.6 MB — too much repo for a test fixture. Dropping the pretty-printing barely helped (the float literals are the bulk), so the sampling step went from 50 ms to 250 ms: the detectors reason about time *spans*, not sample density, beyond their `n >= 4` floor. Same windows, same boundaries, 484 KB. All three perturbation checks re-verified after the change.

## Verification

- **59 src-tauri tests pass** (src-tauri is not in CI — run locally).
- Zero build warnings. The module is `allow(dead_code)` with a comment saying why: nothing consumes it until the FSM lands.
- `cargo fmt --check` divergence unchanged from baseline. Worth noting `cargo fmt -p omniphony-studio` reformats the pre-existing divergence in `osc_parser.rs`/`osc_listener.rs` — I ran into that and reverted; format only the files you touch here.

## What is left of 3.7

The state machine and runner, which is where the real risk sits — that code sends the control changes. The plan's guidance for it still stands: keep the JS in-tree behind a flag for one release, and validate a full tuning run reaches equivalent kp/ki on the same setup. That last part is yours; it needs a live renderer and a listen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)