### PR TITLE
Derive crossover band edges in the backend

### DIFF
--- a/omniphony-studio/src-tauri/src/layouts.rs
+++ b/omniphony-studio/src-tauri/src/layouts.rs
@@ -43,7 +43,7 @@ fn default_coord_mode() -> String {
     "polar".to_string()
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Layout {
     pub key: String,
     pub name: String,
@@ -53,6 +53,27 @@ pub struct Layout {
     /// Defaults to 1.0 when absent from the layout file.
     #[serde(default = "default_radius_m")]
     pub radius_m: f64,
+}
+
+// `crossoverCutoffs` is derived, not stored, so it cannot go stale. Every path
+// that ships a layout — the state bundle, a layout change, a speaker's
+// frequency being edited — serializes through here and gets the current
+// answer. Storing it as a field would mean remembering to refresh it at each
+// of those, and forgetting one is invisible until a band edge is wrong.
+impl Serialize for Layout {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Layout", 5)?;
+        state.serialize_field("key", &self.key)?;
+        state.serialize_field("name", &self.name)?;
+        state.serialize_field("speakers", &self.speakers)?;
+        state.serialize_field("radius_m", &self.radius_m)?;
+        state.serialize_field("crossoverCutoffs", &crossover_cutoffs(&self.speakers))?;
+        state.end()
+    }
 }
 
 #[derive(Serialize)]
@@ -531,6 +552,31 @@ pub fn load_layout_file(path: &Path) -> Option<Layout> {
     })
 }
 
+/// Interior crossover band edges for a speaker set, in Hz: every distinct
+/// cutoff a spatialized speaker declares, sorted.
+///
+/// The bands themselves are `[0, ...cutoffs, +inf]`. Only the interior edges
+/// are published because JSON has no infinity — the frontend caps the ends.
+///
+/// Non-spatialized speakers are skipped: an LFE's low-pass is not a band
+/// boundary for the objects being panned, and counting it would split the
+/// heatmap on an edge nothing is rendered across.
+pub fn crossover_cutoffs(speakers: &[Speaker]) -> Vec<f64> {
+    let mut cutoffs: Vec<f64> = speakers
+        .iter()
+        .filter(|speaker| speaker.spatialize != 0)
+        .flat_map(|speaker| [speaker.freq_low, speaker.freq_high])
+        .flatten()
+        .map(f64::from)
+        .filter(|value| *value > 0.0)
+        .collect();
+    cutoffs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    // Two speakers meeting at "the same" cutoff rarely agree to the last
+    // decimal; anything closer than 0.1 Hz is one edge, not two.
+    cutoffs.dedup_by(|a, b| (*a - *b).abs() < 0.1);
+    cutoffs
+}
+
 /// Default export file name for a speaker set, as `spatialized.non.height`.
 ///
 /// The Studio's naming convention: how many spatialized speakers sit at or
@@ -705,8 +751,9 @@ pub fn save_layout_file(path: &Path, layout: &Layout) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        default_export_name, load_layout_file, normalize_for_export, normalize_speaker,
-        parse_yaml_layout, sanitize_export_name, save_layout_file, Layout, RawSpeaker, Speaker,
+        crossover_cutoffs, default_export_name, load_layout_file, normalize_for_export,
+        normalize_speaker, parse_yaml_layout, sanitize_export_name, save_layout_file, Layout,
+        RawSpeaker, Speaker,
     };
 
     /// A cartesian speaker must derive its angles in the ADM frame the layout
@@ -734,6 +781,97 @@ mod tests {
             freq_low: None,
             freq_high: None,
         }
+    }
+
+    // ── crossover bands ─────────────────────────────────────────────────────
+
+    fn banded(id: &str, low: Option<f32>, high: Option<f32>, spatialize: u8) -> Speaker {
+        let mut speaker = spk(id, 0.0, 1.0, 0.0, spatialize);
+        speaker.freq_low = low;
+        speaker.freq_high = high;
+        speaker
+    }
+
+    #[test]
+    fn a_layout_with_no_crossover_has_no_edges() {
+        let speakers = vec![spk("L", -1.0, 1.0, 0.0, 1), spk("R", 1.0, 1.0, 0.0, 1)];
+        assert!(crossover_cutoffs(&speakers).is_empty());
+    }
+
+    #[test]
+    fn edges_are_sorted_and_deduplicated() {
+        let speakers = vec![
+            banded("sub", None, Some(120.0), 1),
+            banded("mid", Some(120.0), Some(4000.0), 1),
+            banded("hi", Some(4000.0), None, 1),
+        ];
+        assert_eq!(crossover_cutoffs(&speakers), vec![120.0, 4000.0]);
+    }
+
+    /// Two speakers meeting at "the same" cutoff rarely agree to the last
+    /// decimal. Within 0.1 Hz is one edge; beyond it is two.
+    #[test]
+    fn near_identical_cutoffs_collapse_to_one_edge() {
+        let speakers = vec![
+            banded("a", None, Some(120.0), 1),
+            banded("b", Some(120.05), None, 1),
+        ];
+        assert_eq!(crossover_cutoffs(&speakers), vec![120.0]);
+
+        let speakers = vec![
+            banded("a", None, Some(120.0), 1),
+            banded("b", Some(120.5), None, 1),
+        ];
+        assert_eq!(crossover_cutoffs(&speakers).len(), 2);
+    }
+
+    /// An LFE's low-pass is not a band boundary for the objects being panned.
+    #[test]
+    fn a_non_spatialized_speaker_contributes_no_edge() {
+        let speakers = vec![
+            banded("LFE", None, Some(120.0), 0),
+            spk("L", -1.0, 1.0, 0.0, 1),
+        ];
+        assert!(crossover_cutoffs(&speakers).is_empty());
+    }
+
+    #[test]
+    fn non_positive_cutoffs_are_ignored() {
+        let speakers = vec![
+            banded("a", Some(0.0), Some(-5.0), 1),
+            banded("b", Some(80.0), None, 1),
+        ];
+        assert_eq!(crossover_cutoffs(&speakers), vec![80.0]);
+    }
+
+    /// A mixed layout: some speakers banded, some full-range. The full-range
+    /// ones must not add edges, but must not suppress the others' either.
+    #[test]
+    fn a_mixed_layout_keeps_only_the_declared_edges() {
+        let speakers = vec![
+            spk("L", -1.0, 1.0, 0.0, 1),
+            banded("sub", None, Some(80.0), 1),
+            spk("R", 1.0, 1.0, 0.0, 1),
+        ];
+        assert_eq!(crossover_cutoffs(&speakers), vec![80.0]);
+    }
+
+    /// The cutoffs are derived at serialization, so a layout whose speakers
+    /// changed since it was loaded still ships the right edges.
+    #[test]
+    fn serialization_reflects_an_edited_speaker() {
+        let mut layout = Layout {
+            key: "k".to_string(),
+            name: "k".to_string(),
+            radius_m: 1.0,
+            speakers: vec![banded("a", None, Some(80.0), 1)],
+        };
+        let before = serde_json::to_value(&layout).unwrap();
+        assert_eq!(before["crossoverCutoffs"], serde_json::json!([80.0]));
+
+        layout.speakers[0].freq_high = Some(200.0);
+        let after = serde_json::to_value(&layout).unwrap();
+        assert_eq!(after["crossoverCutoffs"], serde_json::json!([200.0]));
     }
 
     // ── export name ─────────────────────────────────────────────────────────

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -1907,6 +1907,19 @@ fn emit_timing_stats(app: &AppHandle, last_hash: &mut Option<u64>) {
     let _ = app.emit("latency:stats", payload);
 }
 
+/// Interior crossover edges of the live layout, for the events that change one.
+///
+/// The frontend edits its own copy of a speaker when one of these arrives, so
+/// it cannot re-derive the band edges from a layout it has not been re-sent.
+/// Shipping them alongside keeps the two in step without a full layout push.
+fn live_crossover_cutoffs(s: &AppState) -> Vec<f64> {
+    s.selected_layout_key
+        .as_ref()
+        .and_then(|key| s.layouts.iter().find(|l| &l.key == key))
+        .map(|layout| crate::layouts::crossover_cutoffs(&layout.speakers))
+        .unwrap_or_default()
+}
+
 fn is_batched_event(event: &str) -> bool {
     BATCHED_EVENTS.contains(&event)
 }
@@ -2454,10 +2467,17 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                         }
                     }
                 }
+                // Spatialize gates whether a speaker's cutoffs count as band
+                // edges at all, so toggling it moves them.
+                let crossover_cutoffs = live_crossover_cutoffs(&s);
                 (
                     Some((
                         "speaker:spatialize",
-                        serde_json::json!({ "id": id, "spatialize": if spatialize { 1 } else { 0 } }),
+                        serde_json::json!({
+                            "id": id,
+                            "spatialize": if spatialize { 1 } else { 0 },
+                            "crossoverCutoffs": crossover_cutoffs,
+                        }),
                     )),
                     removed_ids,
                 )
@@ -2491,10 +2511,15 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                         }
                     }
                 }
+                let crossover_cutoffs = live_crossover_cutoffs(&s);
                 (
                     Some((
                         "speaker:freq_low",
-                        serde_json::json!({ "id": id, "freq_low": freq_low }),
+                        serde_json::json!({
+                            "id": id,
+                            "freq_low": freq_low,
+                            "crossoverCutoffs": crossover_cutoffs,
+                        }),
                     )),
                     removed_ids,
                 )
@@ -2510,10 +2535,15 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                         }
                     }
                 }
+                let crossover_cutoffs = live_crossover_cutoffs(&s);
                 (
                     Some((
                         "speaker:freq_high",
-                        serde_json::json!({ "id": id, "freq_high": freq_high }),
+                        serde_json::json!({
+                            "id": id,
+                            "freq_high": freq_high,
+                            "crossoverCutoffs": crossover_cutoffs,
+                        }),
                     )),
                     removed_ids,
                 )

--- a/omniphony-studio/src/crossover-bands.js
+++ b/omniphony-studio/src/crossover-bands.js
@@ -1,32 +1,24 @@
 import { t } from './i18n.js';
 
-function collectCutoffs(speakers) {
-  if (!Array.isArray(speakers) || speakers.length === 0) {
-    return [];
-  }
-  const cutoffs = [];
-  speakers.forEach((speaker) => {
-    if (Number(speaker?.spatialize) === 0) {
-      return;
-    }
-    [speaker?.freqLow, speaker?.freqHigh].forEach((value) => {
-      const numeric = Number(value);
-      if (Number.isFinite(numeric) && numeric > 0) {
-        cutoffs.push(numeric);
-      }
-    });
-  });
-  cutoffs.sort((a, b) => a - b);
-  return cutoffs.filter((value, index) => index === 0 || Math.abs(value - cutoffs[index - 1]) >= 0.1);
-}
+// Band edges are derived by the backend (`layouts::crossover_cutoffs`) and
+// arrive with every layout as `crossoverCutoffs`, plus on the events that move
+// them (a speaker's frequency limits, or its spatialize flag — a
+// non-spatialized speaker's cutoffs are not band boundaries for the objects
+// being panned). This module keeps only the label *formatting*, which is an
+// i18n concern.
 
 function formatHz(value) {
   return value >= 1000 ? `${(value / 1000).toFixed(value % 1000 === 0 ? 0 : 1)}k` : `${value}`;
 }
 
-export function computeCrossoverBandEdges(speakers) {
-  const cutoffs = collectCutoffs(speakers);
-  if (cutoffs.length === 0) {
+/**
+ * Band edges from the backend's interior cutoffs: `[0, ...cutoffs, Infinity]`.
+ *
+ * Only the interior edges cross the wire — JSON has no infinity — so the open
+ * ends are capped here.
+ */
+export function crossoverBandEdges(cutoffs) {
+  if (!Array.isArray(cutoffs) || cutoffs.length === 0) {
     return [0, Infinity];
   }
   return [0, ...cutoffs, Infinity];
@@ -36,11 +28,11 @@ export function computeCrossoverBandEdges(speakers) {
 // translation, except the single-band case whose label is prose. It defaults to
 // the localized "Full band" and is re-resolved on every call, so callers that
 // rebuild on locale change pick the new wording up for free.
-export function computeCrossoverBandLabels(
-  speakers,
+export function crossoverBandLabels(
+  cutoffs,
   { includeSingleBand = false, singleBandLabel = null, useUnicodeGte = false, useUnicodeDash = false } = {},
 ) {
-  const edges = computeCrossoverBandEdges(speakers);
+  const edges = crossoverBandEdges(cutoffs);
   if (edges.length <= 2 && !includeSingleBand) {
     return null;
   }

--- a/omniphony-studio/src/scene/speaker-band-bars.js
+++ b/omniphony-studio/src/scene/speaker-band-bars.js
@@ -158,7 +158,7 @@ export function createSpeakerBandBar() {
 
 // Redraw the gauge only when its appearance would actually change. The fill
 // colour depends on the layout's whole crossover split, so `edges` (from
-// computeCrossoverBandEdges) is part of the cache key — recolouring all gauges
+// crossoverBandEdges) is part of the cache key — recolouring all gauges
 // when any speaker's cutoffs change the band set.
 export function updateSpeakerBandBar(sprite, speaker, edges) {
   if (!sprite?.userData?.bandCtx) return;

--- a/omniphony-studio/src/scene/speaker-band-select.js
+++ b/omniphony-studio/src/scene/speaker-band-select.js
@@ -17,7 +17,7 @@
 
 import { app } from '../state.js';
 import { t, onLocaleChange } from '../i18n.js';
-import { computeCrossoverBandLabels } from '../crossover-bands.js';
+import { crossoverBandLabels } from '../crossover-bands.js';
 import { renderBandCursor } from '../controls/band-cursor.js';
 
 /**
@@ -29,7 +29,7 @@ import { renderBandCursor } from '../controls/band-cursor.js';
  */
 export function syncCrossoverBandSelects() {
   const selectEl = document.getElementById('heatmapBandSelect');
-  const labels = computeCrossoverBandLabels(app.currentLayoutSpeakers, {
+  const labels = crossoverBandLabels(app.currentLayoutCutoffs, {
     includeSingleBand: true,
   }) || [t('heatmap.bandFull')];
   const maxIndex = Math.max(0, labels.length - 1);

--- a/omniphony-studio/src/sources.js
+++ b/omniphony-studio/src/sources.js
@@ -83,7 +83,7 @@ import {
 } from './mute-solo.js';
 import { formatNumber } from './coordinates.js';
 import { t, tf } from './i18n.js';
-import { computeCrossoverBandLabels } from './crossover-bands.js';
+import { crossoverBandLabels } from './crossover-bands.js';
 
 // ---------------------------------------------------------------------------
 // Callbacks that other modules populate to avoid circular imports.
@@ -668,7 +668,7 @@ export function getSelectedSpeakerContributionForObject(id) {
 }
 
 function getCrossoverBandLabels() {
-  return computeCrossoverBandLabels(app.currentLayoutSpeakers);
+  return crossoverBandLabels(app.currentLayoutCutoffs);
 }
 
 function getSelectedSpeakerBandContributionsForObject(id) {

--- a/omniphony-studio/src/speakers.js
+++ b/omniphony-studio/src/speakers.js
@@ -123,7 +123,7 @@ import { t, tf } from './i18n.js';
 import { pushLog } from './log.js';
 import { scheduleUIFlush } from './flush.js';
 import { updateItemClasses, updateSpeakerMeterUI, updateObjectMeterUI } from './flush.js';
-import { computeCrossoverBandLabels, computeCrossoverBandEdges } from './crossover-bands.js';
+import { crossoverBandLabels, crossoverBandEdges } from './crossover-bands.js';
 import { onSpeakerSelectionChanged } from './controls/speaker-test.js';
 
 import {
@@ -274,6 +274,10 @@ function get_currentLayoutKey() { return app.currentLayoutKey; }
 function set_currentLayoutKey(v) { app.currentLayoutKey = v; }
 function get_currentLayoutSpeakers() { return app.currentLayoutSpeakers; }
 function set_currentLayoutSpeakers(v) { app.currentLayoutSpeakers = v; }
+/** Band edges come from the layout the speakers belong to, not from the speakers. */
+function set_currentLayoutCutoffs(layout) {
+  app.currentLayoutCutoffs = Array.isArray(layout?.crossoverCutoffs) ? layout.crossoverCutoffs : [];
+}
 
 function syncInputValueUnlessEditing(inputEl, nextValue) {
   if (!inputEl) return;
@@ -908,7 +912,7 @@ export function updateSpeakerItem(entry, id, speaker) {
 }
 
 function getCrossoverBandLabels() {
-  return computeCrossoverBandLabels(app.currentLayoutSpeakers, {
+  return crossoverBandLabels(app.currentLayoutCutoffs, {
     useUnicodeGte: true,
     useUnicodeDash: true,
   });
@@ -1075,7 +1079,7 @@ export function updateSpeakerVisualsFromState(index) {
   if (bandBar) {
     bandBar.visible = app.speakerBandBarsEnabled;
     bandBar.position.set(scenePosition.x + SPEAKER_BAND_BAR_OFFSET, scenePosition.y, scenePosition.z);
-    updateSpeakerBandBar(bandBar, speaker, computeCrossoverBandEdges(currentLayoutSpeakers));
+    updateSpeakerBandBar(bandBar, speaker, crossoverBandEdges(app.currentLayoutCutoffs));
   }
 
   const entry = speakerItems.get(String(index));
@@ -1560,7 +1564,7 @@ export function renderSpeakersList() {
 
   speakersListEl.textContent = '';
   const activeIds = new Set();
-  const bandEdges = computeCrossoverBandEdges(currentLayoutSpeakers);
+  const bandEdges = crossoverBandEdges(app.currentLayoutCutoffs);
   currentLayoutSpeakers.forEach((speaker, index) => {
     const id = String(index);
     activeIds.add(id);
@@ -2238,6 +2242,7 @@ export function renderLayout(key) {
   if (!layout) {
     set_currentLayoutKey(null);
     set_currentLayoutSpeakers([]);
+    app.currentLayoutCutoffs = [];
     renderSpeakersList();
     set_selectedSpeakerIndex(null);
     app.polarEditArmed = false;
@@ -2251,6 +2256,7 @@ export function renderLayout(key) {
   set_currentLayoutKey(key);
   const newSpeakers = Array.isArray(layout.speakers) ? layout.speakers : [];
   set_currentLayoutSpeakers(newSpeakers);
+  set_currentLayoutCutoffs(layout);
   syncCrossoverBandSelects();
   sceneState.metersPerUnit = Math.max(0.01, Number(layout.radius_m) || 1.0);
   speakerDelays.clear();
@@ -2320,7 +2326,7 @@ export function renderLayout(key) {
     }
   });
 
-  const bandEdges = computeCrossoverBandEdges(layout.speakers);
+  const bandEdges = crossoverBandEdges(layout.crossoverCutoffs);
   layout.speakers.forEach((speaker, index) => {
     const mesh = new THREE.Mesh(speakerGeometry.clone(), speakerMaterial.clone());
     const scenePosition = normalizedOmniphonyToScenePosition(speaker);
@@ -2485,6 +2491,7 @@ function patchCurrentLayout(key) {
   const nextSpeakers = Array.isArray(layout.speakers) ? layout.speakers : [];
   set_currentLayoutKey(key);
   set_currentLayoutSpeakers(nextSpeakers);
+  set_currentLayoutCutoffs(layout);
   syncCrossoverBandSelects();
   sceneState.metersPerUnit = Math.max(0.01, Number(layout.radius_m) || 1.0);
   speakerDelays.clear();
@@ -2539,6 +2546,7 @@ export function hydrateLayoutSelect(layouts, selectedLayoutKey) {
   } else {
     set_currentLayoutKey(null);
     set_currentLayoutSpeakers([]);
+    app.currentLayoutCutoffs = [];
     renderSpeakersList();
     renderSpeakerEditor();
   }

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -563,6 +563,10 @@ export const app = {
   // Layout
   currentLayoutKey: null,
   currentLayoutSpeakers: [],
+  // Interior crossover edges for the live layout, from the backend. Set
+  // alongside currentLayoutSpeakers, and refreshed by the events that move
+  // them (speaker freq limits, spatialize).
+  currentLayoutCutoffs: [],
 
   // UI flush
   uiFlushScheduled: false,

--- a/omniphony-studio/src/tauri-bridge.js
+++ b/omniphony-studio/src/tauri-bridge.js
@@ -329,6 +329,11 @@ export function setupTauriBridge() {
     }
     const next = Number(payload.spatialize) === 0 ? 0 : 1;
     setSpeakerSpatializeLocal(index, next);
+    // Spatialize gates whether this speaker's cutoffs are band edges at all.
+    if (Array.isArray(payload.crossoverCutoffs)) {
+      app.currentLayoutCutoffs = payload.crossoverCutoffs;
+      syncCrossoverBandSelects();
+    }
     updateSpeakerControlsUI();
   });
 
@@ -353,6 +358,9 @@ export function setupTauriBridge() {
     if (!speaker) return;
     const fl = payload.freq_low;
     speaker.freqLow = fl != null && fl > 0 ? fl : null;
+    if (Array.isArray(payload.crossoverCutoffs)) {
+      app.currentLayoutCutoffs = payload.crossoverCutoffs;
+    }
     syncCrossoverBandSelects();
     if (app.selectedSpeakerIndex === index) renderSpeakerEditor();
   });
@@ -364,6 +372,9 @@ export function setupTauriBridge() {
     if (!speaker) return;
     const fh = payload.freq_high;
     speaker.freqHigh = fh != null && fh > 0 ? fh : null;
+    if (Array.isArray(payload.crossoverCutoffs)) {
+      app.currentLayoutCutoffs = payload.crossoverCutoffs;
+    }
     syncCrossoverBandSelects();
     if (app.selectedSpeakerIndex === index) renderSpeakerEditor();
   });


### PR DESCRIPTION
Phase 3.3 of the Studio Rust/Web rebalancing plan — the one I deferred earlier for a design question. Targets `main` directly.

## What moved

`crossover-bands.js` walked the speakers to collect their frequency limits, sorted them, deduplicated with a 0.1 Hz hysteresis and skipped the non-spatialized ones. That is a domain rule about **what counts as a band boundary**, living in the frontend and consumed by the heatmap, the band bars and the band selectors.

It moves to `layouts::crossover_cutoffs`. The JS keeps only label formatting, which is genuinely an i18n concern.

## The design question that made me defer it

The obvious shape — publish the edges for the live layout — is **wrong**, and quietly so.

`renderLayout()` draws whichever layout is *selected*, which is not always the one the renderer has adopted: the layout menu ([tauri-bridge.js](omniphony-studio/src/tauri-bridge.js) on `layout:selected`) and startup when the current layout cannot be patched both render a non-live layout. Its band bars would have been drawn with **another layout's** edges — a visual error I could not have caught by reading, and one no test would have flagged.

The backend already loads every layout and ships them all in the bundle, so each carries its own cutoffs. That closes it properly rather than by picking the common case.

## Derived at serialization, not stored

`Layout` gets a hand-written `Serialize` that computes `crossoverCutoffs` on the fly instead of carrying a field.

Stored, it would need refreshing at every path that can change a speaker's frequency limits or its spatialize flag — load, layout change, three separate OSC handlers. Forgetting one is invisible until a band edge is wrong. Computed, no call site can leave it stale. That is the same failure class as the three wrong-frame copies in #293, avoided by construction this time.

Only the interior edges cross the wire — the bands are `[0, ...cutoffs, +inf]` and JSON has no infinity, so the frontend caps the ends.

## The live-edit path

Three events move the edges without re-sending a layout: `speaker:freq_low`, `speaker:freq_high` and `speaker:spatialize`. They now carry the recomputed cutoffs, because the frontend edits its own copy of the speaker when one arrives and cannot re-derive from a layout it has not been re-sent.

`spatialize` is in that list deliberately — it gates whether a speaker's cutoffs are band boundaries at all, so toggling it moves them. Easy one to miss.

## Tests

No-crossover layout, sorted and deduplicated edges, the 0.1 Hz hysteresis **from both sides** (0.05 Hz apart collapses, 0.5 Hz apart does not), a non-spatialized speaker contributing nothing, non-positive cutoffs ignored, a mixed full-range/banded layout, and that serializing a layout whose speaker was edited reflects the change — the property the computed-at-serialization design exists for.

**77 src-tauri tests pass** (src-tauri is not in CI). `npm run build` green, knip clean, `test:math` 588/588, zero build warnings, `cargo fmt --check` divergence unchanged from baseline (`layouts.rs` formatted on its own, not via `cargo fmt -p`).

## Not verified

Not run against a live renderer. The acceptance criteria that need it: the same bands shown for several layouts **including no-crossover and mixed-crossover ones**, and heatmap band selection unchanged. Also worth exercising the path this PR was reshaped around — pick a different layout from the menu and confirm its band bars use *its* edges, not the live layout's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)