### PR TITLE
Validate render-backend and input state in the backend

### DIFF
--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -178,6 +178,82 @@ pub struct HybridState {
     pub metric: Option<String>,
 }
 
+impl RenderBackendState {
+    /// Bring a freshly-received backend state into a shape the frontend can
+    /// render without checking it first.
+    ///
+    /// The renderer is the authority on which backends exist, but the values
+    /// still travel over a protocol that can carry a stale config: an id from
+    /// a backend that is no longer registered, a curve point outside the unit
+    /// square, a metric nothing implements. The frontend used to test all of
+    /// this on arrival, which put the rules for "valid state" on the far side
+    /// of the boundary from the state itself.
+    pub fn sanitize(&mut self) {
+        fn lowered(value: &Option<String>) -> Option<String> {
+            value
+                .as_ref()
+                .map(|v| v.trim().to_ascii_lowercase())
+                .filter(|v| !v.is_empty())
+        }
+
+        self.selection = lowered(&self.selection);
+        self.effective = lowered(&self.effective);
+        self.allowed_evaluation_modes = self
+            .allowed_evaluation_modes
+            .iter()
+            .map(|value| value.trim().to_ascii_lowercase())
+            .filter(|value| !value.is_empty())
+            .collect();
+
+        // A hybrid's inner models may be any registered backend except another
+        // hybrid. When the engine has not published its list, any non-hybrid id
+        // is accepted rather than none — an empty list means "unknown", not
+        // "nothing is valid".
+        let known: Vec<String> = self
+            .available_backends
+            .as_array()
+            .map(|backends| {
+                backends
+                    .iter()
+                    .filter_map(|backend| backend.get("id").and_then(|v| v.as_str()))
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let valid_inner = |id: &Option<String>| -> Option<String> {
+            let id = lowered(id)?;
+            if id == "hybrid" {
+                return None;
+            }
+            if known.is_empty() || known.iter().any(|k| *k == id) {
+                Some(id)
+            } else {
+                None
+            }
+        };
+        self.hybrid.external_backend = valid_inner(&self.hybrid.external_backend);
+        self.hybrid.internal_backend = valid_inner(&self.hybrid.internal_backend);
+
+        // The curve is a blend weight against a normalised distance: a point
+        // outside the unit square has no meaning, and a non-finite one would
+        // poison every sample drawn from it.
+        self.hybrid
+            .curve
+            .retain(|point| point[0].is_finite() && point[1].is_finite());
+        for point in &mut self.hybrid.curve {
+            point[0] = point[0].clamp(0.0, 1.0);
+            point[1] = point[1].clamp(0.0, 1.0);
+        }
+        self.hybrid.curve_smoothing = self
+            .hybrid
+            .curve_smoothing
+            .filter(|v| v.is_finite())
+            .map(|v| v.clamp(0.0, 1.0));
+        self.hybrid.metric = lowered(&self.hybrid.metric)
+            .filter(|metric| matches!(metric.as_str(), "spherical" | "chebyshev"));
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct RenderBackendState {
     pub selection: Option<String>,
@@ -826,5 +902,154 @@ impl Default for AppState {
             last_snapshot_emit_hash: None,
             last_overlay_emit_hash: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::RenderBackendState;
+
+    fn with_backends(ids: &[&str]) -> RenderBackendState {
+        RenderBackendState {
+            available_backends: serde_json::json!(ids
+                .iter()
+                .map(|id| serde_json::json!({ "id": id }))
+                .collect::<Vec<_>>()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ids_are_trimmed_and_lowercased() {
+        let mut state = RenderBackendState {
+            selection: Some("  VBAP  ".to_string()),
+            effective: Some("Hybrid".to_string()),
+            ..Default::default()
+        };
+        state.sanitize();
+        assert_eq!(state.selection.as_deref(), Some("vbap"));
+        assert_eq!(state.effective.as_deref(), Some("hybrid"));
+    }
+
+    #[test]
+    fn a_blank_id_becomes_none_rather_than_an_empty_string() {
+        let mut state = RenderBackendState {
+            selection: Some("   ".to_string()),
+            ..Default::default()
+        };
+        state.sanitize();
+        assert_eq!(state.selection, None);
+    }
+
+    /// The acceptance case: an id from a backend that is no longer registered.
+    #[test]
+    fn an_unknown_inner_backend_is_dropped() {
+        let mut state = with_backends(&["vbap", "cavern"]);
+        state.hybrid.external_backend = Some("gone".to_string());
+        state.hybrid.internal_backend = Some("vbap".to_string());
+        state.sanitize();
+        assert_eq!(state.hybrid.external_backend, None);
+        assert_eq!(state.hybrid.internal_backend.as_deref(), Some("vbap"));
+    }
+
+    /// A hybrid cannot nest inside itself, whatever the registry says.
+    #[test]
+    fn a_hybrid_cannot_be_its_own_inner_backend() {
+        let mut state = with_backends(&["vbap", "hybrid"]);
+        state.hybrid.external_backend = Some("hybrid".to_string());
+        state.sanitize();
+        assert_eq!(state.hybrid.external_backend, None);
+    }
+
+    /// An empty registry means "not published yet", not "nothing is valid" —
+    /// rejecting everything there would blank a working hybrid config.
+    #[test]
+    fn an_unpublished_registry_accepts_any_non_hybrid_id() {
+        let mut state = RenderBackendState::default();
+        state.hybrid.external_backend = Some("vbap".to_string());
+        state.hybrid.internal_backend = Some("hybrid".to_string());
+        state.sanitize();
+        assert_eq!(state.hybrid.external_backend.as_deref(), Some("vbap"));
+        assert_eq!(state.hybrid.internal_backend, None);
+    }
+
+    /// The other acceptance case: a curve point outside the unit square.
+    #[test]
+    fn curve_points_are_clamped_into_the_unit_square() {
+        let mut state = RenderBackendState::default();
+        state.hybrid.curve = vec![[-0.5, 2.0], [0.5, 0.5], [3.0, -1.0]];
+        state.sanitize();
+        assert_eq!(state.hybrid.curve, vec![[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]);
+    }
+
+    /// A non-finite point cannot be clamped into anything meaningful, so it is
+    /// removed — leaving it would poison every sample drawn from the curve.
+    #[test]
+    fn non_finite_curve_points_are_removed_not_clamped() {
+        let mut state = RenderBackendState::default();
+        state.hybrid.curve = vec![
+            [0.0, 0.0],
+            [f64::NAN, 0.5],
+            [1.0, f64::INFINITY],
+            [1.0, 1.0],
+        ];
+        state.sanitize();
+        assert_eq!(state.hybrid.curve, vec![[0.0, 0.0], [1.0, 1.0]]);
+    }
+
+    #[test]
+    fn smoothing_is_clamped_and_non_finite_is_dropped() {
+        let mut state = RenderBackendState::default();
+        state.hybrid.curve_smoothing = Some(5.0);
+        state.sanitize();
+        assert_eq!(state.hybrid.curve_smoothing, Some(1.0));
+
+        state.hybrid.curve_smoothing = Some(f64::NAN);
+        state.sanitize();
+        assert_eq!(state.hybrid.curve_smoothing, None);
+    }
+
+    #[test]
+    fn only_implemented_metrics_survive() {
+        let mut state = RenderBackendState::default();
+        state.hybrid.metric = Some("Chebyshev".to_string());
+        state.sanitize();
+        assert_eq!(state.hybrid.metric.as_deref(), Some("chebyshev"));
+
+        state.hybrid.metric = Some("manhattan".to_string());
+        state.sanitize();
+        assert_eq!(state.hybrid.metric, None);
+    }
+
+    #[test]
+    fn evaluation_modes_are_normalised_and_blanks_dropped() {
+        let mut state = RenderBackendState {
+            allowed_evaluation_modes: vec![
+                " Realtime ".to_string(),
+                String::new(),
+                "PRECOMPUTED_POLAR".to_string(),
+            ],
+            ..Default::default()
+        };
+        state.sanitize();
+        assert_eq!(
+            state.allowed_evaluation_modes,
+            vec!["realtime".to_string(), "precomputed_polar".to_string()]
+        );
+    }
+
+    /// Sanitizing an already-clean state must not change it.
+    #[test]
+    fn sanitize_is_idempotent() {
+        let mut state = with_backends(&["vbap"]);
+        state.selection = Some("vbap".to_string());
+        state.hybrid.external_backend = Some("vbap".to_string());
+        state.hybrid.curve = vec![[0.0, 0.0], [1.0, 1.0]];
+        state.hybrid.curve_smoothing = Some(0.5);
+        state.hybrid.metric = Some("spherical".to_string());
+        state.sanitize();
+        let once = state.clone();
+        state.sanitize();
+        assert_eq!(format!("{once:?}"), format!("{state:?}"));
     }
 }

--- a/omniphony-studio/src-tauri/src/commands/input.rs
+++ b/omniphony-studio/src-tauri/src/commands/input.rs
@@ -35,19 +35,26 @@ pub fn control_input_config_apply(state: State<SharedState>) {
     );
 }
 
+/// Canonical spelling of an input mode, or `None` if it is not one.
+///
+/// The protocol carries two historical aliases — `bridge` for `pipe_bridge`
+/// and `live` for `pipewire`. Both directions go through here: the frontend
+/// used to re-implement this table when reading a snapshot, which meant the
+/// same aliases were resolved in two places and only one of them was the
+/// authority.
+pub fn normalize_input_mode(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "bridge" | "pipe_bridge" => Some("pipe_bridge"),
+        "live" | "pipewire" => Some("pipewire"),
+        "pipewire_bridge" => Some("pipewire_bridge"),
+        _ => None,
+    }
+}
+
 #[tauri::command]
 pub fn control_input_mode(state: State<SharedState>, value: String) {
-    let trimmed = value.trim().to_ascii_lowercase();
-    if !matches!(
-        trimmed.as_str(),
-        "bridge" | "pipe_bridge" | "live" | "pipewire" | "pipewire_bridge"
-    ) {
+    let Some(normalized) = normalize_input_mode(&value) else {
         return;
-    }
-    let normalized = match trimmed.as_str() {
-        "bridge" => "pipe_bridge",
-        "live" => "pipewire",
-        other => other,
     };
     send_control(
         &state.osc_tx,

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -539,11 +539,18 @@ fn apply_input_domain_state(s: &mut AppState, value: &str) -> bool {
     let Ok(parsed) = serde_json::from_str::<InputDomainState>(value) else {
         return false;
     };
+    // Canonicalise before the state is stored, so what the frontend receives
+    // never carries a protocol alias. An unrecognised mode is dropped rather
+    // than stored: a mode nothing can act on is worse than the last good one.
     if let Some(mode) = parsed.mode {
-        s.input_mode = Some(mode);
+        if let Some(normalized) = crate::commands::input::normalize_input_mode(&mode) {
+            s.input_mode = Some(normalized.to_string());
+        }
     }
     if let Some(active_mode) = parsed.active_mode {
-        s.input_active_mode = Some(active_mode);
+        if let Some(normalized) = crate::commands::input::normalize_input_mode(&active_mode) {
+            s.input_active_mode = Some(normalized.to_string());
+        }
     }
     if let Some(apply_pending) = parsed.apply_pending {
         s.input_apply_pending = Some(if apply_pending { 1 } else { 0 });
@@ -636,7 +643,10 @@ fn apply_renderer_domain_state(s: &mut AppState, value: &str) -> bool {
     if let Some(vbap_polar) = parsed.vbap_polar {
         s.vbap_polar = vbap_polar;
     }
-    if let Some(render_backend_state) = parsed.render_backend_state {
+    if let Some(mut render_backend_state) = parsed.render_backend_state {
+        // Validate before storing, so the snapshot the frontend receives is
+        // already correct rather than merely reported.
+        render_backend_state.sanitize();
         s.render_backend_state = render_backend_state;
     }
     if let Some(options) = parsed.options {

--- a/omniphony-studio/src/init.js
+++ b/omniphony-studio/src/init.js
@@ -167,19 +167,14 @@ export function applyInitState(payload) {
   }
   updateVbapCartesian();
   if (payload.renderBackendState && typeof payload.renderBackendState === 'object') {
-    // Accept any backend id the engine reports (built-in or contributor-
-    // registered); the engine already validated it against its registry.
+    // Ids, evaluation modes, the hybrid inner backends, its curve, smoothing
+    // and metric all arrive validated: `RenderBackendState::sanitize` runs in
+    // the backend before the state is stored, so this is hydration only.
     if (typeof payload.renderBackendState.selection === 'string') {
-      const selection = payload.renderBackendState.selection.trim().toLowerCase();
-      if (selection) {
-        app.renderBackendState.selection = selection;
-      }
+      app.renderBackendState.selection = payload.renderBackendState.selection;
     }
     if (typeof payload.renderBackendState.effective === 'string') {
-      const effective = payload.renderBackendState.effective.trim().toLowerCase();
-      if (effective) {
-        app.renderBackendState.effective = effective;
-      }
+      app.renderBackendState.effective = payload.renderBackendState.effective;
     }
     app.renderBackendState.effectiveLabel = typeof payload.renderBackendState.effectiveLabel === 'string'
       ? payload.renderBackendState.effectiveLabel
@@ -189,8 +184,6 @@ export function applyInitState(payload) {
       : null;
     app.renderBackendState.allowedEvaluationModes = Array.isArray(payload.renderBackendState.allowedEvaluationModes)
       ? payload.renderBackendState.allowedEvaluationModes
-        .map((value) => String(value ?? '').trim().toLowerCase())
-        .filter((value) => value.length > 0)
       : [];
     app.renderBackendState.frozenRoomRatio = payload.renderBackendState.frozenRoomRatio === true;
     app.renderBackendState.frozenSpeakers = payload.renderBackendState.frozenSpeakers === true;
@@ -207,42 +200,14 @@ export function applyInitState(payload) {
       : {};
     const hybrid = payload.renderBackendState.hybrid;
     if (hybrid && typeof hybrid === 'object') {
-      // Any registered backend can be a hybrid inner model, except a nested
-      // hybrid. The dropdown is populated from `availableBackends`; accept an id
-      // present in that list (or any non-hybrid id if the list isn't published).
-      const available = app.renderBackendState.availableBackends;
-      const validInner = (id) =>
-        typeof id === 'string'
-        && id.length > 0
-        && id !== 'hybrid'
-        && (!Array.isArray(available)
-          || available.length === 0
-          || available.some((b) => String(b.id) === id));
-      const external = typeof hybrid.externalBackend === 'string'
-        ? hybrid.externalBackend.trim().toLowerCase()
-        : null;
-      const internal = typeof hybrid.internalBackend === 'string'
-        ? hybrid.internalBackend.trim().toLowerCase()
-        : null;
-      app.renderBackendState.hybrid.externalBackend = validInner(external) ? external : null;
-      app.renderBackendState.hybrid.internalBackend = validInner(internal) ? internal : null;
-      app.renderBackendState.hybrid.curve = Array.isArray(hybrid.curve)
-        ? hybrid.curve
-          .filter((point) => Array.isArray(point) && point.length === 2
-            && Number.isFinite(point[0]) && Number.isFinite(point[1]))
-          .map((point) => [
-            Math.min(1, Math.max(0, point[0])),
-            Math.min(1, Math.max(0, point[1]))
-          ])
-        : null;
+      app.renderBackendState.hybrid.externalBackend = hybrid.externalBackend ?? null;
+      app.renderBackendState.hybrid.internalBackend = hybrid.internalBackend ?? null;
+      app.renderBackendState.hybrid.curve = Array.isArray(hybrid.curve) ? hybrid.curve : null;
       if (typeof hybrid.metric === 'string') {
-        const metric = hybrid.metric.trim().toLowerCase();
-        if (['spherical', 'chebyshev'].includes(metric)) {
-          app.renderBackendState.hybrid.metric = metric;
-        }
+        app.renderBackendState.hybrid.metric = hybrid.metric;
       }
       if (Number.isFinite(hybrid.curveSmoothing)) {
-        app.renderBackendState.hybrid.curveSmoothing = Math.min(1, Math.max(0, hybrid.curveSmoothing));
+        app.renderBackendState.hybrid.curveSmoothing = hybrid.curveSmoothing;
       }
     }
   }
@@ -576,21 +541,18 @@ export function applyInitState(payload) {
   if (typeof payload.audioError === 'string') {
     app.audioError = payload.audioError.trim() || null;
   }
+  // The protocol's two historical aliases (`bridge` for `pipe_bridge`, `live`
+  // for `pipewire`) are resolved by `normalize_input_mode` in the backend, on
+  // the way in as well as the way out. An unrecognised mode never reaches the
+  // snapshot, so there is nothing to test for here.
   if (typeof payload.inputMode === 'string') {
-    const value = payload.inputMode.trim().toLowerCase();
-    if (value === 'bridge' || value === 'pipe_bridge' || value === 'live' || value === 'pipewire' || value === 'pipewire_bridge') {
-      const normalized = value === 'bridge' ? 'pipe_bridge' : (value === 'live' ? 'pipewire' : value);
-      if (!app.inputModeDirty || normalized === app.inputMode) {
-        app.inputMode = normalized;
-        app.inputModeDirty = false;
-      }
+    if (!app.inputModeDirty || payload.inputMode === app.inputMode) {
+      app.inputMode = payload.inputMode;
+      app.inputModeDirty = false;
     }
   }
   if (typeof payload.inputActiveMode === 'string') {
-    const value = payload.inputActiveMode.trim().toLowerCase();
-    if (value === 'bridge' || value === 'pipe_bridge' || value === 'live' || value === 'pipewire' || value === 'pipewire_bridge') {
-      app.inputActiveMode = value === 'bridge' ? 'pipe_bridge' : (value === 'live' ? 'pipewire' : value);
-    }
+    app.inputActiveMode = payload.inputActiveMode;
   }
   if (typeof payload.inputApplyPending === 'number') {
     const pending = payload.inputApplyPending !== 0;


### PR DESCRIPTION
Phase 4.1 of the Studio Rust/Web rebalancing plan. Targets `main` directly.

## What moved

`init.js` tested the state it received *before* storing it: backend ids trimmed and lowercased, hybrid inner backends checked against the published registry, curve points clamped into the unit square, the metric matched against the two that exist, and the input mode's protocol aliases resolved.

So the rules for "what is a valid state" lived on the far side of the boundary from the state itself — and an invalid one could round-trip.

- **`RenderBackendState::sanitize()`** runs before the state is stored, so the snapshot the frontend receives is already correct rather than merely reported.
- **`normalize_input_mode()`** is extracted from the outgoing command path and applied on the way in too. The two historical aliases (`bridge` → `pipe_bridge`, `live` → `pipewire`) were being resolved in two places, and only one of them was the authority.

`init.js` becomes hydration for these fields and loses 38 lines.

## Three judgement calls worth reviewing

**An empty backend registry means "not published yet", not "nothing is valid".** Rejecting every inner backend there would blank a working hybrid config on a connection that has not sent its list. An unpublished registry accepts any non-hybrid id — which is what the frontend did, and it would have been easy to "tighten" into a regression.

**A non-finite curve point is removed, not clamped.** There is no sensible place to put a NaN on the curve, and leaving one would poison every sample drawn from it (including the ones #303 now takes from the backend).

**An unrecognised input mode is dropped, not stored.** A mode nothing can act on is worse than keeping the last good one.

## Tests

Eleven, including both cases the plan names as acceptance criteria — an unknown backend id, and an out-of-range curve point — plus trimming, blanks becoming `None`, a hybrid refusing to nest inside itself, the unpublished-registry case, non-finite removal, smoothing and metric filtering, evaluation-mode normalisation, and **idempotence** (sanitizing clean state must not change it).

**83 src-tauri tests pass** (src-tauri is not in CI). `npm run build` green, knip clean, `test:math` 588/588, zero build warnings, `cargo fmt --check` divergence unchanged from baseline.

## Deliberately not in here

The plan lists two more items under 4.1 that I left alone:

- **Adaptive-resampling hydration** (`init.js` L373-451, 20+ params). Reading it, it is plain hydration with defaults — not validation. Moving it would relocate code without moving a rule, and would grow the serde layer for no gain.
- **The default-virtual-bed seed** (L535-551). It fires on the *first authoritative snapshot reporting no saved bed*, and the backend does not currently track "first connection" — it would need new state, which is a different change from validating what already arrives.

Both are worth doing, but as their own PRs with their own reasoning rather than folded in here.

## Not verified

Not run against a live renderer. The acceptance check that needs it: feed a stale config (an unknown backend id, an out-of-range curve point) and confirm the *corrected* values come back in the state bundle. The unit tests prove `sanitize` does the right thing; they do not prove it is on every path the renderer publishes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)