### PR TITLE
Define the audio-config schema in the backend

### DIFF
--- a/omniphony-studio/src-tauri/src/audio_config.rs
+++ b/omniphony-studio/src-tauri/src/audio_config.rs
@@ -1,0 +1,371 @@
+//! The audio configuration schema: defaults, ranges, and the one place they
+//! are enforced.
+//!
+//! These twenty-odd clamps used to live in `buildAudioConfigPayload` in the
+//! frontend, which meant the definition of a valid adaptive-resampling
+//! configuration sat in the layer that *collects* the values rather than the
+//! one that owns them. The command forwarded whatever it was handed.
+//!
+//! Now the command takes the raw form values, applies the schema, forwards the
+//! corrected configuration and hands it back — so what the user sees after an
+//! edit is what the renderer was actually told.
+//!
+//! Every bound here is the frontend's, preserved: this is a move, not a
+//! retune. The one deliberate difference is that a non-finite value falls back
+//! to its default instead of propagating — JS would send a `NaN` through as
+//! JSON `null`, which the renderer then read as "absent".
+
+use serde::{Deserialize, Serialize};
+
+/// Round half away from zero, matching JavaScript's `Math.round` for the
+/// positive values these fields hold. Rust's `f64::round` agrees there; this
+/// exists so the intent is stated rather than assumed.
+fn round_like_js(value: f64) -> f64 {
+    value.round()
+}
+
+/// A number with a default for when the form sends nothing usable.
+fn finite_or(value: Option<f64>, default: f64) -> f64 {
+    match value {
+        Some(v) if v.is_finite() => v,
+        _ => default,
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AdaptiveResampling {
+    pub enabled: bool,
+    pub enable_far_mode: bool,
+    pub force_silence_in_far_mode: bool,
+    pub hard_recover_high_in_far_mode: bool,
+    pub hard_recover_low_in_far_mode: bool,
+    pub far_mode_return_fade_in_ms: Option<f64>,
+    pub kp_near: Option<f64>,
+    pub ki: Option<f64>,
+    /// Kept in the payload for protocol compatibility. Known to have no effect
+    /// on the loop, so it is passed through rather than given a range that
+    /// would imply one.
+    pub integral_discharge_ratio: Option<f64>,
+    pub max_adjust: Option<f64>,
+    pub high_recover_entry_margin_ms: Option<f64>,
+    pub update_interval_callbacks: Option<f64>,
+    pub low_recover_settle_stable_ms: Option<f64>,
+    pub low_recover_entry_margin_ms: Option<f64>,
+    pub low_recover_exit_margin_ms: Option<f64>,
+    pub low_recover_settle_margin_ms: Option<f64>,
+    pub low_recover_refill_delta_alpha: Option<f64>,
+    pub control_smoothing_cutoff_hz: Option<f64>,
+    pub control_smoothing_order: Option<f64>,
+    pub paused: bool,
+    pub use_pre_bridge_clock: bool,
+    pub use_output_pacing: bool,
+    pub disable_backpressure: bool,
+}
+
+impl Default for AdaptiveResampling {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            enable_far_mode: false,
+            force_silence_in_far_mode: false,
+            hard_recover_high_in_far_mode: false,
+            hard_recover_low_in_far_mode: false,
+            far_mode_return_fade_in_ms: None,
+            kp_near: None,
+            ki: None,
+            integral_discharge_ratio: None,
+            max_adjust: None,
+            high_recover_entry_margin_ms: None,
+            update_interval_callbacks: None,
+            low_recover_settle_stable_ms: None,
+            low_recover_entry_margin_ms: None,
+            low_recover_exit_margin_ms: None,
+            low_recover_settle_margin_ms: None,
+            low_recover_refill_delta_alpha: None,
+            control_smoothing_cutoff_hz: None,
+            control_smoothing_order: None,
+            paused: false,
+            use_pre_bridge_clock: false,
+            use_output_pacing: false,
+            disable_backpressure: false,
+        }
+    }
+}
+
+/// The effective configuration: every field resolved to a usable number.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectiveAdaptiveResampling {
+    pub enabled: bool,
+    pub enable_far_mode: bool,
+    pub force_silence_in_far_mode: bool,
+    pub hard_recover_high_in_far_mode: bool,
+    pub hard_recover_low_in_far_mode: bool,
+    pub far_mode_return_fade_in_ms: f64,
+    pub kp_near: f64,
+    pub ki: f64,
+    pub integral_discharge_ratio: f64,
+    pub max_adjust: f64,
+    pub high_recover_entry_margin_ms: f64,
+    pub update_interval_callbacks: f64,
+    pub low_recover_settle_stable_ms: f64,
+    pub low_recover_entry_margin_ms: f64,
+    pub low_recover_exit_margin_ms: f64,
+    pub low_recover_settle_margin_ms: f64,
+    pub low_recover_refill_delta_alpha: f64,
+    pub control_smoothing_cutoff_hz: f64,
+    pub control_smoothing_order: f64,
+    pub paused: bool,
+    pub use_pre_bridge_clock: bool,
+    pub use_output_pacing: bool,
+    pub disable_backpressure: bool,
+}
+
+impl AdaptiveResampling {
+    /// Apply the schema.
+    ///
+    /// The bounds are the frontend's, field for field. Where a field has no
+    /// bound (`kpNear`, `ki`, `maxAdjust`, `integralDischargeRatio`) it keeps
+    /// only its default — the renderer owns whatever range those have.
+    pub fn resolve(&self) -> EffectiveAdaptiveResampling {
+        EffectiveAdaptiveResampling {
+            enabled: self.enabled,
+            enable_far_mode: self.enable_far_mode,
+            force_silence_in_far_mode: self.force_silence_in_far_mode,
+            hard_recover_high_in_far_mode: self.hard_recover_high_in_far_mode,
+            hard_recover_low_in_far_mode: self.hard_recover_low_in_far_mode,
+
+            far_mode_return_fade_in_ms: round_like_js(finite_or(
+                self.far_mode_return_fade_in_ms,
+                0.0,
+            ))
+            .max(0.0),
+            kp_near: finite_or(self.kp_near, 1.0),
+            ki: finite_or(self.ki, 1.0),
+            integral_discharge_ratio: finite_or(self.integral_discharge_ratio, 0.25),
+            max_adjust: finite_or(self.max_adjust, 0.01),
+
+            // At least one callback, at least one millisecond: a zero here
+            // would make the recovery test fire on every callback.
+            high_recover_entry_margin_ms: round_like_js(finite_or(
+                self.high_recover_entry_margin_ms,
+                1000.0,
+            ))
+            .max(1.0),
+            update_interval_callbacks: round_like_js(finite_or(
+                self.update_interval_callbacks,
+                1.0,
+            ))
+            .max(1.0),
+
+            low_recover_settle_stable_ms: finite_or(self.low_recover_settle_stable_ms, 200.0)
+                .max(0.0),
+            low_recover_entry_margin_ms: finite_or(self.low_recover_entry_margin_ms, 18.0).max(0.0),
+            low_recover_exit_margin_ms: finite_or(self.low_recover_exit_margin_ms, 6.0).max(0.0),
+            low_recover_settle_margin_ms: finite_or(self.low_recover_settle_margin_ms, 6.0)
+                .max(0.0),
+            // A blend factor: outside [0, 1] it is not a blend.
+            low_recover_refill_delta_alpha: finite_or(self.low_recover_refill_delta_alpha, 0.5)
+                .clamp(0.0, 1.0),
+
+            // A zero cutoff would divide by zero in the smoother.
+            control_smoothing_cutoff_hz: finite_or(self.control_smoothing_cutoff_hz, 0.5)
+                .max(0.001),
+            // Only first and second order are implemented.
+            control_smoothing_order: round_like_js(finite_or(self.control_smoothing_order, 1.0))
+                .clamp(1.0, 2.0),
+
+            paused: self.paused,
+            use_pre_bridge_clock: self.use_pre_bridge_clock,
+            use_output_pacing: self.use_output_pacing,
+            disable_backpressure: self.disable_backpressure,
+        }
+    }
+}
+
+/// The audio configuration as the form sends it.
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AudioConfig {
+    pub output_device: Option<String>,
+    pub sample_rate: Option<f64>,
+    pub latency_target_ms: Option<f64>,
+    pub adaptive_resampling: AdaptiveResampling,
+}
+
+/// The audio configuration as the renderer will receive it.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectiveAudioConfig {
+    pub output_device: Option<String>,
+    pub sample_rate: Option<f64>,
+    pub latency_target_ms: Option<f64>,
+    pub adaptive_resampling: EffectiveAdaptiveResampling,
+}
+
+impl AudioConfig {
+    pub fn resolve(&self) -> EffectiveAudioConfig {
+        EffectiveAudioConfig {
+            // An empty device name means "whatever the system picks", which is
+            // what absent means — so it is normalised to absent rather than
+            // sent as an empty string the renderer would try to open.
+            output_device: self
+                .output_device
+                .as_ref()
+                .map(|d| d.trim().to_string())
+                .filter(|d| !d.is_empty()),
+            sample_rate: self.sample_rate.filter(|v| v.is_finite() && *v > 0.0),
+            latency_target_ms: self.latency_target_ms.filter(|v| v.is_finite() && *v > 0.0),
+            adaptive_resampling: self.adaptive_resampling.resolve(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(json: serde_json::Value) -> AudioConfig {
+        serde_json::from_value(json).expect("payload must deserialize")
+    }
+
+    #[test]
+    fn an_empty_payload_resolves_to_the_defaults() {
+        let effective = raw(serde_json::json!({})).resolve();
+        let r = &effective.adaptive_resampling;
+        assert_eq!(r.kp_near, 1.0);
+        assert_eq!(r.ki, 1.0);
+        assert_eq!(r.integral_discharge_ratio, 0.25);
+        assert_eq!(r.max_adjust, 0.01);
+        assert_eq!(r.high_recover_entry_margin_ms, 1000.0);
+        assert_eq!(r.update_interval_callbacks, 1.0);
+        assert_eq!(r.low_recover_settle_stable_ms, 200.0);
+        assert_eq!(r.control_smoothing_cutoff_hz, 0.5);
+        assert_eq!(r.control_smoothing_order, 1.0);
+        assert!(!r.enabled);
+    }
+
+    /// The acceptance case: out-of-range input must come back corrected.
+    #[test]
+    fn out_of_range_values_are_pulled_into_range() {
+        let effective = raw(serde_json::json!({
+            "adaptiveResampling": {
+                "farModeReturnFadeInMs": -500,
+                "highRecoverEntryMarginMs": 0,
+                "updateIntervalCallbacks": 0,
+                "lowRecoverSettleStableMs": -1,
+                "lowRecoverRefillDeltaAlpha": 5,
+                "controlSmoothingCutoffHz": 0,
+                "controlSmoothingOrder": 9,
+            }
+        }))
+        .resolve();
+        let r = &effective.adaptive_resampling;
+        assert_eq!(r.far_mode_return_fade_in_ms, 0.0);
+        assert_eq!(r.high_recover_entry_margin_ms, 1.0);
+        assert_eq!(r.update_interval_callbacks, 1.0);
+        assert_eq!(r.low_recover_settle_stable_ms, 0.0);
+        assert_eq!(r.low_recover_refill_delta_alpha, 1.0);
+        assert_eq!(r.control_smoothing_cutoff_hz, 0.001);
+        assert_eq!(r.control_smoothing_order, 2.0);
+    }
+
+    #[test]
+    fn the_blend_factor_is_clamped_at_both_ends() {
+        let low = raw(serde_json::json!({
+            "adaptiveResampling": { "lowRecoverRefillDeltaAlpha": -3 }
+        }))
+        .resolve();
+        assert_eq!(low.adaptive_resampling.low_recover_refill_delta_alpha, 0.0);
+    }
+
+    #[test]
+    fn the_smoothing_order_is_rounded_before_clamping() {
+        for (input, expected) in [(1.4, 1.0), (1.6, 2.0), (2.4, 2.0), (0.2, 1.0)] {
+            let effective = raw(serde_json::json!({
+                "adaptiveResampling": { "controlSmoothingOrder": input }
+            }))
+            .resolve();
+            assert_eq!(
+                effective.adaptive_resampling.control_smoothing_order, expected,
+                "order {input}"
+            );
+        }
+    }
+
+    /// JS sent a `NaN` through as JSON `null`, which the renderer then read as
+    /// "absent". Falling back to the default is the deliberate difference.
+    #[test]
+    fn a_non_finite_value_falls_back_to_its_default() {
+        let effective = raw(serde_json::json!({
+            "adaptiveResampling": { "kpNear": null, "controlSmoothingCutoffHz": null }
+        }))
+        .resolve();
+        assert_eq!(effective.adaptive_resampling.kp_near, 1.0);
+        assert_eq!(
+            effective.adaptive_resampling.control_smoothing_cutoff_hz,
+            0.5
+        );
+    }
+
+    /// Fields with no bound keep whatever the user typed — the renderer owns
+    /// their range, and inventing one here would silently retune the loop.
+    #[test]
+    fn unbounded_fields_are_passed_through_untouched() {
+        let effective = raw(serde_json::json!({
+            "adaptiveResampling": { "kpNear": 250.0, "ki": -4.0, "maxAdjust": 0.9 }
+        }))
+        .resolve();
+        assert_eq!(effective.adaptive_resampling.kp_near, 250.0);
+        assert_eq!(effective.adaptive_resampling.ki, -4.0);
+        assert_eq!(effective.adaptive_resampling.max_adjust, 0.9);
+    }
+
+    #[test]
+    fn an_empty_device_name_becomes_absent() {
+        let effective = raw(serde_json::json!({ "outputDevice": "   " })).resolve();
+        assert_eq!(effective.output_device, None);
+
+        let effective = raw(serde_json::json!({ "outputDevice": " hw:1 " })).resolve();
+        assert_eq!(effective.output_device.as_deref(), Some("hw:1"));
+    }
+
+    #[test]
+    fn a_non_positive_sample_rate_becomes_absent() {
+        assert_eq!(
+            raw(serde_json::json!({ "sampleRate": 0 }))
+                .resolve()
+                .sample_rate,
+            None
+        );
+        assert_eq!(
+            raw(serde_json::json!({ "sampleRate": 48000 }))
+                .resolve()
+                .sample_rate,
+            Some(48000.0)
+        );
+    }
+
+    #[test]
+    fn booleans_survive_the_round_trip() {
+        let effective = raw(serde_json::json!({
+            "adaptiveResampling": { "enabled": true, "paused": true, "useOutputPacing": true }
+        }))
+        .resolve();
+        let r = &effective.adaptive_resampling;
+        assert!(r.enabled && r.paused && r.use_output_pacing);
+        assert!(!r.disable_backpressure);
+    }
+
+    /// Resolving an already-effective payload must not move it.
+    #[test]
+    fn resolve_is_idempotent() {
+        let once = raw(serde_json::json!({
+            "adaptiveResampling": { "controlSmoothingOrder": 9, "lowRecoverRefillDeltaAlpha": 5 }
+        }))
+        .resolve();
+        let twice = raw(serde_json::to_value(&once).unwrap()).resolve();
+        assert_eq!(once.adaptive_resampling, twice.adaptive_resampling);
+    }
+}

--- a/omniphony-studio/src-tauri/src/commands/audio.rs
+++ b/omniphony-studio/src-tauri/src/commands/audio.rs
@@ -19,11 +19,18 @@ pub fn control_audio_sample_rate(state: State<SharedState>, sample_rate: i32) {
 }
 
 #[tauri::command]
-pub fn control_audio_config(state: State<SharedState>, payload: serde_json::Value) {
-    let text = match serde_json::to_string(&payload) {
-        Ok(text) => text,
-        Err(_) => return,
-    };
+pub fn control_audio_config(
+    state: State<SharedState>,
+    payload: serde_json::Value,
+) -> Option<serde_json::Value> {
+    // The form sends what the user typed; the schema decides what it means.
+    // Returning the effective configuration is what lets the UI show the
+    // corrected value rather than the rejected one — the frontend used to
+    // apply these bounds itself on the way out, so a field that was pulled
+    // into range looked accepted as typed.
+    let raw: crate::audio_config::AudioConfig = serde_json::from_value(payload).ok()?;
+    let effective = raw.resolve();
+    let text = serde_json::to_string(&effective).ok()?;
     send_control(
         &state.osc_tx,
         OscControlMsg::SendString {
@@ -31,6 +38,7 @@ pub fn control_audio_config(state: State<SharedState>, payload: serde_json::Valu
             value: text,
         },
     );
+    serde_json::to_value(&effective).ok()
 }
 
 #[tauri::command]

--- a/omniphony-studio/src-tauri/src/main.rs
+++ b/omniphony-studio/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app_state;
+mod audio_config;
 mod auto_tune;
 mod commands;
 mod config;

--- a/omniphony-studio/src/controls/audio.js
+++ b/omniphony-studio/src/controls/audio.js
@@ -25,6 +25,13 @@ function getAudioSampleRateInputEl() { return inAudioPanel('audioSampleRateInput
 function getAudioSampleRateMenuEl() { return inAudioPanel('audioSampleRateMenu'); }
 function getAudioOutputSummaryEl() { return inAudioPanel('audioOutputSummary'); }
 
+// What the user typed, unmodified. The bounds, the defaults and the coercions
+// live in `src-tauri/src/audio_config.rs`, which is also what forwards the
+// configuration to the renderer — so there is one definition of a valid audio
+// config, on the side that owns it. `control_audio_config` hands back the
+// effective values, and `applyEffectiveAudioConfig` below renders those, so a
+// field pulled into range shows its corrected value instead of looking
+// accepted as typed.
 export function buildAudioConfigPayload() {
   return {
     outputDevice: app.audioOutputDevice || null,
@@ -36,20 +43,20 @@ export function buildAudioConfigPayload() {
       forceSilenceInFarMode: app.adaptiveResamplingForceSilenceInFarMode === true,
       hardRecoverHighInFarMode: app.adaptiveResamplingHardRecoverHighInFarMode === true,
       hardRecoverLowInFarMode: app.adaptiveResamplingHardRecoverLowInFarMode === true,
-      farModeReturnFadeInMs: Math.max(0, Math.round(app.adaptiveResamplingFarModeReturnFadeInMs ?? 0)),
-      kpNear: Number(app.adaptiveResamplingKpNear ?? 1),
-      ki: Number(app.adaptiveResamplingKi ?? 1),
-      integralDischargeRatio: Number(app.adaptiveResamplingIntegralDischargeRatio ?? 0.25),
-      maxAdjust: Number(app.adaptiveResamplingMaxAdjust ?? 0.01),
-      highRecoverEntryMarginMs: Math.max(1, Math.round(app.adaptiveResamplingHighRecoverEntryMarginMs ?? 1000)),
-      updateIntervalCallbacks: Math.max(1, Math.round(app.adaptiveResamplingUpdateIntervalCallbacks ?? 1)),
-      lowRecoverSettleStableMs: Math.max(0, Number(app.adaptiveResamplingLowRecoverSettleStableMs ?? 200)),
-      lowRecoverEntryMarginMs: Math.max(0, Number(app.adaptiveResamplingLowRecoverEntryMarginMs ?? 18)),
-      lowRecoverExitMarginMs: Math.max(0, Number(app.adaptiveResamplingLowRecoverExitMarginMs ?? 6)),
-      lowRecoverSettleMarginMs: Math.max(0, Number(app.adaptiveResamplingLowRecoverSettleMarginMs ?? 6)),
-      lowRecoverRefillDeltaAlpha: Math.min(1, Math.max(0, Number(app.adaptiveResamplingLowRecoverRefillDeltaAlpha ?? 0.5))),
-      controlSmoothingCutoffHz: Math.max(0.001, Number(app.adaptiveResamplingControlSmoothingCutoffHz ?? 0.5)),
-      controlSmoothingOrder: Math.min(2, Math.max(1, Math.round(Number(app.adaptiveResamplingControlSmoothingOrder ?? 1)))),
+      farModeReturnFadeInMs: app.adaptiveResamplingFarModeReturnFadeInMs,
+      kpNear: app.adaptiveResamplingKpNear,
+      ki: app.adaptiveResamplingKi,
+      integralDischargeRatio: app.adaptiveResamplingIntegralDischargeRatio,
+      maxAdjust: app.adaptiveResamplingMaxAdjust,
+      highRecoverEntryMarginMs: app.adaptiveResamplingHighRecoverEntryMarginMs,
+      updateIntervalCallbacks: app.adaptiveResamplingUpdateIntervalCallbacks,
+      lowRecoverSettleStableMs: app.adaptiveResamplingLowRecoverSettleStableMs,
+      lowRecoverEntryMarginMs: app.adaptiveResamplingLowRecoverEntryMarginMs,
+      lowRecoverExitMarginMs: app.adaptiveResamplingLowRecoverExitMarginMs,
+      lowRecoverSettleMarginMs: app.adaptiveResamplingLowRecoverSettleMarginMs,
+      lowRecoverRefillDeltaAlpha: app.adaptiveResamplingLowRecoverRefillDeltaAlpha,
+      controlSmoothingCutoffHz: app.adaptiveResamplingControlSmoothingCutoffHz,
+      controlSmoothingOrder: app.adaptiveResamplingControlSmoothingOrder,
       paused: app.adaptiveResamplingPaused === true,
       usePreBridgeClock: app.adaptiveResamplingUsePreBridgeClock === true,
       useOutputPacing: app.adaptiveResamplingUseOutputPacing === true,
@@ -58,9 +65,37 @@ export function buildAudioConfigPayload() {
   };
 }
 
+/** Adopt the values the backend actually applied, so the form shows them. */
+function applyEffectiveAudioConfig(effective) {
+  const r = effective?.adaptiveResampling;
+  if (!r || typeof r !== 'object') return;
+  const numeric = {
+    farModeReturnFadeInMs: 'adaptiveResamplingFarModeReturnFadeInMs',
+    kpNear: 'adaptiveResamplingKpNear',
+    ki: 'adaptiveResamplingKi',
+    integralDischargeRatio: 'adaptiveResamplingIntegralDischargeRatio',
+    maxAdjust: 'adaptiveResamplingMaxAdjust',
+    highRecoverEntryMarginMs: 'adaptiveResamplingHighRecoverEntryMarginMs',
+    updateIntervalCallbacks: 'adaptiveResamplingUpdateIntervalCallbacks',
+    lowRecoverSettleStableMs: 'adaptiveResamplingLowRecoverSettleStableMs',
+    lowRecoverEntryMarginMs: 'adaptiveResamplingLowRecoverEntryMarginMs',
+    lowRecoverExitMarginMs: 'adaptiveResamplingLowRecoverExitMarginMs',
+    lowRecoverSettleMarginMs: 'adaptiveResamplingLowRecoverSettleMarginMs',
+    lowRecoverRefillDeltaAlpha: 'adaptiveResamplingLowRecoverRefillDeltaAlpha',
+    controlSmoothingCutoffHz: 'adaptiveResamplingControlSmoothingCutoffHz',
+    controlSmoothingOrder: 'adaptiveResamplingControlSmoothingOrder'
+  };
+  for (const [field, key] of Object.entries(numeric)) {
+    if (Number.isFinite(r[field])) app[key] = r[field];
+  }
+  dirty.adaptiveResampling = true;
+  scheduleUIFlush();
+}
+
 export function sendAudioConfig({ apply = true } = {}) {
   const payload = buildAudioConfigPayload();
-  return invoke('control_audio_config', { payload }).then(() => {
+  return invoke('control_audio_config', { payload }).then((effective) => {
+    applyEffectiveAudioConfig(effective);
     if (!apply) return null;
     return invoke('control_audio_config_apply');
   });


### PR DESCRIPTION
Phase 4.4 of the Studio Rust/Web rebalancing plan. Targets `main` directly; Studio-only, unlike 4.2/4.3 which touch the renderer on both hosts.

## What moved

`buildAudioConfigPayload` applied twenty-odd clamps, roundings and defaults on its way out. So the definition of a valid adaptive-resampling configuration sat in the layer that *collects* the values rather than the one that owns them — and `control_audio_config` forwarded whatever it was handed without looking. The plan says Rust "re-validates defensively"; for this command it did not.

The schema moves to `audio_config.rs`. The command takes the raw form values, resolves them, forwards the corrected configuration to the renderer, and **returns it**.

## The return path is the point

The clamps used to run *before* the value left the form, so a field pulled into range still displayed as typed: the UI showed a number the renderer had never been given. Type `controlSmoothingOrder: 9`, the renderer gets `2`, the box keeps saying `9`.

`applyEffectiveAudioConfig` adopts the resolved values, so the correction is visible. That is the acceptance criterion for this phase, and it is not something the clamps-in-JS arrangement could have satisfied.

## Bounds preserved, not invented

Every bound is the frontend's, field for field — a move, not a retune.

Fields with **no** bound (`kpNear`, `ki`, `maxAdjust`, `integralDischargeRatio`) keep whatever was typed. The renderer owns their range, and inventing one here would silently retune the loop; a test pins that they pass through untouched. `integralDischargeRatio` in particular stays a pass-through: it is known to have no effect on the loop, so giving it a range would imply one it does not have.

**One deliberate difference:** a non-finite value falls back to its default instead of propagating. JS sent a `NaN` through as JSON `null`, which the renderer then read as "absent" — a different thing from the value the user meant.

## Tests

Ten: the defaults, the acceptance case (out-of-range input coming back corrected), the blend factor clamped at *both* ends, rounding-before-clamping on the smoothing order, non-finite fallback, unbounded fields passed through untouched, empty device name and non-positive sample rate becoming absent, booleans surviving the round trip, and **idempotence** — resolving an already-effective payload must not move it.

**82 src-tauri tests pass** (src-tauri is not in CI). `npm run build` green, knip flags nothing new, `test:math` 588/588, zero build warnings, `cargo fmt --check` divergence unchanged from baseline.

## Not verified

Not exercised through the real form. Worth typing an out-of-range value into one of the adaptive-resampling fields and confirming the box **snaps to the corrected value** rather than keeping what you typed — and that the adaptive-resampling round-trip is otherwise unchanged, since this touches every field of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)