### PR TITLE
Say when an object slot goes away

### DIFF
--- a/omniphony-renderer/OSC_PROTOCOL.md
+++ b/omniphony-renderer/OSC_PROTOCOL.md
@@ -91,6 +91,23 @@ Serialized JSON speaker runtime/config snapshot with per-speaker `gain`, `delayM
 | `generation` | `i64` | Monotonic content generation ID |
 | `name` | `string` | Object or bed label |
 
+#### `/omniphony/object/{idx}/remove`
+
+Sent when an object's slot goes away — the frame's `object_count` shrank past
+it, or the content changed.
+
+| Argument | Type | Description |
+|---|---|---|
+| `generation` | `i64` | Monotonic content generation ID |
+
+A slot going away is also signalled the older way, by zeroing its position,
+`/size` and `/meta`, and that is still sent for clients that predate this
+message. Both are emitted for the same slot: the zeroed triple first, then this.
+
+A client that only watches `object_count` has to infer which slots are gone,
+which is what leaves ghost objects behind after a seek — the count can stay the
+same while the objects behind it change.
+
 ### Metering
 
 Enabled with `--osc-metering`.

--- a/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
@@ -119,6 +119,25 @@ impl OscSender {
             };
             let meta_bytes = rosc::encoder::encode(&OscPacket::Message(meta_msg))?;
             self.send_to_all(&meta_bytes);
+
+            // Say it outright, after the zeroed triple above. A client that
+            // understands this drops the object; one that does not still sees
+            // the zeros and clears its display the old way.
+            //
+            // This is emitted here rather than at the call sites on purpose:
+            // `send_object_frame` is the single emitter both hosts go through
+            // (the FFI/mpv path in `engine.rs`, and the CLI decode path in
+            // `cli/decode/*`), so the two cannot drift apart.
+            let remove_msg = OscMessage {
+                addr: format!(
+                    "/omniphony/object/{}/{}",
+                    stale_id,
+                    osc_contract::OBJECT_REMOVE_SUFFIX
+                ),
+                args: vec![OscType::Long(self.content_generation as i64)],
+            };
+            let remove_bytes = rosc::encoder::encode(&OscPacket::Message(remove_msg))?;
+            self.send_to_all(&remove_bytes);
         }
 
         for (object_id, obj) in objects.iter().enumerate() {

--- a/omniphony-renderer/runtime_control/src/osc_contract.rs
+++ b/omniphony-renderer/runtime_control/src/osc_contract.rs
@@ -476,6 +476,15 @@ pub const METER_DRC_GAIN: &str = "/omniphony/meter/drc_gain";
 pub const METER_MASTER: &str = "/omniphony/meter/master";
 pub const REGISTER: &str = "/omniphony/register";
 pub const SPATIAL_FRAME: &str = "/omniphony/spatial/frame";
+/// Suffix for the per-object lifecycle message: `/omniphony/object/{id}/remove`.
+///
+/// An object's slot going away used to be signalled only by zeroing its
+/// position, size and meta — a client had to infer "gone" from "silent at the
+/// origin", or from the frame's object count, which is what left ghosts behind
+/// after a seek. This says it.
+///
+/// The zeroed triple is still sent for clients that predate this.
+pub const OBJECT_REMOVE_SUFFIX: &str = "remove";
 pub const TIMESTAMP: &str = "/omniphony/timestamp";
 pub const YIELD_RESUME_PORT: &str = "/omniphony/yield/resume_port";
 

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -2069,6 +2069,14 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                 s.current_content_generation = Some(generation);
                 s.current_coordinate_format = coordinate_format;
 
+                // Compatibility path for renderers that predate
+                // `/omniphony/object/{id}/remove`: infer which slots are gone
+                // from the frame's object count. A current renderer sends the
+                // removal outright, so this only catches what it already did.
+                //
+                // Removable once no renderer older than that lifecycle message
+                // is in use — it is the inference the explicit signal replaces,
+                // and keeping it is what lets an old renderer still clean up.
                 let stale_ids: Vec<String> = if is_reset {
                     s.sources.keys().cloned().collect()
                 } else {

--- a/omniphony-studio/src/state.js
+++ b/omniphony-studio/src/state.js
@@ -614,9 +614,6 @@ export function supportsRealtimeKey(key) {
   return Array.isArray(realtime) && realtime.includes(key);
 }
 
-export function usesNumericSpatialPlaceholders() {
-  return (app.producerCapabilities?.producer || 'renderer') === 'renderer';
-}
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/omniphony-studio/src/tauri-bridge.js
+++ b/omniphony-studio/src/tauri-bridge.js
@@ -19,7 +19,6 @@ import {
   speakerGainCache,
   speakerDelays,
   layoutsByKey,
-  usesNumericSpatialPlaceholders
 } from './state.js';
 
 import { setObjectTestReportedPosition, setObjectTestClipState } from './controls/object-test.js';
@@ -256,23 +255,16 @@ export function setupTauriBridge() {
       }
     }
 
-    if (usesNumericSpatialPlaceholders()) {
-      // Ensure IDs [0..objectCount-1] exist for renderer snapshots that use numeric IDs.
-      for (let i = 0; i < objectCount; i += 1) {
-        const id = String(i);
-        if (!sourceMeshes.has(id)) {
-          updateSource(id, { x: 0, y: 0, z: 0, name: `Object_${i}`, _noTrail: true });
-        }
-      }
-
-      // Safety purge in case stale objects remain locally.
-      for (const id of Array.from(sourceMeshes.keys())) {
-        const idx = Number(id);
-        if (Number.isInteger(idx) && idx >= objectCount) {
-          removeSource(id);
-        }
-      }
-    }
+    // Objects are no longer synthesised from `objectCount` and purged by
+    // comparing indices against it. The renderer says which slots exist: a
+    // position update creates one, `/omniphony/object/{id}/remove` drops it
+    // (handled by `source:remove` above). Inferring it from the count is what
+    // left ghosts after a seek — the count can stay the same while the objects
+    // behind it change, so no index ever crossed the purge threshold.
+    //
+    // A client that registers gets a full object snapshot (`force_full_next`
+    // in the engine's OSC listener), so nothing depends on having watched the
+    // stream from the start.
 
     // The stream is now active again → drop any synthetic at-rest bed markers so
     // they don't coexist with the live objects.


### PR DESCRIPTION
Phase 4.2 of the Studio Rust/Web rebalancing plan — the first item that touches the **renderer**, and the first where the two-host rule applies.

## The bug

An object's slot disappearing was only ever signalled by **zeroing** its position, `/size` and `/meta`. A client had to infer "gone" from "silent at the origin", or from the frame's `object_count`.

That inference is what leaves ghosts behind after a seek: **the count can stay the same while the objects behind it change**, so no index ever crosses the purge threshold and every stale object survives.

`/omniphony/object/{id}/remove` says it outright. The zeroed triple is still sent for clients that predate it — the mpv overlay and the carla bridge both read it — so this is additive.

## On the two-host rule

`CLAUDE.md` warns that a renderer-side protocol change has to be wired into both the FFI/mpv host and the CLI decode host, because a fix on one does not reach the other. I checked before writing anything: `send_object_frame` has **four** call sites across both hosts —

- `orender_engine/src/engine.rs:994` and `:1199` (FFI/mpv)
- `src/cli/decode/spatial_metadata.rs:149` and `src/cli/decode/sample_write.rs:702` (CLI decode)

— and all four go through the *same* `OscSender::send_object_frame` in `orender_engine`. Emitting from inside that function rather than at the call sites is what makes the two hosts unable to drift apart here. Worth stating explicitly, because the same change written one level up would have needed doing twice and looked identical in review.

## Studio stops inferring

The frontend synthesised objects `[0..objectCount-1]` and purged any index at or above the count.

Both were **duplicates**: the Studio backend already removes stale sources by exactly that rule and wipes them all on a reset. So deleting the frontend copy does not remove a safety net — it removes a second copy of one, and leaves the backend's.

That backend path is now labelled as the compatibility fallback for renderers older than this message, with a note on when it can go. Which is what the plan asks for: the fallback in the backend, not the frontend.

`usesNumericSpatialPlaceholders` had no callers left and is deleted with it.

Nothing creates objects from a count any more: a position update creates one, the removal drops it. A registering client still gets a complete snapshot — registration sets `force_full_next` in the engine's OSC listener — so nothing depends on having watched the stream from the start. I checked that before removing the synthesis, since it is the assumption the whole change rests on.

## Verification

- **Workspace suite: 674 passed, 0 failed**, including the contract test that fails on any OSC address spelled out rather than named in `osc_contract`.
- src-tauri: 79 passed. `npm run build` green, knip clean, `test:math` 588/588, `cargo fmt --check` clean on the renderer and unchanged from baseline on src-tauri.
- Documented in `OSC_PROTOCOL.md` next to the frame it belongs to.

One flake to note: `orender_engine`'s `display_changes_bump_the_generation_and_reach_the_published_state` failed once under parallel execution and passed on re-run. Pre-existing, unrelated — it has shown up in #303 too.

## Not verified

Not run against a live renderer, and this one is squarely a runtime behaviour. The acceptance criteria need it: numeric-object streams populating and cleaning up correctly on **play, seek and track-switch**, and no ghost objects after a seek — which is the case the old inference got wrong and the reason this exists.

Worth watching both hosts, despite the shared emitter: mpv playback and a CLI decode run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)