### PR TITLE
Say what a synthesized object is

### DIFF
--- a/omniphony-renderer/orender_engine/src/channel_objects.rs
+++ b/omniphony-renderer/orender_engine/src/channel_objects.rs
@@ -195,6 +195,7 @@ impl ChannelObjectStages {
             size: spec.size,
             fixed: false,
             label: String::new(),
+            kind: spec.kind,
         })
     }
 

--- a/omniphony-renderer/orender_engine/src/object_gen.rs
+++ b/omniphony-renderer/orender_engine/src/object_gen.rs
@@ -52,10 +52,51 @@ pub struct ObjectGenParamSpec {
     pub unit: &'static str,
 }
 
+/// What a synthesized object *is*, as the generator that made it knows.
+///
+/// Clients used to read this off the object's name with a regular expression
+/// (`^Ambience_`, `^Phantom_`, …), which meant the classification lived in the
+/// consumer and a rename silently reclassified everything. Same reasoning as
+/// `ObjectMeta::fixed` — see `docs/channel-object-contract.md`.
+///
+/// This is the *kind*, not the badge: turning `Phantom_L_C` into the label
+/// `L·C` stays a display concern and stays in the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ObjectKind {
+    /// An ordinary object carried by the stream.
+    #[default]
+    Dynamic,
+    /// Synthesized to fill the height layer from a 2-D bed.
+    Height,
+    /// Extracted from between channels, or relocalized from one.
+    Phantom,
+}
+
+impl ObjectKind {
+    /// Spelling on the wire. Empty for `Dynamic`, so the common case costs
+    /// nothing and an older client reading an absent field sees the same.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            ObjectKind::Dynamic => "",
+            ObjectKind::Height => "height",
+            ObjectKind::Phantom => "phantom",
+        }
+    }
+
+    /// Parse the wire spelling; anything unrecognised is `Dynamic`.
+    pub fn from_wire(value: &str) -> Self {
+        match value {
+            "height" => ObjectKind::Height,
+            "phantom" => ObjectKind::Phantom,
+            _ => ObjectKind::Dynamic,
+        }
+    }
+}
+
 /// One synthesized object the generator emits. Position/name are static for a
 /// given layout+input (planned in [`ObjectGenerator::prepare`]); only the audio
 /// content varies per frame.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SynthObjectSpec {
     /// Display name, surfaced over OSC to Studio (3D view + object list).
     pub name: String,
@@ -66,6 +107,9 @@ pub struct SynthObjectSpec {
     pub gain_db: i8,
     /// Object spatial extent `(w, d, h)` ∈ [0, 1]³.
     pub size: [f32; 3],
+    /// What this object is. Defaults to [`ObjectKind::Dynamic`], so a
+    /// generator that does not set it behaves as before.
+    pub kind: ObjectKind,
 }
 
 /// Read-only environment for [`ObjectGenerator::prepare`].
@@ -403,6 +447,7 @@ impl ObjectGenerator for CopyUpGenerator {
                 position,
                 gain_db: GAIN_DB,
                 size: SIZE,
+                kind: ObjectKind::Height,
             });
         }
         specs
@@ -729,12 +774,14 @@ impl ObjectGenerator for PadGenerator {
                 position: pos_l,
                 gain_db: PAD_GAIN_DB,
                 size: SIZE,
+                kind: ObjectKind::Height,
             });
             specs.push(SynthObjectSpec {
                 name: name_r.to_string(),
                 position: pos_r,
                 gain_db: PAD_GAIN_DB,
                 size: SIZE,
+                kind: ObjectKind::Height,
             });
         }
 
@@ -756,6 +803,7 @@ impl ObjectGenerator for PadGenerator {
                 position,
                 gain_db: PAD_GAIN_DB,
                 size: SIZE,
+                kind: ObjectKind::Height,
             });
         }
         specs
@@ -1304,6 +1352,7 @@ impl ObjectGenerator for DiracGenerator {
                 position: *pos,
                 gain_db: DIRAC_GAIN_DB,
                 size: DIRAC_SIZE,
+                kind: ObjectKind::Height,
             })
             .collect();
         self.objects = specs.len();

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -261,6 +261,10 @@ pub struct ObjectMeta {
     /// Canonical channel-label name for a fixed channel (`"L"`, `"TFL"`…);
     /// empty for dynamic objects.
     pub label: String,
+    /// What this object is, as the generator that made it knows. Explicit for
+    /// the same reason as `fixed`: clients used to read it off the name with a
+    /// regular expression, so a rename silently reclassified everything.
+    pub kind: crate::object_gen::ObjectKind,
 }
 
 /// Epsilon for position/float comparison in delta OSC sending.

--- a/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
@@ -138,6 +138,9 @@ impl OscSender {
                         OscType::Int(i32::from(obj.fixed)),
                         OscType::String(obj.label.clone()),
                         OscType::Long(self.content_generation as i64),
+                        // Appended, so a client reading the first three by
+                        // index is unaffected. Empty for an ordinary object.
+                        OscType::String(obj.kind.as_wire().to_string()),
                     ],
                 };
                 let meta_bytes = rosc::encoder::encode(&OscPacket::Message(meta_msg))?;

--- a/omniphony-renderer/orender_engine/src/phantom_extract.rs
+++ b/omniphony-renderer/orender_engine/src/phantom_extract.rs
@@ -30,6 +30,7 @@
 //! [`PhantomExtractStage::process_and_extend`] does not allocate (steady state)
 //! and never panics.
 
+use crate::object_gen::ObjectKind;
 use bridge_api::RChannelLabel;
 use renderer::live_params::PhantomExtractMode;
 
@@ -253,6 +254,7 @@ fn phantom_spec(name: String, position: [f64; 3]) -> SynthObjectSpec {
         position,
         gain_db: PHANTOM_GAIN_DB,
         size: PHANTOM_SIZE,
+        kind: ObjectKind::Phantom,
     }
 }
 

--- a/omniphony-renderer/orender_engine/src/phantom_spectral.rs
+++ b/omniphony-renderer/orender_engine/src/phantom_spectral.rs
@@ -45,6 +45,7 @@
 //! [`SpectralExtractor::prepare`]; [`SpectralExtractor::process`] is
 //! allocation-free and never panics.
 
+use crate::object_gen::ObjectKind;
 use std::sync::Arc;
 
 use realfft::num_complex::Complex;
@@ -339,6 +340,7 @@ impl SpectralExtractor {
                 },
                 gain_db: SPEC_GAIN_DB,
                 size: SPEC_SIZE,
+                kind: ObjectKind::Phantom,
             })
             .collect()
     }

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -71,6 +71,8 @@ pub fn build_object_metas(
                     .unwrap_or([0.0, 0.0, 0.0]),
                 fixed: false,
                 label: String::new(),
+                // Carried by the stream, not synthesized here.
+                kind: crate::object_gen::ObjectKind::Dynamic,
             })
         })
         .collect()

--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -596,6 +596,9 @@ pub fn build_virtual_bed_objects(
             size: [0.0, 0.0, 0.0],
             fixed: true,
             label: bridge_api::labels::canonical_name(*label).to_string(),
+            // A bed channel at its canonical pose: `fixed` already says what
+            // it is, so it is not one of the synthesized kinds.
+            kind: crate::object_gen::ObjectKind::Dynamic,
         });
     }
     if objects.is_empty() {

--- a/omniphony-studio/src-tauri/src/app_state.rs
+++ b/omniphony-studio/src-tauri/src/app_state.rs
@@ -30,6 +30,11 @@ pub struct SourcePosition {
     /// Canonical channel-label name for a fixed channel ("L", "TFL"…).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    /// "height", "phantom", or absent for an ordinary object. Explicit from
+    /// the renderer; inferred from the name by the parser only for renderers
+    /// that predate the field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(rename = "sourceTag", skip_serializing_if = "Option::is_none")]

--- a/omniphony-studio/src-tauri/src/osc_listener.rs
+++ b/omniphony-studio/src-tauri/src/osc_listener.rs
@@ -2170,6 +2170,7 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                             "directSpeakerIndex": entry.direct_speaker_index,
                             "fixed": entry.fixed,
                             "label": entry.label,
+                            "kind": entry.kind,
                             "sourceTag": entry.source_tag,
                             "name": entry.name
                         }
@@ -2182,11 +2183,13 @@ fn handle_event(ev: OscEvent, app: &AppHandle, state: &Arc<Mutex<AppState>>) {
                 fixed,
                 label,
                 generation,
+                kind,
             } => {
                 let current_generation = s.current_content_generation;
                 let entry = s.sources.entry(id.clone()).or_default();
                 entry.fixed = Some(fixed);
                 entry.label = label.clone();
+                entry.kind = kind.clone();
                 if entry.generation.is_none() {
                     entry.generation = generation.or(current_generation);
                 }

--- a/omniphony-studio/src-tauri/src/osc_parser.rs
+++ b/omniphony-studio/src-tauri/src/osc_parser.rs
@@ -53,6 +53,36 @@ fn clamp(v: f64, min: f64, max: f64) -> f64 {
 // form also carry their angles, and the frontend re-derives cartesian from
 // those, which is why this mostly stayed invisible.
 
+/// Classify an object from its name, for renderers that predate the explicit
+/// `kind` on `/meta`.
+///
+/// This is the regular expression the frontend used to run, moved to the
+/// backend so the frontend never has to classify. It is a compatibility path,
+/// not the rule: a current renderer says what the object is, and this is only
+/// consulted when it does not.
+///
+/// Removable once no renderer older than that field is in use.
+fn infer_object_kind(name: Option<&str>) -> Option<String> {
+    let name = name?;
+    let lower = name.to_ascii_lowercase();
+    // Bed->height synthesis: PAD "Ambience_FL", copy-up "Height_Ls_synth",
+    // DirAC diffuse "Diffuse_TFL".
+    if lower.starts_with("ambience_") || lower.starts_with("diffuse_") {
+        return Some("height".to_string());
+    }
+    if lower.starts_with("height_") && lower.ends_with("_synth") {
+        return Some("height".to_string());
+    }
+    // Phantom extraction and the spectral sector rings.
+    if lower.starts_with("phantom_")
+        || lower.starts_with("direct_")
+        || lower.starts_with("directh_")
+    {
+        return Some("phantom".to_string());
+    }
+    None
+}
+
 fn find_id_in_address(parts: &[&str]) -> Option<String> {
     let anchors = ["source", "sources", "object", "obj", "track", "channel"];
     let reserved: std::collections::HashSet<&str> = [
@@ -145,6 +175,9 @@ pub enum OscEvent {
         label: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         generation: Option<u64>,
+        /// `"height"`, `"phantom"`, or absent for an ordinary object.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        kind: Option<String>,
     },
     #[serde(rename = "update:size")]
     UpdateSize {
@@ -574,11 +607,20 @@ fn parse_omniphony_object_meta(
         Some(OscType::Int(v)) if *v >= 0 => Some(*v as u64),
         _ => None,
     };
+    // Appended after `generation`; absent from renderers that predate it, in
+    // which case the kind is inferred from the name below.
+    let kind = raw_args
+        .get(3)
+        .and_then(unwrap_string)
+        .map(|k| k.trim().to_ascii_lowercase())
+        .filter(|k| matches!(k.as_str(), "height" | "phantom"))
+        .or_else(|| infer_object_kind(label.as_deref()));
     Some(OscEvent::UpdateMeta {
         id,
         fixed,
         label,
         generation,
+        kind,
     })
 }
 
@@ -1109,6 +1151,49 @@ mod tests {
     use rosc::OscType;
 
     #[test]
+    fn the_name_fallback_classifies_what_the_regex_used_to() {
+        for name in [
+            "Ambience_FL",
+            "Diffuse_TFL",
+            "Height_Ls_synth",
+            "AMBIENCE_FR",
+        ] {
+            assert_eq!(
+                super::infer_object_kind(Some(name)).as_deref(),
+                Some("height"),
+                "{name}"
+            );
+        }
+        for name in ["Phantom_L_C", "Phantom_C", "Direct_FL", "DirectH_FL"] {
+            assert_eq!(
+                super::infer_object_kind(Some(name)).as_deref(),
+                Some("phantom"),
+                "{name}"
+            );
+        }
+    }
+
+    /// An ordinary object has no kind — the badge must stay blank rather than
+    /// picking one of the synthesized icons.
+    #[test]
+    fn an_ordinary_name_infers_nothing() {
+        for name in ["Dialogue", "Obj_3", "L", "heights"] {
+            assert_eq!(super::infer_object_kind(Some(name)), None, "{name}");
+        }
+        assert_eq!(super::infer_object_kind(None), None);
+    }
+
+    /// `Height_x_synth` needs both ends: the prefix alone is a different thing.
+    #[test]
+    fn the_height_pattern_needs_its_suffix() {
+        assert_eq!(super::infer_object_kind(Some("Height_Ls")), None);
+        assert_eq!(
+            super::infer_object_kind(Some("Height_Ls_synth")).as_deref(),
+            Some("height")
+        );
+    }
+
+    #[test]
     fn parses_object_meta_message() {
         let parsed = parse_osc_message(
             "/omniphony/object/3/meta",
@@ -1126,6 +1211,7 @@ mod tests {
                 fixed: true,
                 label: Some(label),
                 generation: Some(7),
+                ..
             }) if id == "3" && label == "LFE"
         ));
     }
@@ -1183,6 +1269,7 @@ mod tests {
                 fixed: false,
                 label: None,
                 generation: None,
+                ..
             }) if id == "12"
         ));
     }

--- a/omniphony-studio/src/sources.js
+++ b/omniphony-studio/src/sources.js
@@ -120,41 +120,56 @@ export function getObjectDisplayName(id) {
   return name;
 }
 
-// Classify a (possibly synthesized) object from its name into a compact badge:
-// a `type` for the list's fixed type-icon ('height' for the bed→height upmix
-// objects, 'phantom' for the phantom-extraction objects, '' otherwise) and a
-// short position `code` (e.g. FL, Ls, L·C, L). Keeps the long technical name off
-// the vertical strip so list rows don't grow tall.
+// A compact badge for the list: a `type` for the fixed type-icon, and a short
+// position `code` (FL, Ls, L·C, L) that keeps the long technical name off the
+// vertical strip.
+//
+// The `type` is the renderer's — it arrives on the object's meta as `kind`
+// (`docs/channel-object-contract.md`), the way `fixed` does. It used to be read
+// off the name here with a regular expression, which meant renaming a generator's
+// output silently reclassified it.
+//
+// The `code` stays here on purpose: turning `Phantom_L_C` into `L·C` or marking
+// the high ring with `↑` is display formatting, not something the protocol
+// should carry. The patterns below survive for that alone — they no longer
+// decide what an object *is*.
+/** The renderer's classification of an object, or '' when it says nothing. */
+function objectKind(id) {
+  const kind = sourcePositionsRaw.get(String(id))?.kind;
+  return kind === 'height' || kind === 'phantom' ? kind : '';
+}
+
 export function objectBadge(id) {
   // The injected source's name is a sentence ("Test object"), which the list's
   // vertical strip cannot carry — it is sized for codes like FL or TBR. Give it
   // one. Not translated, like every other code in that strip.
   if (String(id) === OBJECT_TEST_SOURCE_ID) return { type: '', code: 'INJ' };
+  const kind = objectKind(id);
   const name = getObjectDisplayName(id);
   // Bed→height synth objects: PAD "Ambience_FL", copy_up "Height_Ls_synth",
   // DirAC diffuse "Diffuse_TFL".
   let m = name.match(/^Ambience_(.+)$/i);
-  if (m) return { type: 'height', code: m[1] };
+  if (m) return { type: kind, code: m[1] };
   m = name.match(/^Height_(.+)_synth$/i);
-  if (m) return { type: 'height', code: m[1] };
+  if (m) return { type: kind, code: m[1] };
   m = name.match(/^Diffuse_(.+)$/i);
-  if (m) return { type: 'height', code: m[1] };
+  if (m) return { type: kind, code: m[1] };
   // Phantom extraction "Phantom_L_C" → a source localized between two channels;
   // single-label "Phantom_C" → a relocalized channel.
   m = name.match(/^Phantom_([^_]+)_(.+)$/i);
-  if (m) return { type: 'phantom', code: `${m[1]}·${m[2]}` };
+  if (m) return { type: kind, code: `${m[1]}·${m[2]}` };
   m = name.match(/^Phantom_([^_]+)$/i);
-  if (m) return { type: 'phantom', code: m[1] };
+  if (m) return { type: kind, code: m[1] };
   // Spectral extraction sectors: high ring "DirectH_FL" (marked ↑ to keep the
   // code distinct from the floor ring's), floor ring "Direct_FL".
   m = name.match(/^DirectH_(.+)$/i);
-  if (m) return { type: 'phantom', code: `${m[1]}↑` };
+  if (m) return { type: kind, code: `${m[1]}↑` };
   m = name.match(/^Direct_(.+)$/i);
-  if (m) return { type: 'phantom', code: m[1] };
+  if (m) return { type: kind, code: m[1] };
   // Default: strip a single technical prefix word, as before.
   const u = name.indexOf('_');
   const code = u >= 0 ? name.slice(u + 1) : name;
-  return { type: '', code: code || name };
+  return { type: kind, code: code || name };
 }
 
 export function formatObjectLabel(id) {
@@ -1065,6 +1080,8 @@ export function updateSource(id, position) {
     // channel and its canonical label — never inferred from directSpeakerIndex.
     fixed: position?.fixed === true ? true : undefined,
     label: typeof position?.label === 'string' && position.label ? position.label : undefined,
+    // What the object is, per the renderer. See objectBadge().
+    kind: typeof position?.kind === 'string' && position.kind ? position.kind : undefined,
     t: now
   });
   sourcePositionsRaw.set(String(id), raw);


### PR DESCRIPTION
Phase 4.3 of the Studio Rust/Web rebalancing plan. Second and last item touching the renderer.

## The problem

An object's kind — a bed→height synthesis, a phantom extraction — was recoverable only by matching its **name** against a regular expression in the client: `^Ambience_`, `^Height_.*_synth$`, `^Phantom_`, `^Direct[H]?_`.

So the classification lived in the consumer. Renaming a generator's output silently reclassified everything it produced, and nothing would fail — no test, no type, no warning.

`ObjectKind` (Dynamic / Height / Phantom) goes on `SynthObjectSpec` and travels through `ObjectMeta` to a fourth argument on `/omniphony/object/{id}/meta`.

This is the same move, for the same reason, as `ObjectMeta::fixed` — whose doc comment already says *"clients must not infer this from `direct_speaker_index`"*, per phase 4 of `docs/channel-object-contract.md`. There was a precedent; this follows it rather than inventing a shape.

## Kind explicit, code still in the client

`objectBadge` produced **two** things from one regex: a *type* and a *display code*. Only the type moves.

Turning `Phantom_L_C` into `L·C`, or marking the high spectral ring with `↑`, is display formatting the protocol has no business carrying. The patterns survive for that alone and no longer decide what an object *is* — same line drawn as in #305, where band edges moved to Rust and label formatting stayed in JS.

## Coverage

Set at every construction site, which the compiler enumerated rather than my grep:

- **five in `object_gen`** — all height: the copy-up, both PAD ambience pairs, the DirAC diffuse set;
- **two in `phantom_extract`**, **one in `phantom_spectral`** — phantom.

Stream objects and virtual-bed channels are `Dynamic`; `fixed` already says what a bed channel is, so overloading the kind there would duplicate it.

`SynthObjectSpec` gains a `Default` derive so out-of-tree generators can construct with `..Default::default()` — adding a required field to a public struct is a break, and this is the mitigation.

## Two hosts, one emitter

Emitted from `send_object_frame`, the single function the FFI/mpv path and the CLI decode path both go through — the same property #308 relies on. Appended after `generation`, so a client reading the first three args by index is unaffected, and empty for an ordinary object.

## The fallback is in the backend

`infer_object_kind` in the Studio parser is the old regex, moved, consulted **only** when the renderer sends no kind, with a removal note. Per the plan: the compatibility path in the backend, never in JS. The frontend no longer classifies at all.

## Tests

Three in the parser: the fallback's classifications for every synthesized name shape, that an **ordinary name infers nothing** (a wrong type-icon is worse than none), and that `Height_x_synth` needs both ends of the pattern — `Height_Ls` alone is not a synthesis.

**Workspace: 674 passed, 0 failed.** src-tauri: 93 passed. `npm run build` green, knip clean, `cargo fmt --check` clean on the renderer and back to baseline on src-tauri.

## Not verified

Not run against a live renderer. The acceptance criteria need it: badges and colours **identical on current content** — the fallback should make that true even before a renderer rebuild — and synthetic objects tagged correctly **without name tricks**, which is the half only a rebuilt renderer proves. Worth checking the height generator and phantom extraction with the renderer rebuilt, and then again with an older one to exercise the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)