### PR TITLE
fix(osc): rebroadcast live state when a declared option changes

### DIFF
--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -86,13 +86,13 @@ pub(crate) fn handle_control_message(
             return;
         };
         if let Some(raw) = raw_option_value(msg.args.get(1)) {
-            apply_live_option(control, spec, &raw, socket, clients);
+            apply_live_option(control, spec, &raw, socket, clients, host);
         }
         return;
     }
     if let Some(spec) = renderer::options::find_by_legacy_addr(addr) {
         if let Some(raw) = raw_option_value(msg.args.first()) {
-            apply_live_option(control, spec, &raw, socket, clients);
+            apply_live_option(control, spec, &raw, socket, clients, host);
         }
         return;
     }
@@ -667,12 +667,19 @@ fn raw_option_value(arg: Option<&OscType>) -> Option<renderer::options::RawOptio
 /// `options::apply_to_control` (which marks dirty and bumps the replan epoch
 /// on a real change), then commit to config.yaml (`PERSIST`) and notify
 /// clients. Invalid values are dropped with a warning, per the OSC contract.
+///
+/// The live-state bundle goes out with the acknowledgement, exactly as
+/// `apply_control_effects` does for a dirty-marking dedicated handler. Without
+/// it a client that did not send the message never learns the value moved, and
+/// the one that did never learns what the setter made of it — an option clamped
+/// on arrival would keep displaying the number the user typed.
 fn apply_live_option(
     control: &Arc<RendererControl>,
     spec: &'static renderer::options::OptionSpec,
     raw: &renderer::options::RawOptionValue,
     socket: &Arc<UdpSocket>,
     clients: &Arc<OscClientRegistry>,
+    host: Option<&Arc<dyn HostControlHandler>>,
 ) {
     let Some(canonical) = renderer::options::apply_to_control(control, spec, raw) else {
         log::warn!("OSC option {}: rejected value", spec.key);
@@ -687,6 +694,8 @@ fn apply_live_option(
         }
     }
     broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
+    let state_bytes = build_live_state_bundle(control, host);
+    super::transport::send_raw(socket, clients, &state_bytes);
     log::info!("OSC option {} set to '{}'", spec.key, canonical);
 }
 


### PR DESCRIPTION
`apply_live_option` applies a declared option, persists it when `PERSIST` is set, and acknowledges with `STATE_CONFIG_SAVED` — but it never puts the new value back on the wire. The full live-state bundle is only broadcast when `live_state_generation` changes, and the registry path never bumps it, so a declared option set over OSC lands in the engine without any client being told.

Two things go wrong. A client that did not send the message never learns the value moved, so an external controller and an open Studio drift apart until something else forces a resync. And the client that did send it never learns what the setter made of the value: the setters clamp, so a value sent past a declared range is held clamped in the engine while the sender goes on displaying what it sent.

This looks like a regression from the registry migration rather than an original omission. The dedicated per-option handlers the registry replaced did rebroadcast — `apply_control_effects` builds and sends the bundle whenever a handler sets `mark_dirty` — so each option folded into `LIVE_OPTIONS` quietly lost the echo on the way in. All eight declared options are affected today.

The fix sends the bundle alongside the acknowledgement, the same way `apply_control_effects` does. That is one place rather than eight, and it covers any future row for free. `apply_live_option` gains the `host` handle it needs for `build_live_state_bundle`; both call sites already have one.

Scope is one file, `+11/−2`, with no change to the audio path.

Verified locally on this branch: `cargo fmt --all -- --check`, `cargo build --workspace` and `cargo test --workspace` all pass (674 tests, 0 failures). The change does not touch the render path, the crossover, the VBAP panner or the binaural stage, so there are no goldens to regenerate and no residual to quote.

One caveat on how this was checked: the evidence is the code path, not an observed session. I traced the dispatcher, `apply_to_control` (which calls `mark_dirty` but not `bump_live_state`), and the bundle producer, but did not attach a Studio and watch a value go stale. If there is a quicker way to confirm the symptom end to end, I am happy to run it.

Found while building a separate LFE-trim option on top of the registry; that work is not part of this PR.