### PR TITLE
fix(renderer): make live bed edits reach a playing object stream

### DIFF
--- a/omniphony-renderer/orender_engine/src/engine.rs
+++ b/omniphony-renderer/orender_engine/src/engine.rs
@@ -960,6 +960,7 @@ impl Engine {
                 self.coordinate_format,
                 &self.object_channels,
                 &meta.channel_gains,
+                self.fixed_planner.fixed_trims(),
                 meta.sample_pos,
                 meta.ramp_duration,
                 &mut self.frame_events,

--- a/omniphony-renderer/orender_engine/src/osc/dispatch.rs
+++ b/omniphony-renderer/orender_engine/src/osc/dispatch.rs
@@ -156,6 +156,11 @@ pub(crate) fn handle_control_message(
             if trimmed.is_empty() {
                 control.live.write().virtual_bed = None;
                 control.mark_dirty();
+                // The fixed-prefix planner caches on `(labels, options_epoch)`;
+                // without the bump an object stream keeps rendering the old bed
+                // until the next track switch. The channel-stream planner
+                // compares the bed by value and does not need it.
+                control.bump_options_epoch();
                 broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
                 control.bump_live_state();
                 log::info!("OSC virtual bed reset to defaults");
@@ -164,6 +169,8 @@ pub(crate) fn handle_control_message(
                     Ok(layout) => {
                         control.live.write().virtual_bed = Some(layout);
                         control.mark_dirty();
+                        // Same replan trigger as the reset branch above.
+                        control.bump_options_epoch();
                         broadcast_int(socket, clients, osc_contract::STATE_CONFIG_SAVED, 0);
                         control.bump_live_state();
                         log::info!("OSC virtual bed updated");

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -108,20 +108,34 @@ pub fn event_pos_as_adm_cartesian(
 /// Object events map to their PCM channel through the cached
 /// `object_channels` declaration (events for undeclared ids are skipped);
 /// `channel_gains` yields one gain/ramp-only event per listed fixed channel.
+///
+/// `bed_trims` is the virtual bed's per-fixed-channel trim (dB, indexed by
+/// channel, from [`crate::virtual_bed::FixedChannelPlanner::fixed_trims`]),
+/// summed onto each stream channel gain. The stream re-stamps the bed gains on
+/// every metadata frame; without the sum it would silently undo the trim the
+/// plan events carried. A stream gain of −128 is the −inf sentinel and is
+/// passed through untouched (and the saturating sum bottoms out there too).
 pub fn build_spatial_channel_events(
     conf: &Configuration,
     coordinate_format: RCoordinateFormat,
     object_channels: &[(u32, usize)],
     channel_gains: &[RChannelGain],
+    bed_trims: &[i8],
     sample_pos: u64,
     ramp_duration: u32,
     out: &mut Vec<SpatialChannelEvent>,
 ) {
     for gain in channel_gains {
+        let trim = bed_trims.get(gain.channel as usize).copied().unwrap_or(0);
+        let gain_db = if gain.gain_db == i8::MIN {
+            i8::MIN
+        } else {
+            gain.gain_db.saturating_add(trim)
+        };
         out.push(SpatialChannelEvent {
             channel_idx: gain.channel as usize,
             is_bed: true,
-            gain_db: Some(gain.gain_db),
+            gain_db: Some(gain_db),
             ramp_length: Some(ramp_duration),
             size: None,
             position: None,
@@ -187,6 +201,7 @@ mod tests {
             RCoordinateFormat::Cartesian,
             &object_channels,
             &gains,
+            &[],
             480,
             32,
             &mut out,
@@ -201,6 +216,46 @@ mod tests {
         assert_eq!(out[0].sample_pos, Some(480));
         assert!(!out[1].is_bed);
         assert_eq!(out[1].channel_idx, 6);
+    }
+
+    #[test]
+    fn bed_trims_sum_onto_the_stream_channel_gains() {
+        // The stream re-stamps the bed gains on every metadata frame; the bed
+        // trim must combine with them, not lose to them. −128 is the stream's
+        // −inf sentinel: a trim cannot raise a channel the stream silenced.
+        let conf = Configuration::new(Vec::new());
+        let gains = [
+            bridge_api::RChannelGain {
+                channel: 0,
+                gain_db: -3,
+            },
+            bridge_api::RChannelGain {
+                channel: 1,
+                gain_db: i8::MIN,
+            },
+            // Beyond the trims slice: untouched.
+            bridge_api::RChannelGain {
+                channel: 5,
+                gain_db: 2,
+            },
+        ];
+        let trims = [-6i8, -6, 0, 0];
+
+        let mut out = Vec::new();
+        build_spatial_channel_events(
+            &conf,
+            RCoordinateFormat::Cartesian,
+            &[],
+            &gains,
+            &trims,
+            0,
+            0,
+            &mut out,
+        );
+
+        assert_eq!(out[0].gain_db, Some(-9), "stream −3 + trim −6");
+        assert_eq!(out[1].gain_db, Some(i8::MIN), "−inf stays −inf");
+        assert_eq!(out[2].gain_db, Some(2), "no trim entry → unchanged");
     }
 
     #[test]

--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -1055,6 +1055,10 @@ pub struct FixedChannelPlanner {
     planned_labels: Vec<RChannelLabel>,
     planned_epoch: Option<u64>,
     applied_routes: Option<Vec<renderer::spatial_renderer::ChannelRoute>>,
+    /// Bed-entry trim per fixed channel index, cached at plan time so the
+    /// per-metadata-frame event build ([`crate::spatial::build_spatial_channel_events`])
+    /// indexes a slice instead of re-matching label aliases.
+    trims: Vec<i8>,
 }
 
 impl FixedChannelPlanner {
@@ -1067,11 +1071,21 @@ impl FixedChannelPlanner {
         self.planned_labels.clear();
         self.planned_epoch = None;
         self.applied_routes = None;
+        self.trims.clear();
     }
 
     /// Fixed labels of the last planned prefix.
     pub fn fixed_labels(&self) -> &[RChannelLabel] {
         &self.planned_labels
+    }
+
+    /// Bed-entry trim (dB) per fixed channel index, from the last plan.
+    ///
+    /// The stream's own OAMD channel gains re-stamp the bed channels on every
+    /// metadata frame, which would silently undo the plan events' trim; the
+    /// hosts pass this slice to the event build so the two combine instead.
+    pub fn fixed_trims(&self) -> &[i8] {
+        &self.trims
     }
 
     /// Apply a route set computed elsewhere (the fixed-only render path),
@@ -1131,6 +1145,18 @@ impl FixedChannelPlanner {
             )
         };
         let output_layout = renderer.speaker_layout();
+
+        // Trim per fixed channel, mirroring the gain the plan events carry, so
+        // the hosts can fold it into the stream's recurring channel-gain events.
+        let has_back = fixed
+            .iter()
+            .any(|l| matches!(l, RChannelLabel::Lb | RChannelLabel::Rb | RChannelLabel::Cb));
+        self.trims.clear();
+        self.trims.extend(
+            fixed
+                .iter()
+                .map(|l| bed_entry_gain_db(virtual_bed_layout.as_ref(), *l, has_back)),
+        );
 
         match plan_channel_render(
             renderer::live_params::ChannelRenderMode::Spatial,
@@ -2048,6 +2074,79 @@ mod tests {
             planned_positions(&plan_bed(Some(&bed), UNIT_ROOM)),
             planned_positions(&plan_bed(Some(&bed), [1.0, 2.5, 1.0])),
             "a deeper room must move the off-axis objects"
+        );
+    }
+
+    /// A live bed edit reaches a running object stream as a new
+    /// `live.virtual_bed` plus an options-epoch bump (the OSC handler's
+    /// contract). The fixed-prefix planner caches on that epoch: without the
+    /// bump the stream keeps rendering the old bed until the next track
+    /// switch — the regression this test pins, from both sides.
+    #[test]
+    fn live_bed_edit_replans_an_object_stream_prefix() {
+        use renderer::speaker_layout::Speaker;
+        let renderer = crate::renderer_build::build_spatial_renderer(
+            &crate::renderer_build::SpatialRendererParams::from_render_config(None),
+            SpeakerLayout::preset("7.1.4").expect("preset layout"),
+            48_000,
+            bridge_api::RVbapCartesianDefaults {
+                x_size: 9,
+                y_size: 9,
+                z_size: 5,
+                allow_negative_z: true,
+            },
+            bridge_api::RVbapTableMode::Cartesian,
+            None,
+        )
+        .expect("renderer");
+        let control = renderer.renderer_control();
+        let labels = [
+            RChannelLabel::L,
+            RChannelLabel::R,
+            RChannelLabel::C,
+            RChannelLabel::LFE,
+            RChannelLabel::Object,
+        ];
+
+        let mut planner = FixedChannelPlanner::new();
+        let mut out = Vec::new();
+        planner.plan_object_stream_fixed(&labels, &renderer, &mut out);
+        assert!(!out.is_empty(), "initial plan emits the prefix events");
+        assert_eq!(planner.fixed_trims(), &[0, 0, 0, 0], "no bed → unity trims");
+
+        // The edit: LFE trimmed to −6 dB in the bed.
+        let mut lfe = Speaker::new("LFE", 45.0, -10.0);
+        lfe.gain_db = -6;
+        lfe.spatialize = false;
+        control.live.write().virtual_bed = Some(vbed(vec![
+            Speaker::new("L", -30.0, 0.0),
+            Speaker::new("C", 0.0, 0.0),
+            Speaker::new("R", 30.0, 0.0),
+            lfe,
+        ]));
+
+        // Without the epoch bump the plan is (wrongly, if the handler forgot
+        // it) considered current.
+        out.clear();
+        planner.plan_object_stream_fixed(&labels, &renderer, &mut out);
+        assert!(out.is_empty(), "no epoch bump → cached plan");
+
+        control.bump_options_epoch();
+        out.clear();
+        planner.plan_object_stream_fixed(&labels, &renderer, &mut out);
+        let lfe_event = out
+            .iter()
+            .find(|e| e.channel_idx == 3)
+            .expect("LFE event after replan");
+        assert_eq!(
+            lfe_event.gain_db,
+            Some(-6),
+            "replanned event carries the trim"
+        );
+        assert_eq!(
+            planner.fixed_trims(),
+            &[0, 0, 0, -6],
+            "trims exposed for the stream-gain sum"
         );
     }
 

--- a/omniphony-renderer/src/cli/decode/spatial_metadata.rs
+++ b/omniphony-renderer/src/cli/decode/spatial_metadata.rs
@@ -166,6 +166,7 @@ impl<'a> SpatialMetadataCoordinator<'a> {
                 coordinate_format,
                 &self.spatial.object_channels,
                 &meta.channel_gains,
+                self.spatial.fixed_planner.fixed_trims(),
                 meta.sample_pos,
                 meta.ramp_duration,
                 &mut self.spatial.frame_events,


### PR DESCRIPTION
## Summary

Follow-up to #314, which stamped the bed-entry gain into the plan events — correct, but inaudible on object streams (verified by ear on a TrueHD Atmos title, speakers and headphones alike). Two layers above it still swallowed a live edit:

1. **No replan.** The fixed-prefix planner caches on `(labels, options_epoch)`, and the virtual-bed OSC handler bumped neither (`mark_dirty` + `bump_live_state` are both invisible to it). A live bed edit — gain, position or placement — reached a playing object stream only at the next track switch. The channel-stream planner value-compares the bed each frame, which is why fixed-only content was unaffected.
2. **The stream overwrote the trim.** The decoder re-stamps bed-channel gains on every metadata frame (`channel_gains` → `build_spatial_channel_events`), replacing the state the plan events had just seeded.

## Changes

- The `CONTROL_VIRTUAL_BED` handler bumps the options epoch (set and reset branches).
- `FixedChannelPlanner` caches the per-fixed-channel trim at plan time (`fixed_trims()`, a slice indexed by channel — no alias matching in the per-metadata-frame path).
- `build_spatial_channel_events` takes the trims and sums them onto each stream channel gain. The stream stays authoritative for what it carries; the bed trim rides on top; a −128 stream gain remains the −inf sentinel (a trim cannot raise a silenced channel). Both hosts (embedded engine and CLI decode) pass the slice.

## Tests

- Planner-level regression pinning both sides: a bed edit without an epoch bump is cached; the bump replans with the trim in the events and exposed in `fixed_trims()`.
- Builder test pinning the sum, the −inf passthrough, and that channels beyond the trim slice are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)