### PR TITLE
fix(studio): move the channel gain above the Virtual/Direct choice

### DIFF
--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "Die Koordinaten unten zeigen die tatsächliche Lautsprecherposition.",
   "channelEdit.noMatchingSpeaker": "Kein passender Lautsprecher",
   "channelEdit.gain": "Gain",
-  "help.channelEdit.gain": "Ausgangs-Gain dieses festen Quellkanals in dB. Trimmt einen Kanal relativ zu den anderen (z. B. um den LFE abzusenken); 0 dB lässt ihn unverändert.",
+  "help.channelEdit.gain": "Eingangs-Trim dieses Quellkanals in dB, wirksam egal ob der Kanal Virtual oder Direct ist. Trimmt einen Kanal relativ zu den anderen (z. B. um den LFE abzusenken); 0 dB lässt ihn unverändert.",
   "audio.sampleRate": "Abtastrate",
   "layout.label": "Layout:",
   "layout.loading": "Lädt...",

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "The coordinates below are the speaker's actual position.",
   "channelEdit.noMatchingSpeaker": "No matching speaker",
   "channelEdit.gain": "Gain",
-  "help.channelEdit.gain": "Output gain for this fixed source channel, in dB. Trims one channel relative to the others (for example to pull the LFE down); 0 dB leaves it unchanged.",
+  "help.channelEdit.gain": "Input trim for this source channel, in dB, applied whether the channel is Virtual or Direct. Adjusts one channel relative to the others (for example to pull the LFE down); 0 dB leaves it unchanged.",
   "audio.sampleRate": "Sample rate",
   "layout.label": "Layout:",
   "layout.loading": "Loading...",

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "Las coordenadas siguientes son la posición real del altavoz.",
   "channelEdit.noMatchingSpeaker": "No hay altavoz correspondiente",
   "channelEdit.gain": "Ganancia",
-  "help.channelEdit.gain": "Ganancia de salida de este canal fijo, en dB. Ajusta un canal respecto a los demás (por ejemplo para bajar el LFE); 0 dB lo deja sin cambios.",
+  "help.channelEdit.gain": "Recorte de entrada de este canal de origen, en dB, aplicado tanto si el canal es Virtual como Direct. Ajusta un canal respecto a los demás (por ejemplo para bajar el LFE); 0 dB lo deja sin cambios.",
   "audio.sampleRate": "Frecuencia de muestreo",
   "layout.label": "Layout:",
   "layout.loading": "Cargando...",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "Les coordonnées ci-dessous sont la position réelle de l’enceinte.",
   "channelEdit.noMatchingSpeaker": "Aucune enceinte correspondante",
   "channelEdit.gain": "Gain",
-  "help.channelEdit.gain": "Gain de sortie de ce canal fixe, en dB. Ajuste un canal par rapport aux autres (par exemple pour baisser le LFE) ; 0 dB le laisse inchangé.",
+  "help.channelEdit.gain": "Trim d'entrée de ce canal source, en dB, appliqué que le canal soit Virtual ou Direct. Ajuste un canal par rapport aux autres (par exemple pour baisser le LFE) ; 0 dB le laisse inchangé.",
   "audio.sampleRate": "Fréquence d'échantillonnage",
   "layout.label": "Layout :",
   "layout.loading": "Chargement...",

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "Le coordinate sotto indicano la posizione reale del diffusore.",
   "channelEdit.noMatchingSpeaker": "Nessun diffusore corrispondente",
   "channelEdit.gain": "Gain",
-  "help.channelEdit.gain": "Gain di uscita di questo canale fisso, in dB. Regola un canale rispetto agli altri (ad esempio per abbassare l'LFE); 0 dB lo lascia invariato.",
+  "help.channelEdit.gain": "Trim d'ingresso di questo canale sorgente, in dB, applicato sia che il canale sia Virtual sia Direct. Regola un canale rispetto agli altri (ad esempio per abbassare l'LFE); 0 dB lo lascia invariato.",
   "audio.sampleRate": "Frequenza di campionamento",
   "layout.label": "Layout:",
   "layout.loading": "Caricamento...",

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "以下の座標はスピーカーの実際の位置です。",
   "channelEdit.noMatchingSpeaker": "対応するスピーカーがありません",
   "channelEdit.gain": "ゲイン",
-  "help.channelEdit.gain": "この固定チャンネルの出力ゲイン（dB）。他のチャンネルに対して調整します（例: LFE を下げる）。0 dB は変更なし。",
+  "help.channelEdit.gain": "このソースチャンネルの入力トリム（dB）。Virtual／Direct のどちらでも適用されます。他のチャンネルに対して調整します（例: LFE を下げる）。0 dB は変更なし。",
   "audio.sampleRate": "サンプルレート",
   "layout.label": "レイアウト:",
   "layout.loading": "読み込み中...",

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "As coordenadas abaixo são a posição real da caixa.",
   "channelEdit.noMatchingSpeaker": "Nenhuma caixa correspondente",
   "channelEdit.gain": "Ganho",
-  "help.channelEdit.gain": "Ganho de saída deste canal fixo, em dB. Ajusta um canal em relação aos outros (por exemplo para baixar o LFE); 0 dB o deixa inalterado.",
+  "help.channelEdit.gain": "Ajuste de entrada deste canal de origem, em dB, aplicado com o canal em Virtual ou Direct. Ajusta um canal em relação aos outros (por exemplo para baixar o LFE); 0 dB o deixa inalterado.",
   "audio.sampleRate": "Taxa de amostragem",
   "layout.label": "Layout:",
   "layout.loading": "Carregando...",

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -343,7 +343,7 @@
   "channelEdit.destinationPosition": "以下坐标是扬声器的实际位置。",
   "channelEdit.noMatchingSpeaker": "没有匹配的扬声器",
   "channelEdit.gain": "增益",
-  "help.channelEdit.gain": "此固定声道的输出增益（dB）。相对其他声道进行微调（例如降低 LFE）；0 dB 表示不变。",
+  "help.channelEdit.gain": "此源声道的输入微调（dB），无论声道处于 Virtual 还是 Direct 模式都会生效。相对其他声道进行微调（例如降低 LFE）；0 dB 表示不变。",
   "audio.sampleRate": "采样率",
   "layout.label": "布局:",
   "layout.loading": "加载中...",

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -704,6 +704,14 @@
       <div class="info-section" id="channelEditSection" style="display:none">
         <div class="info-title" id="channelEditTitle" data-i18n="channelEdit.title">Channel Editor</div>
         <div id="channelEditBody" class="editor-body">
+          <!-- Gain sits above the Virtual/Direct choice: it is an input trim
+               that applies in both placements, so it must not read as a
+               setting of one of them. -->
+          <div class="editor-row gain-row" style="margin-bottom:0.35rem">
+            <label for="channelEditGainSlider" data-i18n="channelEdit.gain" data-help-i18n="help.channelEdit.gain">Gain</label>
+            <input id="channelEditGainSlider" class="gain-slider" type="range" min="-24" max="12" step="1" value="0" />
+            <div id="channelEditGainBox" class="gain-box">0 dB</div>
+          </div>
           <label class="switch-row" style="cursor:pointer;margin-bottom:0.35rem">
             <span id="channelEditSpatializeText" data-i18n="virtualBed.virtual">Virtual</span>
             <input id="channelEditSpatializeToggle" type="checkbox" />
@@ -760,11 +768,6 @@
               </div>
               <button id="channelEditPolarGizmoBtn" type="button" class="toggle-btn" data-i18n="speaker.edit3d">3D Edit</button>
             </div>
-          </div>
-          <div class="editor-row gain-row">
-            <label for="channelEditGainSlider" data-i18n="channelEdit.gain" data-help-i18n="help.channelEdit.gain">Gain</label>
-            <input id="channelEditGainSlider" class="gain-slider" type="range" min="-24" max="12" step="1" value="0" />
-            <div id="channelEditGainBox" class="gain-box">0 dB</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

In the Studio channel editor the gain slider sat at the very bottom, below the Virtual/Direct switch and the position tables — visually a property of the chosen placement, with no way to tell whether it applies in the other one. It does: it is an input trim on the decoded channel, applied identically in both placements (and since #315, live on a playing stream).

## Changes

- The gain row moves to the top of the editor, above the Virtual/Direct switch: the trim belongs to the channel, the placement only decides where the trimmed signal goes.
- `help.channelEdit.gain` called it an "output gain" — the one thing it is not. Reworded in all eight locales as an input trim that applies whether the channel is Virtual or Direct. `i18n:check` reports full parity.

No logic changes; the JS drives the controls by id and is unaffected by the DOM order. The row moves within the pinned editor section, so the overlay extents are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)