### PR TITLE
fix(renderer): make the speaker test audible on direct (non-spatialized) speakers

### DIFF
--- a/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
@@ -879,7 +879,9 @@ impl SpeakerRenderStage {
     /// (`BandRenderer::speaker_indices`), so the noise goes through the very
     /// same LR4 bank as programme audio and only the bands listing this speaker
     /// are summed. A full-range speaker sums all of them and hears the whole
-    /// signal; a sub hears only its own.
+    /// signal; a sub hears only its own. A direct (non-spatialized) speaker
+    /// appears in no band at all — programme audio bypasses the filter bank on
+    /// its way there, so the test bypasses it too and plays unfiltered.
     ///
     /// `test.level` is a **peak** target, not an RMS one: the contribution
     /// written here never exceeds `±level`, so a level ≤ 1.0 cannot clip. That
@@ -968,10 +970,21 @@ impl SpeakerRenderStage {
         let gain = test.level / crate::speaker_test::PinkNoise::CREST;
         let ceiling = test.level.abs();
 
+        // A speaker listed in no band is a direct (non-spatialized) route —
+        // band membership is computed over spatialized speakers only. Programme
+        // audio reaches such a speaker by bypassing the filter bank entirely
+        // (see the direct-channel path in `mix_channels`), so the test must do
+        // the same: summing "the bands that cover this speaker" would sum
+        // nothing and the test would be silent.
+        let covered = self
+            .render_bands
+            .iter()
+            .any(|band| band.speaker_indices.contains(&test.speaker_idx));
+
         // Sum only the bands this speaker covers. Without a crossover there is
         // one band covering everything, so this degenerates to unfiltered noise.
         match self.crossover_filter_bank.as_ref() {
-            Some(bank) => {
+            Some(bank) if covered => {
                 let states = bank.ensure_states(&mut self.test_filter_states);
                 for f in 0..frames {
                     let raw = self.test_noise.next_sample();
@@ -986,7 +999,7 @@ impl SpeakerRenderStage {
                         (acc * gain).clamp(-ceiling, ceiling);
                 }
             }
-            None => {
+            _ => {
                 for f in 0..frames {
                     let raw = self.test_noise.next_sample();
                     output[f * self.num_speakers + test.speaker_idx] +=

--- a/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
@@ -75,6 +75,18 @@ pub(super) struct SpeakerRenderStage {
     /// `crossover_filter_states`: the test is its own source and must not share
     /// filter memory with an input channel.
     pub(super) test_filter_states: Option<CrossoverStates>,
+    /// Usable frequency range per speaker of THIS stage's layout
+    /// (`(freq_low, freq_high)`, `None` = open end), captured at build time so
+    /// the test can band-limit a direct (non-spatialized) speaker to its own
+    /// range — such a speaker appears in no crossover band.
+    pub(super) speaker_freq_ranges: Vec<(Option<f32>, Option<f32>)>,
+    /// Dedicated LR4 bank splitting at the tested direct speaker's own edges.
+    /// Built lazily when a test targets a direct speaker that declares a
+    /// frequency range; dropped whenever the test identity changes (its edges
+    /// are the tested speaker's own). Always LR4 regardless of the live
+    /// `crossover_type`: a single-speaker test has nothing to phase-align with,
+    /// so the FIR engine's latency would buy nothing.
+    pub(super) test_direct_bank: Option<CrossoverBank>,
     /// Samples the current test has been running, against the safety cap. Reset
     /// whenever the test target or level changes.
     pub(super) test_elapsed_samples: u64,
@@ -791,6 +803,12 @@ impl SpeakerRenderStage {
             bed_delays: Vec::new(),
             test_noise: crate::speaker_test::PinkNoise::default(),
             test_filter_states: None,
+            speaker_freq_ranges: layout
+                .speakers
+                .iter()
+                .map(|s| (s.freq_low, s.freq_high))
+                .collect(),
+            test_direct_bank: None,
             test_elapsed_samples: 0,
             test_identity: None,
             object_test_filter_states: None,
@@ -857,6 +875,12 @@ impl SpeakerRenderStage {
         self.crossover_filter_states.clear();
         self.bed_delays.clear();
         self.test_filter_states = None;
+        self.speaker_freq_ranges = active_layout
+            .speakers
+            .iter()
+            .map(|s| (s.freq_low, s.freq_high))
+            .collect();
+        self.test_direct_bank = None;
         self.object_test_filter_states = None;
         self.crossover_band_scratch.iter_mut().for_each(Vec::clear);
         self.render_bands_topology_identity = topology_identity;
@@ -881,7 +905,10 @@ impl SpeakerRenderStage {
     /// are summed. A full-range speaker sums all of them and hears the whole
     /// signal; a sub hears only its own. A direct (non-spatialized) speaker
     /// appears in no band at all — programme audio bypasses the filter bank on
-    /// its way there, so the test bypasses it too and plays unfiltered.
+    /// its way there — but its declared `freq_low`/`freq_high` still say what
+    /// it can reproduce, so the test band-limits to that range with a
+    /// dedicated LR4 split, and plays unfiltered only when no range is
+    /// declared.
     ///
     /// `test.level` is a **peak** target, not an RMS one: the contribution
     /// written here never exceeds `±level`, so a level ≤ 1.0 cannot clip. That
@@ -917,6 +944,7 @@ impl SpeakerRenderStage {
                 self.test_identity = None;
                 self.test_elapsed_samples = 0;
                 self.test_noise.reset();
+                self.test_direct_bank = None;
             }
             return false;
         };
@@ -934,6 +962,9 @@ impl SpeakerRenderStage {
             if let Some(states) = self.test_filter_states.as_mut() {
                 states.reset();
             }
+            // The dedicated direct-speaker bank splits at the tested speaker's
+            // own edges, so a new target invalidates it.
+            self.test_direct_bank = None;
         }
 
         let frames = output.len() / self.num_speakers;
@@ -971,11 +1002,9 @@ impl SpeakerRenderStage {
         let ceiling = test.level.abs();
 
         // A speaker listed in no band is a direct (non-spatialized) route —
-        // band membership is computed over spatialized speakers only. Programme
-        // audio reaches such a speaker by bypassing the filter bank entirely
-        // (see the direct-channel path in `mix_channels`), so the test must do
-        // the same: summing "the bands that cover this speaker" would sum
-        // nothing and the test would be silent.
+        // band membership is computed over spatialized speakers only, so the
+        // band-summing path below would sum nothing and the test would be
+        // silent. Such a speaker gets the dedicated fallback further down.
         let covered = self
             .render_bands
             .iter()
@@ -1000,10 +1029,52 @@ impl SpeakerRenderStage {
                 }
             }
             _ => {
-                for f in 0..frames {
-                    let raw = self.test_noise.next_sample();
-                    output[f * self.num_speakers + test.speaker_idx] +=
-                        (raw * gain).clamp(-ceiling, ceiling);
+                // Direct (non-spatialized) speaker, or no crossover at all.
+                // Programme audio reaches a direct speaker by bypassing the
+                // filter bank (see the direct-channel path in `mix_channels`),
+                // but the speaker's declared frequency range still says what
+                // it can reproduce — so the test honours it with a dedicated
+                // LR4 split at the speaker's own edges, and only falls back to
+                // unfiltered noise when no range is declared. `lo < hi` guards
+                // a degenerate range, whose middle band would be near-silence.
+                let (lo, hi) = self
+                    .speaker_freq_ranges
+                    .get(test.speaker_idx)
+                    .copied()
+                    .unwrap_or((None, None));
+                let range_valid = match (lo, hi) {
+                    (Some(lo), Some(hi)) => lo < hi,
+                    (None, None) => false,
+                    _ => true,
+                };
+                if range_valid {
+                    if self.test_direct_bank.is_none() {
+                        // Built once per test start (identity change drops it),
+                        // not in the steady-state path.
+                        let edges: Vec<f32> = [lo, hi].into_iter().flatten().collect();
+                        self.test_direct_bank = Some(CrossoverBank::Lr4(LR4CrossoverBank::new(
+                            &edges,
+                            self.sample_rate,
+                        )));
+                    }
+                    let bank = self.test_direct_bank.as_ref().expect("just built");
+                    let states = bank.ensure_states(&mut self.test_filter_states);
+                    // Bands are [0, lo), [lo, hi), [hi, ∞) minus the absent
+                    // edges — the speaker's own band is right after the low
+                    // split when there is one.
+                    let keep = usize::from(lo.is_some());
+                    for f in 0..frames {
+                        let raw = self.test_noise.next_sample();
+                        let bands = bank.process_sample(raw, states);
+                        output[f * self.num_speakers + test.speaker_idx] +=
+                            (bands.get(keep) * gain).clamp(-ceiling, ceiling);
+                    }
+                } else {
+                    for f in 0..frames {
+                        let raw = self.test_noise.next_sample();
+                        output[f * self.num_speakers + test.speaker_idx] +=
+                            (raw * gain).clamp(-ceiling, ceiling);
+                    }
                 }
             }
         }

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -2076,6 +2076,12 @@ fn crossover_renderer() -> SpatialRenderer {
     layout.speakers[1].freq_high = Some(2000.0);
     layout.speakers[2].freq_low = Some(2000.0);
     layout.speakers[2].freq_high = None;
+    renderer_for_layout(layout)
+}
+
+/// Build a renderer over an arbitrary layout with the same defaults as
+/// [`crossover_renderer`].
+fn renderer_for_layout(layout: SpeakerLayout) -> SpatialRenderer {
     SpatialRenderer::new(
         layout,
         48_000,
@@ -2203,10 +2209,11 @@ fn speaker_test_is_limited_to_the_speakers_bands() {
 ///
 /// Band membership is computed over spatialized speakers only, so a direct
 /// speaker appears in no band; the original band-summing injection summed
-/// nothing for it and the test was silent. Programme audio reaches a direct
-/// speaker by bypassing the filter bank, so the test must play unfiltered
-/// there — asserted by comparing its slew ratio against the sub's: identical
-/// low-passed noise on both would mean the fallback did not engage.
+/// nothing for it and the test was silent. A direct speaker that declares no
+/// frequency range plays the test unfiltered (programme audio reaches it by
+/// bypassing the filter bank, and nothing says what to cut) — asserted by
+/// comparing its slew ratio against the sub's: identical low-passed noise on
+/// both would mean the fallback did not engage.
 #[test]
 fn speaker_test_reaches_a_direct_speaker_despite_the_crossover() {
     let frames = 4096;
@@ -2250,6 +2257,66 @@ fn speaker_test_reaches_a_direct_speaker_despite_the_crossover() {
          (direct {:.4}, sub {:.4})",
         slew(&direct),
         slew(&sub)
+    );
+}
+
+/// A direct speaker that declares a frequency range gets a band-limited test,
+/// even though it belongs to no crossover band.
+///
+/// Programme audio bypasses the filter bank on its way to a direct speaker,
+/// but `freq_low`/`freq_high` still describe what it can reproduce — a
+/// direct-routed sub must not be fed full-range noise. The injection builds a
+/// dedicated LR4 split at the speaker's own edges instead. Asserted like
+/// `speaker_test_is_limited_to_the_speakers_bands`: a direct sub cut at 80 Hz
+/// must slew like the spatialized sub's band, far below the tweeter's.
+#[test]
+fn a_direct_speakers_test_honours_its_declared_frequency_range() {
+    let frames = 4096;
+    let pcm = vec![0.0f32; frames];
+
+    let mut channel_for = |idx: usize, freq_high: Option<f32>| -> Vec<f32> {
+        let mut layout = SpeakerLayout::preset("7.1.4").unwrap();
+        layout.speakers[0].freq_low = None;
+        layout.speakers[0].freq_high = Some(80.0);
+        layout.speakers[1].freq_low = Some(80.0);
+        layout.speakers[1].freq_high = Some(2000.0);
+        layout.speakers[2].freq_low = Some(2000.0);
+        layout.speakers[2].freq_high = None;
+        // Speaker 3 is the LFE, the preset's one non-spatialized speaker.
+        assert!(!layout.speakers[3].spatialize);
+        layout.speakers[3].freq_high = freq_high;
+        let mut r = renderer_for_layout(layout);
+        r.control.live.write().speaker_test = Some(crate::live_params::SpeakerTest {
+            speaker_idx: idx,
+            level: 0.1,
+            isolation: crate::live_params::TestIsolation::TestOnly,
+        });
+        let out = r.render_frame(&pcm, 1, &[], Vec::new(), false).unwrap();
+        let n = out.n_channels;
+        (0..frames).map(|f| out.samples[f * n + idx]).collect()
+    };
+
+    let slew = |ch: &[f32]| -> f32 {
+        let amp: f32 = ch.iter().map(|s| s.abs()).sum::<f32>() / ch.len() as f32;
+        assert!(amp > 0.0, "speaker produced no test signal");
+        let step: f32 =
+            ch.windows(2).map(|w| (w[1] - w[0]).abs()).sum::<f32>() / (ch.len() - 1) as f32;
+        step / amp
+    };
+
+    let direct_sub = slew(&channel_for(3, Some(80.0)));
+    let spatial_sub = slew(&channel_for(0, None));
+    let top = slew(&channel_for(2, None));
+
+    assert!(
+        direct_sub < top * 0.25,
+        "a direct speaker cut at 80 Hz must be band-limited, not full-range \
+         (direct sub {direct_sub:.4}, top {top:.4})"
+    );
+    assert!(
+        direct_sub < spatial_sub * 2.0 && spatial_sub < direct_sub * 2.0,
+        "the direct sub's band must move like the spatialized sub's \
+         (direct sub {direct_sub:.4}, spatialized sub {spatial_sub:.4})"
     );
 }
 

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -2198,6 +2198,61 @@ fn speaker_test_is_limited_to_the_speakers_bands() {
     );
 }
 
+/// A direct (non-spatialized) speaker must still produce a test signal when a
+/// crossover is active.
+///
+/// Band membership is computed over spatialized speakers only, so a direct
+/// speaker appears in no band; the original band-summing injection summed
+/// nothing for it and the test was silent. Programme audio reaches a direct
+/// speaker by bypassing the filter bank, so the test must play unfiltered
+/// there — asserted by comparing its slew ratio against the sub's: identical
+/// low-passed noise on both would mean the fallback did not engage.
+#[test]
+fn speaker_test_reaches_a_direct_speaker_despite_the_crossover() {
+    let frames = 4096;
+    let pcm = vec![0.0f32; frames];
+
+    // The fixture is the 7.1.4 preset: speaker 3 is the LFE, the preset's one
+    // non-spatialized speaker.
+    assert!(!SpeakerLayout::preset("7.1.4").unwrap().speakers[3].spatialize);
+
+    let mut channel_for = |idx: usize| -> Vec<f32> {
+        let mut r = crossover_renderer();
+        r.control.live.write().speaker_test = Some(crate::live_params::SpeakerTest {
+            speaker_idx: idx,
+            level: 0.1,
+            isolation: crate::live_params::TestIsolation::TestOnly,
+        });
+        let out = r.render_frame(&pcm, 1, &[], Vec::new(), false).unwrap();
+        let n = out.n_channels;
+        (0..frames).map(|f| out.samples[f * n + idx]).collect()
+    };
+
+    let direct = channel_for(3);
+    let amp: f32 = direct.iter().map(|s| s.abs()).sum::<f32>() / frames as f32;
+    assert!(
+        amp > 0.0,
+        "the direct (non-spatialized) speaker must produce a test signal"
+    );
+
+    // Unfiltered, not accidentally low-passed: full-range noise slews far
+    // faster than the sub's 80 Hz band.
+    let sub = channel_for(0);
+    let slew = |ch: &[f32]| -> f32 {
+        let amp: f32 = ch.iter().map(|s| s.abs()).sum::<f32>() / ch.len() as f32;
+        let step: f32 =
+            ch.windows(2).map(|w| (w[1] - w[0]).abs()).sum::<f32>() / (ch.len() - 1) as f32;
+        step / amp
+    };
+    assert!(
+        slew(&direct) > slew(&sub) * 4.0,
+        "the direct speaker's test must be full-range, not band-limited \
+         (direct {:.4}, sub {:.4})",
+        slew(&direct),
+        slew(&sub)
+    );
+}
+
 /// A test at full scale must not put a single sample past full scale.
 ///
 /// This is the regression guard for the bug that shipped in the original test


### PR DESCRIPTION
## Problem

Starting a pink-noise speaker test on a non-spatialized speaker (e.g. the LFE, which is direct-routed in the stock layouts) produced **no sound at all** whenever a crossover was active.

## Cause

`compute_bands` builds `FreqBand::speaker_indices` over **spatialized speakers only** — a direct speaker appears in no band. `inject_speaker_test` sums "the bands covering the speaker under test", which for a direct speaker sums nothing, so the injected contribution was exactly zero.

## Fix

Two-part fallback for a speaker covered by no band:

1. **Declared range** — a direct speaker's `freq_low`/`freq_high` still describe what it can reproduce (a direct-routed sub must not be fed full-range noise), so the test builds a dedicated LR4 split at the speaker's own edges and plays only the band inside its range. Always LR4 regardless of the live `crossover_type`: a single-speaker test has nothing to phase-align with. Built once per test start, dropped on identity change / topology refresh.
2. **No range declared** — unfiltered noise, mirroring how programme audio reaches a direct speaker (the direct-channel path bypasses the filter bank entirely).

Filtered behaviour for spatialized speakers is unchanged.

## Tests

- `speaker_test_reaches_a_direct_speaker_despite_the_crossover`: the 7.1.4 preset's LFE (no declared range) must produce signal, and that signal must be full-range. Verified to fail (silence) on the pre-fix code.
- `a_direct_speakers_test_honours_its_declared_frequency_range`: a direct speaker cut at 80 Hz must slew like the spatialized sub's band, far below the tweeter's — full-range noise on it would fail.

`cargo fmt --check` clean; full `renderer` suite (326 tests) + doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)