### PR TITLE
feat(renderer): give the bed channel gain 0.1 dB resolution

### DIFF
--- a/omniphony-renderer/dsp_fixtures/src/scene.rs
+++ b/omniphony-renderer/dsp_fixtures/src/scene.rs
@@ -222,7 +222,7 @@ pub fn move_events(n_objects: usize, seed_round: u64) -> Vec<SpatialChannelEvent
             SpatialChannelEvent {
                 channel_idx: ch,
                 is_bed: false,
-                gain_db: Some(0),
+                gain_db: Some(0.0),
                 ramp_length: Some(BLOCK_SAMPLES as u32),
                 size: Some([0.0, 0.0, 0.0]),
                 position: Some([
@@ -256,7 +256,7 @@ pub fn drift_events(n_objects: usize, seed_round: u64) -> Vec<SpatialChannelEven
             SpatialChannelEvent {
                 channel_idx: ch,
                 is_bed: false,
-                gain_db: Some(0),
+                gain_db: Some(0.0),
                 ramp_length: Some(BLOCK_SAMPLES as u32),
                 size: Some([0.0, 0.0, 0.0]),
                 position: Some([az.sin(), az.cos(), (ch % 5) as f64 * 0.25]),
@@ -504,7 +504,7 @@ pub fn render_single_object_binaural(
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(BLOCK_SAMPLES as u32),
         size: Some([0.0, 0.0, 0.0]),
         position: Some(position),

--- a/omniphony-renderer/orender_engine/src/channel_objects.rs
+++ b/omniphony-renderer/orender_engine/src/channel_objects.rs
@@ -167,7 +167,7 @@ impl ChannelObjectStages {
             .map(move |(index, spec)| SpatialChannelEvent {
                 channel_idx: channel_count + index,
                 is_bed: false,
-                gain_db: Some(spec.gain_db),
+                gain_db: Some(f32::from(spec.gain_db)),
                 ramp_length: Some(0),
                 size: Some(spec.size),
                 position: Some(spec.position),
@@ -190,7 +190,7 @@ impl ChannelObjectStages {
             z: spec.position[2] as f32,
             coord_mode: "cartesian".to_string(),
             direct_speaker_index: None,
-            gain: spec.gain_db as i32,
+            gain: f32::from(spec.gain_db),
             priority: 0.0,
             size: spec.size,
             fixed: false,

--- a/omniphony-renderer/orender_engine/src/osc.rs
+++ b/omniphony-renderer/orender_engine/src/osc.rs
@@ -248,7 +248,7 @@ pub struct ObjectMeta {
     pub coord_mode: String,
     pub direct_speaker_index: Option<u32>,
     /// Gain in dB (integer, -128 = silent).
-    pub gain: i32,
+    pub gain: f32,
     pub priority: f32,
     /// Per-axis object spatial extent (w, d, h), each in [0.0, 1.0].
     /// `[0.0, 0.0, 0.0]` denotes a point source.
@@ -281,7 +281,7 @@ struct ObjectSnapshot {
     z: f32,
     coord_mode: String,
     direct_speaker_index: Option<u32>,
-    gain: i32,
+    gain: f32,
     priority: f32,
     size: [f32; 3],
 }

--- a/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
+++ b/omniphony-renderer/orender_engine/src/osc/metadata_emit.rs
@@ -179,7 +179,9 @@ impl OscSender {
                         OscType::Float(obj.y),
                         OscType::Float(obj.z),
                         OscType::Int(obj.direct_speaker_index.map(|v| v as i32).unwrap_or(-1)),
-                        OscType::Int(obj.gain),
+                        // The wire stays Int: the native mpv overlay parses this tag, and it
+                        // is display-only — the editor reads the bed itself, not this frame.
+                        OscType::Int(obj.gain.round() as i32),
                         OscType::Float(obj.priority),
                         OscType::Int(ramp_duration as i32),
                         OscType::Long(self.content_generation as i64),

--- a/omniphony-renderer/orender_engine/src/spatial.rs
+++ b/omniphony-renderer/orender_engine/src/spatial.rs
@@ -63,7 +63,9 @@ pub fn build_object_metas(
                 z: z as f32,
                 coord_mode: fallback_coord_mode(),
                 direct_speaker_index: None,
-                gain: event.gain_db().map_or(-128, |g| g as i32),
+                gain: event
+                    .gain_db()
+                    .map_or(renderer::spatial_renderer::GAIN_DB_NEG_INF, f32::from),
                 priority: 0.0,
                 size: event
                     .size()
@@ -120,17 +122,17 @@ pub fn build_spatial_channel_events(
     coordinate_format: RCoordinateFormat,
     object_channels: &[(u32, usize)],
     channel_gains: &[RChannelGain],
-    bed_trims: &[i8],
+    bed_trims: &[f32],
     sample_pos: u64,
     ramp_duration: u32,
     out: &mut Vec<SpatialChannelEvent>,
 ) {
     for gain in channel_gains {
-        let trim = bed_trims.get(gain.channel as usize).copied().unwrap_or(0);
+        let trim = bed_trims.get(gain.channel as usize).copied().unwrap_or(0.0);
         let gain_db = if gain.gain_db == i8::MIN {
-            i8::MIN
+            renderer::spatial_renderer::GAIN_DB_NEG_INF
         } else {
-            gain.gain_db.saturating_add(trim)
+            (f32::from(gain.gain_db) + trim).max(renderer::spatial_renderer::GAIN_DB_NEG_INF)
         };
         out.push(SpatialChannelEvent {
             channel_idx: gain.channel as usize,
@@ -154,7 +156,7 @@ pub fn build_spatial_channel_events(
         out.push(SpatialChannelEvent {
             channel_idx,
             is_bed: false,
-            gain_db: event.gain_db(),
+            gain_db: event.gain_db().map(f32::from),
             ramp_length: event.ramp_length(),
             size: event
                 .size()
@@ -211,7 +213,7 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert!(out[0].is_bed);
         assert_eq!(out[0].channel_idx, 2);
-        assert_eq!(out[0].gain_db, Some(-3));
+        assert_eq!(out[0].gain_db, Some(-3.0));
         assert_eq!(out[0].ramp_length, Some(32));
         assert_eq!(out[0].sample_pos, Some(480));
         assert!(!out[1].is_bed);
@@ -239,7 +241,7 @@ mod tests {
                 gain_db: 2,
             },
         ];
-        let trims = [-6i8, -6, 0, 0];
+        let trims = [-6.0f32, -6.0, 0.0, 0.0];
 
         let mut out = Vec::new();
         build_spatial_channel_events(
@@ -253,9 +255,13 @@ mod tests {
             &mut out,
         );
 
-        assert_eq!(out[0].gain_db, Some(-9), "stream −3 + trim −6");
-        assert_eq!(out[1].gain_db, Some(i8::MIN), "−inf stays −inf");
-        assert_eq!(out[2].gain_db, Some(2), "no trim entry → unchanged");
+        assert_eq!(out[0].gain_db, Some(-9.0), "stream −3 + trim −6");
+        assert_eq!(
+            out[1].gain_db,
+            Some(renderer::spatial_renderer::GAIN_DB_NEG_INF),
+            "−inf stays −inf"
+        );
+        assert_eq!(out[2].gain_db, Some(2.0), "no trim entry → unchanged");
     }
 
     #[test]
@@ -271,7 +277,7 @@ mod tests {
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].name, "Music");
         assert_eq!(metas[0].direct_speaker_index, None);
-        assert_eq!(metas[0].gain, -3);
+        assert_eq!(metas[0].gain, -3.0);
         assert!((metas[0].x - 0.1).abs() < 1e-6);
     }
 

--- a/omniphony-renderer/orender_engine/src/virtual_bed.rs
+++ b/omniphony-renderer/orender_engine/src/virtual_bed.rs
@@ -583,7 +583,7 @@ pub fn build_virtual_bed_objects(
         // Per-channel gain from the virtual bed (dB); 0 = unity when unset.
         let gain = find_virtual_bed_entry(virtual_bed, *label, use_7_1)
             .map(|entry| entry.gain_db)
-            .unwrap_or(0);
+            .unwrap_or(0.0);
         objects.push(ObjectMeta {
             name,
             x,
@@ -631,17 +631,25 @@ fn find_virtual_bed_entry(
     })
 }
 
-/// The bed entry's `gain_db` as an audio-event gain: clamped into the event's
-/// `i8` domain (where −128 is the −inf sentinel — a bare cast would wrap),
-/// unity when the bed has no entry for the label.
+/// The bed entry's `gain_db` as an audio-event gain: clamped into the event
+/// domain (where `GAIN_DB_NEG_INF` = −128 is the −inf floor), unity when the
+/// bed has no entry for the label. Carried as `f32` end to end so the editor's
+/// 0.1 dB steps survive — the whole-dB `i8` lives only on the decoder side.
 ///
 /// The event is what the render paths consume; `ObjectMeta.gain` is only the
 /// Studio/OSC display value. Stamping the entry gain here is what makes the
 /// bed editor's per-channel gain reach the sound (#220).
-fn bed_entry_gain_db(layout: Option<&SpeakerLayout>, label: RChannelLabel, use_7_1: bool) -> i8 {
+fn bed_entry_gain_db(layout: Option<&SpeakerLayout>, label: RChannelLabel, use_7_1: bool) -> f32 {
     find_virtual_bed_entry(layout, label, use_7_1)
-        .map(|entry| entry.gain_db.clamp(i8::MIN as i32, i8::MAX as i32) as i8)
-        .unwrap_or(0)
+        .map(|entry| {
+            let db = entry.gain_db;
+            if db.is_finite() {
+                db.clamp(renderer::spatial_renderer::GAIN_DB_NEG_INF, 127.0)
+            } else {
+                0.0
+            }
+        })
+        .unwrap_or(0.0)
 }
 
 /// Whether a channel should be virtualized (`true`) or routed direct to its
@@ -1058,7 +1066,7 @@ pub struct FixedChannelPlanner {
     /// Bed-entry trim per fixed channel index, cached at plan time so the
     /// per-metadata-frame event build ([`crate::spatial::build_spatial_channel_events`])
     /// indexes a slice instead of re-matching label aliases.
-    trims: Vec<i8>,
+    trims: Vec<f32>,
 }
 
 impl FixedChannelPlanner {
@@ -1084,7 +1092,7 @@ impl FixedChannelPlanner {
     /// The stream's own OAMD channel gains re-stamp the bed channels on every
     /// metadata frame, which would silently undo the plan events' trim; the
     /// hosts pass this slice to the event build so the two combine instead.
-    pub fn fixed_trims(&self) -> &[i8] {
+    pub fn fixed_trims(&self) -> &[f32] {
         &self.trims
     }
 
@@ -1462,7 +1470,7 @@ mod tests {
         use renderer::speaker_layout::Speaker;
         // A virtual bed sets C to -6 dB; channels with no explicit gain stay at 0.
         let mut center = Speaker::new("C", 0.0, 0.0);
-        center.gain_db = -6;
+        center.gain_db = -6.0;
         let bed = vbed(vec![
             Speaker::new("L", -30.0, 0.0),
             center,
@@ -1484,9 +1492,9 @@ mod tests {
             .iter()
             .find(|o| o.name.eq_ignore_ascii_case("C"))
             .expect("C object present");
-        assert_eq!(c.gain, -6, "C gain comes from the virtual bed");
+        assert_eq!(c.gain, -6.0, "C gain comes from the virtual bed");
         for obj in objects.iter().filter(|o| !o.name.eq_ignore_ascii_case("C")) {
-            assert_eq!(obj.gain, 0, "{} has no configured gain", obj.name);
+            assert_eq!(obj.gain, 0.0, "{} has no configured gain", obj.name);
         }
     }
 
@@ -1499,9 +1507,9 @@ mod tests {
         // a spatialized channel (C) and a direct-routed one (LFE).
         use renderer::speaker_layout::Speaker;
         let mut c = Speaker::new("C", 0.0, 0.0);
-        c.gain_db = -6;
+        c.gain_db = -6.5;
         let mut lfe = Speaker::new("LFE", 45.0, -10.0);
-        lfe.gain_db = -6;
+        lfe.gain_db = -6.5;
         lfe.spatialize = false;
         let bed = vbed(vec![
             Speaker::new("L", -30.0, 0.0),
@@ -1538,13 +1546,13 @@ mod tests {
                 .gain_db
         };
 
-        assert_eq!(gain_of(1), Some(-6), "spatialized C carries the bed gain");
+        assert_eq!(gain_of(1), Some(-6.5), "spatialized C carries the bed gain");
         assert_eq!(
             gain_of(3),
-            Some(-6),
+            Some(-6.5),
             "direct-routed LFE carries the bed gain"
         );
-        assert_eq!(gain_of(0), Some(0), "unset entries stay at unity");
+        assert_eq!(gain_of(0), Some(0.0), "unset entries stay at unity");
     }
 
     #[test]
@@ -1554,7 +1562,7 @@ mod tests {
         // the −inf sentinel instead (and symmetrically on the positive side).
         use renderer::speaker_layout::Speaker;
         let mut c = Speaker::new("C", 0.0, 0.0);
-        c.gain_db = -200;
+        c.gain_db = -200.0;
         let bed = vbed(vec![
             Speaker::new("L", -30.0, 0.0),
             c,
@@ -1578,7 +1586,11 @@ mod tests {
             .iter()
             .find(|e| e.channel_idx == 1)
             .expect("C event present");
-        assert_eq!(c_event.gain_db, Some(i8::MIN), "clamped, not wrapped");
+        assert_eq!(
+            c_event.gain_db,
+            Some(renderer::spatial_renderer::GAIN_DB_NEG_INF),
+            "clamped to the −inf floor"
+        );
     }
 
     #[test]
@@ -2112,11 +2124,15 @@ mod tests {
         let mut out = Vec::new();
         planner.plan_object_stream_fixed(&labels, &renderer, &mut out);
         assert!(!out.is_empty(), "initial plan emits the prefix events");
-        assert_eq!(planner.fixed_trims(), &[0, 0, 0, 0], "no bed → unity trims");
+        assert_eq!(
+            planner.fixed_trims(),
+            &[0.0, 0.0, 0.0, 0.0],
+            "no bed → unity trims"
+        );
 
         // The edit: LFE trimmed to −6 dB in the bed.
         let mut lfe = Speaker::new("LFE", 45.0, -10.0);
-        lfe.gain_db = -6;
+        lfe.gain_db = -6.5;
         lfe.spatialize = false;
         control.live.write().virtual_bed = Some(vbed(vec![
             Speaker::new("L", -30.0, 0.0),
@@ -2140,12 +2156,12 @@ mod tests {
             .expect("LFE event after replan");
         assert_eq!(
             lfe_event.gain_db,
-            Some(-6),
+            Some(-6.5),
             "replanned event carries the trim"
         );
         assert_eq!(
             planner.fixed_trims(),
-            &[0, 0, 0, -6],
+            &[0.0, 0.0, 0.0, -6.5],
             "trims exposed for the stream-gain sum"
         );
     }

--- a/omniphony-renderer/renderer/examples/gain_modes.rs
+++ b/omniphony-renderer/renderer/examples/gain_modes.rs
@@ -72,7 +72,7 @@ fn gains_at(r: &mut SpatialRenderer, p: [f64; 3]) -> Vec<f32> {
     let ev = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(0),
         size: Some([0.0, 0.0, 0.0]),
         position: Some(p),

--- a/omniphony-renderer/renderer/src/spatial_renderer/components.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/components.rs
@@ -127,6 +127,23 @@ pub(super) fn evaluation_build_config(
     }
 }
 
+/// Event/channel gain floor: at or below this the channel is −inf dB (silent).
+///
+/// Inherited from the decoder side's `i8` convention where −128 is the mute
+/// sentinel; sums that land below it clamp to exactly this value, so a plain
+/// `<=` comparison is the whole test.
+pub const GAIN_DB_NEG_INF: f32 = -128.0;
+
+/// Linear gain for an event/channel dB value, honouring the −inf floor.
+#[inline]
+pub fn gain_db_to_linear(gain_db: f32) -> f32 {
+    if gain_db <= GAIN_DB_NEG_INF {
+        0.0
+    } else {
+        10.0_f32.powf(gain_db / 20.0)
+    }
+}
+
 /// Format-agnostic spatial metadata for one audio channel (bed or object).
 ///
 /// The renderer accepts this type instead of any format-specific event type
@@ -141,8 +158,11 @@ pub struct SpatialChannelEvent {
     pub channel_idx: usize,
     /// `true` → direct speaker routing (bed); `false` → VBAP spatialization (object).
     pub is_bed: bool,
-    /// Channel gain in dB (`None` = unchanged).
-    pub gain_db: Option<i8>,
+    /// Channel gain in dB (`None` = unchanged). Values at or below
+    /// [`GAIN_DB_NEG_INF`] mean −inf (silent); stream metadata arrives in
+    /// whole dB (the decoder side is `i8`), fractional values come from the
+    /// virtual bed's 0.1 dB trim.
+    pub gain_db: Option<f32>,
     /// Ramp duration in audio frames (`None` = unchanged).
     pub ramp_length: Option<u32>,
     /// Object spatial extent per axis (w, d, h), each in [0.0, 1.0]
@@ -168,8 +188,8 @@ pub(super) struct ChannelState {
     /// silent.
     pub(super) initialized: bool,
 
-    /// Gain in dB
-    pub(super) gain_db: i8,
+    /// Gain in dB. At or below [`GAIN_DB_NEG_INF`] the channel is silent.
+    pub(super) gain_db: f32,
 
     /// Linear gain actually applied at the end of the last rendered block.
     /// Every gain step (metadata jump, mute toggle, plan transition, stream
@@ -217,7 +237,7 @@ impl Default for ChannelState {
     fn default() -> Self {
         Self {
             initialized: false,
-            gain_db: -128, // -inf dB (muted)
+            gain_db: GAIN_DB_NEG_INF, // -inf dB (muted)
             slewed_gain: 0.0,
             ramp: ChannelRampState::default(),
             interp_prev_gains: Vec::new(),

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -78,7 +78,7 @@ mod components;
 mod construction;
 mod speaker_stage;
 use components::{ChannelState, evaluation_build_config};
-pub use components::{RenderedFrame, SpatialChannelEvent};
+pub use components::{GAIN_DB_NEG_INF, RenderedFrame, SpatialChannelEvent, gain_db_to_linear};
 use speaker_stage::SpeakerRenderStage;
 
 /// Snapshot of `LiveParams` taken at the start of each render frame.
@@ -892,17 +892,13 @@ impl SpatialRenderer {
                             _ => 1.0,
                         };
                         // Stream metadata gain, same semantics as the VBAP path:
-                        // silent (-128 = -inf dB) until the first metadata arrives.
+                        // silent (−inf floor) until the first metadata arrives.
                         let gain_db = states
                             .get(c)
                             .filter(|s| s.initialized)
                             .map(|s| s.gain_db)
-                            .unwrap_or(-128);
-                        let gain_linear = if gain_db == -128 {
-                            0.0
-                        } else {
-                            10.0_f32.powf(gain_db as f32 / 20.0)
-                        };
+                            .unwrap_or(components::GAIN_DB_NEG_INF);
+                        let gain_linear = components::gain_db_to_linear(gain_db);
                         // Slewed like the VBAP path (block-end value: the binaural
                         // stage updates per block anyway).
                         let ramp_samples = self.sample_rate as f32 * GAIN_SLEW_SECS;

--- a/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
@@ -256,12 +256,8 @@ impl SpeakerRenderStage {
             let state = SpatialRenderer::state_mut(channel_states, input_channel_idx);
             let gain_db = state.gain_db;
 
-            // Convert gain from dB to linear
-            let gain_linear = if gain_db == -128 {
-                0.0 // -inf dB
-            } else {
-                10.0_f32.powf(gain_db as f32 / 20.0)
-            };
+            // Convert gain from dB to linear (−inf floor honoured).
+            let gain_linear = super::components::gain_db_to_linear(gain_db);
             // Slewed per-sample gain factor (includes the mute 0/1 factor):
             // factor(s) = gain_start + gain_step * s.
             let ramp_samples = self.sample_rate as f32 * GAIN_SLEW_SECS;

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -75,7 +75,7 @@ fn unified_crossover_matches_per_band() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.3, -0.2, 0.4]),
@@ -160,7 +160,7 @@ fn unified_polar_matches_per_band() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.3, -0.2, 0.4]),
@@ -263,7 +263,7 @@ fn unified_table_with_two_speaker_fallback_band() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.3, -0.2, 0.4]),
@@ -498,7 +498,7 @@ fn virtual_bed_mixes_direct_and_virtualized_channels() {
         SpatialChannelEvent {
             channel_idx: 0,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: Some([0.0, 0.0, 0.0]),
             position: Some([0.0, 1.0, 0.0]), // front-centre object
@@ -507,7 +507,7 @@ fn virtual_bed_mixes_direct_and_virtualized_channels() {
         SpatialChannelEvent {
             channel_idx: 1,
             is_bed: true,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: None,
             position: None,
@@ -638,7 +638,7 @@ fn spatialized_lfe_alone_in_low_band_routes_object_bass() {
         let events = vec![SpatialChannelEvent {
             channel_idx: 0,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: Some([0.0, 0.0, 0.0]),
             position: Some([0.0, 1.0, 0.0]),
@@ -705,7 +705,7 @@ fn spatialized_lfe_alone_in_low_band_routes_object_bass() {
         SpatialChannelEvent {
             channel_idx: 0,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: Some([0.0, 0.0, 0.0]),
             position: Some([0.0, 1.0, 0.0]),
@@ -714,7 +714,7 @@ fn spatialized_lfe_alone_in_low_band_routes_object_bass() {
         SpatialChannelEvent {
             channel_idx: 1,
             is_bed: true,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: None,
             position: None,
@@ -804,7 +804,7 @@ fn all_four_ramp_modes_render_distinctly() {
         vec![SpatialChannelEvent {
             channel_idx: 0,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(40),
             size: Some([0.0, 0.0, 0.0]),
             position: Some(position),
@@ -936,7 +936,7 @@ fn binaural_object_ramp_advances_and_lateralizes() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([1.0, 0.0, 0.0]),
@@ -1034,7 +1034,7 @@ fn binaural_output_follows_master_gain() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.5, 1.0, 0.0]),
@@ -1127,7 +1127,7 @@ fn binaural_ear_mute_uses_dedicated_ear_params() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.0, 1.0, 0.0]),
@@ -1201,7 +1201,7 @@ fn binaural_clipping_flags_ear_and_auto_gain_reduces_master() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.5, 1.0, 0.0]),
@@ -1309,7 +1309,7 @@ fn binaural_lfe_bed_feeds_both_ears_equally_and_dry() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: true,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(0),
         size: None,
         position: None,
@@ -1430,7 +1430,7 @@ speakers:
         let event = vec![SpatialChannelEvent {
             channel_idx: 0,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: None,
             position: Some(pos),
@@ -1559,7 +1559,7 @@ fn cascaded_binaural_builds_stage_and_lateralizes() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([1.0, 0.0, 0.0]),
@@ -1632,7 +1632,7 @@ fn cascaded_matches_direct_at_virtual_speaker_direction() {
         let event = vec![SpatialChannelEvent {
             channel_idx: 0,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: Some([0.0, 0.0, 0.0]),
             position: Some(pos),
@@ -1685,7 +1685,7 @@ fn cascaded_binaural_follows_master_gain() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.5, 1.0, 0.0]),
@@ -1737,7 +1737,7 @@ fn cascaded_lfe_routes_direct_to_both_ears() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: true,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(0),
         size: None,
         position: None,
@@ -1790,7 +1790,7 @@ fn interp_survives_speaker_cascade_width_switch() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.4, 0.6, 0.2]),
@@ -1908,7 +1908,7 @@ fn rendered_frame_reports_the_geometry_it_produced() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(frames as u32),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.3, -0.2, 0.4]),
@@ -2009,7 +2009,7 @@ fn an_output_mode_change_is_ramped_not_stepped() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(frames as u32),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.3, -0.2, 0.4]),
@@ -2531,7 +2531,7 @@ fn a_recycled_output_buffer_renders_identically_to_a_fresh_one() {
     let event = vec![SpatialChannelEvent {
         channel_idx: 0,
         is_bed: false,
-        gain_db: Some(0),
+        gain_db: Some(0.0),
         ramp_length: Some(40),
         size: Some([0.0, 0.0, 0.0]),
         position: Some([0.3, -0.2, 0.4]),
@@ -2577,7 +2577,7 @@ fn fir_crossover_keeps_beds_aligned_with_objects() {
         SpatialChannelEvent {
             channel_idx: 0,
             is_bed: true,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: None,
             position: None,
@@ -2586,7 +2586,7 @@ fn fir_crossover_keeps_beds_aligned_with_objects() {
         SpatialChannelEvent {
             channel_idx: 1,
             is_bed: false,
-            gain_db: Some(0),
+            gain_db: Some(0.0),
             ramp_length: Some(0),
             size: Some([0.0, 0.0, 0.0]),
             position: Some([0.0, 1.0, 0.0]),

--- a/omniphony-renderer/renderer/src/speaker_layout.rs
+++ b/omniphony-renderer/renderer/src/speaker_layout.rs
@@ -94,9 +94,10 @@ pub struct Speaker {
     /// Set to false for LFE/subwoofers (default: true)
     pub spatialize: bool,
 
-    /// Per-entry gain in dB (default: 0 = unity). Used by the virtual bed to set
-    /// `ObjectMeta.gain` per input channel; ignored for output-layout speakers.
-    pub gain_db: i32,
+    /// Per-entry gain in dB (default: 0 = unity). Used by the virtual bed as
+    /// the per-input-channel trim (0.1 dB resolution, like the per-speaker
+    /// output gain); ignored for output-layout speakers.
+    pub gain_db: f32,
 
     /// Per-speaker output delay in milliseconds (default: 0.0).
     pub delay_ms: f32,
@@ -147,7 +148,7 @@ struct RawSpeaker {
     #[serde(default = "default_spatialize")]
     spatialize: bool,
     #[serde(default)]
-    gain_db: i32,
+    gain_db: f32,
     #[serde(default = "default_delay_ms")]
     delay_ms: f32,
     #[serde(default)]
@@ -226,7 +227,9 @@ impl Serialize for Speaker {
             state.serialize_field("distance", &self.distance)?;
         }
         state.serialize_field("spatialize", &self.spatialize)?;
-        if self.gain_db != 0 {
+        // Same 0.01 dB write tolerance as the render-config gains: below that
+        // is inaudible and must not re-add a key the user never set.
+        if self.gain_db.abs() > 0.01 {
             state.serialize_field("gain_db", &self.gain_db)?;
         }
         state.serialize_field("delay_ms", &self.delay_ms)?;
@@ -261,7 +264,7 @@ impl Speaker {
             y,
             z,
             spatialize,
-            gain_db: 0,
+            gain_db: 0.0,
             delay_ms: delay_ms.max(0.0),
             freq_low: None,
             freq_high: None,
@@ -293,7 +296,7 @@ impl Speaker {
             y,
             z,
             spatialize,
-            gain_db: 0,
+            gain_db: 0.0,
             delay_ms: delay_ms.max(0.0),
             freq_low: None,
             freq_high: None,

--- a/omniphony-studio/src/controls/virtual-bed.js
+++ b/omniphony-studio/src/controls/virtual-bed.js
@@ -154,7 +154,9 @@ function defaultEntry(base) {
 function readEntry(base, match) {
   if (!match) return defaultEntry(base);
   const cartesian = String(match.coord_mode || '').toLowerCase() === 'cartesian';
-  const gainDb = Number.isFinite(Number(match.gain_db)) ? Math.round(Number(match.gain_db)) : 0;
+  const gainDb = Number.isFinite(Number(match.gain_db))
+    ? Math.round(Number(match.gain_db) * 10) / 10
+    : 0;
   const spatialize = match.spatialize !== false;
   if (cartesian && Number.isFinite(Number(match.x))) {
     const x = Number(match.x) || 0;
@@ -251,7 +253,8 @@ function buildLayoutPayload(channels) {
         entry.elevation = Number(c.elevation) || 0;
         entry.distance = Number(c.distance) > 0 ? Number(c.distance) : 0.01;
       }
-      if (Math.round(c.gainDb || 0) !== 0) entry.gain_db = Math.round(c.gainDb);
+      const gainDb = Math.round((Number(c.gainDb) || 0) * 10) / 10;
+      if (gainDb !== 0) entry.gain_db = gainDb;
       return entry;
     })
   };
@@ -364,7 +367,8 @@ export function applyChannelSceneCartesian(name, sx, sy, sz) {
 
 export function applyChannelGain(name, gainDb) {
   commitChannel(name, (c) => {
-    c.gainDb = Math.round(Number(gainDb) || 0);
+    // 0.1 dB resolution, matching the per-speaker output gain.
+    c.gainDb = Math.round((Number(gainDb) || 0) * 10) / 10;
   });
 }
 
@@ -657,7 +661,10 @@ export function renderChannelEditor(force = false) {
   const gainSlider = el('channelEditGainSlider');
   if (gainSlider) gainSlider.value = String(ch.gainDb || 0);
   const gainBox = el('channelEditGainBox');
-  if (gainBox) gainBox.textContent = `${ch.gainDb > 0 ? '+' : ''}${ch.gainDb || 0} dB`;
+  if (gainBox) {
+    const g = Number(ch.gainDb) || 0;
+    gainBox.textContent = `${g > 0 ? '+' : ''}${g.toFixed(1)} dB`;
+  }
 
   // Direct channels are pinned to their speaker: only Direct/Virtual + gain edit.
   const positionInputs = [

--- a/omniphony-studio/src/index.html
+++ b/omniphony-studio/src/index.html
@@ -709,7 +709,7 @@
                setting of one of them. -->
           <div class="editor-row gain-row" style="margin-bottom:0.35rem">
             <label for="channelEditGainSlider" data-i18n="channelEdit.gain" data-help-i18n="help.channelEdit.gain">Gain</label>
-            <input id="channelEditGainSlider" class="gain-slider" type="range" min="-24" max="12" step="1" value="0" />
+            <input id="channelEditGainSlider" class="gain-slider" type="range" min="-24" max="12" step="0.1" value="0" />
             <div id="channelEditGainBox" class="gain-box">0 dB</div>
           </div>
           <label class="switch-row" style="cursor:pointer;margin-bottom:0.35rem">

--- a/omniphony-studio/src/listeners/channel-editor-listeners.js
+++ b/omniphony-studio/src/listeners/channel-editor-listeners.js
@@ -120,12 +120,12 @@ export function setupChannelEditorListeners() {
   if (gainSlider) {
     const gainBox = el('channelEditGainBox');
     gainSlider.addEventListener('input', () => {
-      const v = Math.round(Number(gainSlider.value) || 0);
-      if (gainBox) gainBox.textContent = `${v > 0 ? '+' : ''}${v} dB`;
+      const v = Math.round((Number(gainSlider.value) || 0) * 10) / 10;
+      if (gainBox) gainBox.textContent = `${v > 0 ? '+' : ''}${v.toFixed(1)} dB`;
     });
     gainSlider.addEventListener('change', () => {
       const name = selectedChannel();
-      if (name) applyChannelGain(name, Math.round(Number(gainSlider.value) || 0));
+      if (name) applyChannelGain(name, Number(gainSlider.value) || 0);
     });
     // Double-click resets to unity (0 dB), mirroring the speaker gain slider.
     gainSlider.addEventListener('dblclick', () => {


### PR DESCRIPTION
## Summary

The bed editor's per-channel gain moved in whole dB while the per-speaker output gain next to it moves in 0.1 dB. The integer came from the decoder side's `i8` quietly propagating through types the renderer owns (layout entry `i32`, events `Option<i8>`, channel state, display objects). This also restores the sub-dB steps v-lix gave up when dropping `render.lfe_gain` (#220).

## Changes

- Renderer-owned gains are `f32` end to end: layout entry, plan events, planner trim cache, per-channel state, display objects. Decoder side stays `i8` (bridge ABI and DAMF untouched), converted at the boundary — stream metadata still arrives in whole dB, fractional resolution belongs to the bed trim summed on top.
- −128 remains the −inf convention, now a floor (`GAIN_DB_NEG_INF`): sums clamp onto it exactly, silence stays a single `<=` test, and a shared `gain_db_to_linear` replaces three hand-rolled conversions.
- Layout files write `gain_db` with the same 0.01 dB tolerance as the render-config gains — existing configs round-trip unchanged, integer YAML values parse into the `f32` field.
- The OSC object frame keeps sending the display gain as a rounded `Int`: the native mpv overlay parses that tag, and the editor reads the bed itself, not the display frame. Studio's bed state travels as raw JSON, so decimals survive the state layer untouched.
- Studio: slider steps 0.1 with one-decimal display; payload carries the fractional value.

## Tests

Full workspace suite green (680 passed). The event-path regression tests now exercise a fractional −6.5 dB trim end to end (plan events, replan-on-epoch, stream-gain sum, clamp-to-floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)