### PR TITLE
Make renderer gain slew callback-partition invariant

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -475,6 +475,41 @@ impl BinauralRenderer {
         extra: Option<ExtraSource<'_>>,
         out: &mut [f32],
     ) {
+        self.render_frame_with_gain_slew(
+            input_pcm,
+            input_channel_count,
+            sample_length,
+            params,
+            chan_pos,
+            chan_gain,
+            chan_direct,
+            None,
+            None,
+            extra,
+            out,
+        );
+    }
+
+    /// Internal production path with an optional exact ChannelState gain
+    /// segment. The sidecars are derived start/rate values; ChannelState
+    /// remains the sole owner of gain state and slew advancement.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn render_frame_with_gain_slew(
+        &mut self,
+        input_pcm: &[f32],
+        input_channel_count: usize,
+        sample_length: usize,
+        params: &BinauralFrameParams,
+        chan_pos: &[[f64; 3]],
+        chan_gain: &[f32],
+        chan_direct: &[bool],
+        gain_starts: Option<&[f32]>,
+        gain_steps: Option<&[f32]>,
+        extra: Option<ExtraSource<'_>>,
+        out: &mut [f32],
+    ) {
+        debug_assert!(gain_starts.map_or(true, |values| values.len() == input_channel_count));
+        debug_assert!(gain_steps.map_or(true, |values| values.len() == input_channel_count));
         let BinauralFrameParams {
             head_pose,
             unit_scale_m,
@@ -541,11 +576,25 @@ impl BinauralRenderer {
             if span == 0 {
                 continue;
             }
-            let gain = match extra_here {
+            let gain_end = match extra_here {
                 Some(e) => e.gain,
                 None => chan_gain.get(c).copied().unwrap_or(0.0),
             };
-            if gain == 0.0 {
+            let gain_start = match extra_here {
+                Some(e) => e.gain,
+                None => gain_starts
+                    .and_then(|values| values.get(c))
+                    .copied()
+                    .unwrap_or(gain_end),
+            };
+            let gain_step = match extra_here {
+                Some(_) => 0.0,
+                None => gain_steps
+                    .and_then(|values| values.get(c))
+                    .copied()
+                    .unwrap_or(0.0),
+            };
+            if gain_start == 0.0 && gain_end == 0.0 {
                 // Keep an existing reflection bank fading out so a muted
                 // channel does not freeze its taps at full gain.
                 let slot = match extra_here {
@@ -576,6 +625,14 @@ impl BinauralRenderer {
                     dsp.refl = None;
                 }
                 for s in 0..span {
+                    let gain_unclamped = gain_start + gain_step * s as f32;
+                    let gain = if gain_step > 0.0 {
+                        gain_unclamped.min(gain_end)
+                    } else if gain_step < 0.0 {
+                        gain_unclamped.max(gain_end)
+                    } else {
+                        gain_end
+                    };
                     let v = src_pcm[s * src_stride + src_offset]
                         * gain
                         * std::f32::consts::FRAC_1_SQRT_2;
@@ -709,6 +766,14 @@ impl BinauralRenderer {
                 // adds its distance gain, the reflection taps theirs. The air
                 // low-pass applies to the propagated wave, so it feeds the
                 // direct, the reflections and the reverb send alike.
+                let gain_unclamped = gain_start + gain_step * s as f32;
+                let gain = if gain_step > 0.0 {
+                    gain_unclamped.min(gain_end)
+                } else if gain_step < 0.0 {
+                    gain_unclamped.max(gain_end)
+                } else {
+                    gain_end
+                };
                 let mut raw = src_pcm[s * src_stride + src_offset] * gain;
                 if air > 0.0 {
                     dsp.air_state += (raw - dsp.air_state) * (1.0 - air);

--- a/omniphony-renderer/renderer/src/spatial_renderer/components.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/components.rs
@@ -206,30 +206,90 @@ pub(super) struct ChannelState {
     pub(super) interp_prev_gains: Vec<Gains>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(super) struct GainSlew {
+    start: f32,
+    step: f32,
+    end: f32,
+}
+
+impl GainSlew {
+    #[inline]
+    pub(super) fn start(self) -> f32 {
+        self.start
+    }
+
+    #[inline]
+    pub(super) fn step(self) -> f32 {
+        self.step
+    }
+
+    #[inline]
+    pub(super) fn end(self) -> f32 {
+        self.end
+    }
+
+    #[inline]
+    pub(super) fn at(self, sample_idx: usize) -> f32 {
+        let value = self.start + self.step * sample_idx as f32;
+        if self.step > 0.0 {
+            value.min(self.end)
+        } else if self.step < 0.0 {
+            value.max(self.end)
+        } else {
+            self.end
+        }
+    }
+}
+
 impl ChannelState {
-    /// Advance the gain slew by one block toward `target`; returns the
-    /// block's `(start, per_sample_step)` so mix loops can interpolate
-    /// `start + step * sample_idx`.
+    /// Advance the gain slew by one block toward `target`.
+    ///
+    /// The slew rate is constant in sample time, independent of callback size.
+    /// If the target is reached partway through a block, the remaining samples
+    /// hold the target instead of dilating the final gain change to the callback
+    /// boundary.
     pub(super) fn slew_gain(
         &mut self,
         target: f32,
         sample_length: usize,
         ramp_samples: f32,
-    ) -> (f32, f32) {
+    ) -> GainSlew {
         let start = self.slewed_gain;
-        let max_step = if ramp_samples > 0.0 {
-            sample_length as f32 / ramp_samples
+        if sample_length == 0 {
+            return GainSlew {
+                start,
+                step: 0.0,
+                end: start,
+            };
+        }
+        if ramp_samples <= 0.0 || !ramp_samples.is_finite() {
+            self.slewed_gain = target;
+            return GainSlew {
+                start: target,
+                step: 0.0,
+                end: target,
+            };
+        }
+
+        let delta = target - start;
+        if delta == 0.0 {
+            return GainSlew {
+                start,
+                step: 0.0,
+                end: start,
+            };
+        }
+
+        let step = delta.signum() / ramp_samples;
+        let projected_end = start + step * sample_length as f32;
+        let end = if step > 0.0 {
+            projected_end.min(target)
         } else {
-            f32::INFINITY
+            projected_end.max(target)
         };
-        let delta = (target - start).clamp(-max_step, max_step);
-        self.slewed_gain = start + delta;
-        let step = if sample_length > 0 {
-            delta / sample_length as f32
-        } else {
-            0.0
-        };
-        (start, step)
+        self.slewed_gain = end;
+        GainSlew { start, step, end }
     }
 }
 

--- a/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/construction.rs
@@ -521,6 +521,8 @@ impl SpatialRenderer {
             crossover_duty_ema: Default::default(),
             binaural_pos_buf: Vec::new(),
             binaural_gain_buf: Vec::new(),
+            binaural_gain_start_buf: Vec::new(),
+            binaural_gain_step_buf: Vec::new(),
             binaural_direct_buf: Vec::new(),
             object_test_source: Default::default(),
         })

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -314,8 +314,13 @@ pub struct SpatialRenderer {
     /// Scratch per-channel world positions for the binaural path (reused).
     binaural_pos_buf: Vec<[f64; 3]>,
 
-    /// Scratch per-channel gains for the binaural path (reused).
+    /// Scratch per-channel gain end boundaries for the binaural path (reused).
     binaural_gain_buf: Vec<f32>,
+
+    /// Canonical ChannelState gain segment projected into the binaural handoff.
+    /// These are derived scratch values, not a second gain owner.
+    binaural_gain_start_buf: Vec<f32>,
+    binaural_gain_step_buf: Vec<f32>,
 
     /// Scratch per-channel "direct" flags for the binaural path (reused):
     /// beds mapped to a `spatialize: false` speaker (the LFE) feed both ears
@@ -879,6 +884,10 @@ impl SpatialRenderer {
                     .resize(input_channel_count, [0.0, 1.0, 0.0]);
                 self.binaural_gain_buf.clear();
                 self.binaural_gain_buf.resize(input_channel_count, 0.0);
+                self.binaural_gain_start_buf.clear();
+                self.binaural_gain_start_buf.resize(input_channel_count, 0.0);
+                self.binaural_gain_step_buf.clear();
+                self.binaural_gain_step_buf.resize(input_channel_count, 0.0);
                 self.binaural_direct_buf.clear();
                 self.binaural_direct_buf.resize(input_channel_count, false);
                 let num_routed = channel_routing.len();
@@ -899,17 +908,23 @@ impl SpatialRenderer {
                             .map(|s| s.gain_db)
                             .unwrap_or(components::GAIN_DB_NEG_INF);
                         let gain_linear = components::gain_db_to_linear(gain_db);
-                        // Slewed like the VBAP path (block-end value: the binaural
-                        // stage updates per block anyway).
+                        // ChannelState owns the gain timeline. Carry its exact
+                        // start/rate/end projection into the binaural stage so a
+                        // callback crossing the slew endpoint holds the target
+                        // instead of stretching the fade to the callback edge.
                         let ramp_samples = self.sample_rate as f32 * GAIN_SLEW_SECS;
                         if let Some(state) = states.get_mut(c) {
-                            let (start, step) = state.slew_gain(
+                            let gain_slew = state.slew_gain(
                                 obj_gain * gain_linear,
                                 sample_length,
                                 ramp_samples,
                             );
-                            self.binaural_gain_buf[c] = start + step * sample_length as f32;
+                            self.binaural_gain_start_buf[c] = gain_slew.start();
+                            self.binaural_gain_step_buf[c] = gain_slew.step();
+                            self.binaural_gain_buf[c] = gain_slew.end();
                         } else {
+                            self.binaural_gain_start_buf[c] = 0.0;
+                            self.binaural_gain_step_buf[c] = 0.0;
                             self.binaural_gain_buf[c] = 0.0;
                         }
                         // Same direct/virtual split as the VBAP path.
@@ -962,7 +977,7 @@ impl SpatialRenderer {
                         position: block.position.map(|v| v as f64),
                         gain: 1.0,
                     });
-                self.binaural.render_frame(
+                self.binaural.render_frame_with_gain_slew(
                     input_pcm,
                     input_channel_count,
                     sample_length,
@@ -970,6 +985,8 @@ impl SpatialRenderer {
                     &self.binaural_pos_buf,
                     &self.binaural_gain_buf,
                     &self.binaural_direct_buf,
+                    Some(&self.binaural_gain_start_buf),
+                    Some(&self.binaural_gain_step_buf),
                     extra,
                     &mut output,
                 );

--- a/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/speaker_stage.rs
@@ -258,10 +258,11 @@ impl SpeakerRenderStage {
 
             // Convert gain from dB to linear (−inf floor honoured).
             let gain_linear = super::components::gain_db_to_linear(gain_db);
-            // Slewed per-sample gain factor (includes the mute 0/1 factor):
-            // factor(s) = gain_start + gain_step * s.
+            // Slewed per-sample gain factor (includes the mute 0/1 factor).
+            // ChannelState owns the constant sample-time rate and exact
+            // within-block target clamp.
             let ramp_samples = self.sample_rate as f32 * GAIN_SLEW_SECS;
-            let (gain_start, gain_step) =
+            let gain_slew =
                 state.slew_gain(gain_linear * obj_gain, sample_length, ramp_samples);
 
             // A channel is directly routed when its routing entry is
@@ -319,7 +320,7 @@ impl SpeakerRenderStage {
                 for sample_idx in 0..sample_length {
                     let mut sample = input_pcm
                         [sample_idx * input_channel_count + input_channel_idx]
-                        * (gain_start + gain_step * sample_idx as f32);
+                        * (gain_slew.at(sample_idx));
                     if let Some(delay) = bed_delay.as_mut() {
                         sample = delay.push(sample);
                     }
@@ -426,7 +427,7 @@ impl SpeakerRenderStage {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * (gain_start + gain_step * sample_idx as f32)
+                                        * (gain_slew.at(sample_idx))
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -445,7 +446,7 @@ impl SpeakerRenderStage {
                             for sample_idx in 0..sample_length {
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * (gain_start + gain_step * sample_idx as f32);
+                                    * (gain_slew.at(sample_idx));
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,
@@ -487,7 +488,7 @@ impl SpeakerRenderStage {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * (gain_start + gain_step * sample_idx as f32)
+                                        * (gain_slew.at(sample_idx))
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -506,7 +507,7 @@ impl SpeakerRenderStage {
                             for sample_idx in 0..sample_length {
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * (gain_start + gain_step * sample_idx as f32);
+                                    * (gain_slew.at(sample_idx));
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,
@@ -538,7 +539,7 @@ impl SpeakerRenderStage {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * (gain_start + gain_step * sample_idx as f32)
+                                        * (gain_slew.at(sample_idx))
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -612,7 +613,7 @@ impl SpeakerRenderStage {
                                 }
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * (gain_start + gain_step * sample_idx as f32);
+                                    * (gain_slew.at(sample_idx));
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,
@@ -673,7 +674,7 @@ impl SpeakerRenderStage {
                                 &mut self.crossover_band_scratch,
                                 |sample_idx| {
                                     input_pcm[sample_idx * input_channel_count + input_channel_idx]
-                                        * (gain_start + gain_step * sample_idx as f32)
+                                        * (gain_slew.at(sample_idx))
                                 },
                             );
                             crossover_elapsed += started_at.elapsed();
@@ -710,7 +711,7 @@ impl SpeakerRenderStage {
                                 }
                                 let raw = input_pcm
                                     [sample_idx * input_channel_count + input_channel_idx]
-                                    * (gain_start + gain_step * sample_idx as f32);
+                                    * (gain_slew.at(sample_idx));
                                 let split = split_bands(
                                     raw,
                                     &self.crossover_filter_bank,

--- a/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/tests.rs
@@ -1340,6 +1340,120 @@ fn binaural_lfe_bed_feeds_both_ears_equally_and_dry() {
     );
 }
 
+/// Gain slew is source-time state, so callback partitioning must not change
+/// the audible trajectory. The irregular schedule deliberately crosses the
+/// exact slew endpoint inside a callback.
+#[test]
+fn binaural_gain_slew_is_callback_partition_invariant() {
+    fn render(partitions: &[usize]) -> Vec<f32> {
+        let layout = SpeakerLayout::preset("7.1.4").unwrap();
+        let mut r = SpatialRenderer::new(
+            layout,
+            48_000,
+            1,
+            1,
+            0.0,
+            2.0,
+            VbapTableMode::Cartesian {
+                x_size: 21,
+                y_size: 21,
+                z_size: 9,
+                z_neg_size: 9,
+            },
+            false,
+            true,
+            DistanceModel::Linear,
+            false,
+            1.0,
+            1.0,
+            0.0,
+            1.0,
+            false,
+            [1.0, 2.0, 0.5],
+            2.0,
+            0.5,
+            0.0,
+            0.0,
+            false,
+            false,
+            false,
+            1.0,
+            1.0,
+            PreferredEvaluationMode::PrecomputedCartesian,
+            LiveEvaluationMode::PrecomputedCartesian,
+            21,
+            21,
+            9,
+            9,
+        )
+        .unwrap();
+        r.configure_channel_routing(&[ChannelRoute::Direct(
+            bridge_api::RChannelLabel::LFE,
+        )]);
+        r.control.live.write().binaural.output_mode =
+            crate::live_params::OutputMode::Binaural;
+
+        let event = [SpatialChannelEvent {
+            channel_idx: 0,
+            is_bed: true,
+            gain_db: Some(0.0),
+            ramp_length: Some(0),
+            size: None,
+            position: None,
+            sample_pos: Some(0),
+        }];
+        let mut rendered = Vec::new();
+        for (block_idx, &frames) in partitions.iter().enumerate() {
+            let pcm = vec![1.0f32; frames];
+            let events: &[SpatialChannelEvent] = if block_idx == 0 {
+                &event
+            } else {
+                &[]
+            };
+            let frame = r
+                .render_frame(&pcm, 1, events, Vec::new(), false)
+                .unwrap();
+            rendered.extend_from_slice(&frame.samples);
+        }
+        rendered
+    }
+
+    let uniform = vec![40usize; 30];
+    let irregular = [17usize, 101, 13, 257, 64, 5, 173, 91, 206, 273];
+    assert_eq!(
+        uniform.iter().sum::<usize>(),
+        irregular.iter().sum::<usize>()
+    );
+
+    let a = render(&uniform);
+    let b = render(&irregular);
+    assert_eq!(a.len(), b.len());
+    let max_diff = a
+        .iter()
+        .zip(&b)
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max);
+    assert!(
+        max_diff < 2.0e-6,
+        "callback partition changed the binaural gain trajectory: max diff {max_diff}"
+    );
+
+    let ramp_samples = (48_000.0f32 * GAIN_SLEW_SECS) as usize;
+    let halfway = ramp_samples / 2;
+    let expected_half = 0.5 * std::f32::consts::FRAC_1_SQRT_2;
+    assert!(
+        (a[halfway * 2] - expected_half).abs() < 2.0e-6,
+        "unexpected midpoint gain: got {} expected {expected_half}",
+        a[halfway * 2]
+    );
+    let settled = std::f32::consts::FRAC_1_SQRT_2;
+    assert!(
+        (a[a.len() - 2] - settled).abs() < 2.0e-6,
+        "gain did not settle to unity: got {} expected {settled}",
+        a[a.len() - 2]
+    );
+}
+
 /// After claiming the FP environment, subnormal arithmetic must flush to
 /// zero on this thread (issue #154) — without FTZ/DAZ the product below
 /// stays a nonzero subnormal.


### PR DESCRIPTION
## What changed

- keep `ChannelState` gain slew at one constant sample-time rate across callback boundaries
- clamp only after the target is actually reached instead of dilating the last gain fraction to the callback edge
- carry the same start/rate/end segment into binaural rendering, so the headphone path no longer applies block-end gain as a callback-rate step
- add an adversarial regression that renders one continuous fade under two radically different callback partitions and requires sample-equivalent output

## Why

Host callback boundaries are transport artifacts. The current slew computes the final partial step as `remaining_delta / sample_length`, so a callback that straddles the target changes the audible gain trajectory. In binaural mode, the block-end gain is also applied to the whole block, making the trajectory even more directly callback-size dependent.

The regression uses the direct LFE headphone route to avoid HRTF/reverb differences and compares the same 1200-sample fade under 40-sample blocks versus an irregular partition that crosses the 960-sample slew endpoint inside a 273-sample callback.

## Validation

The branch is based directly on upstream `b1b78a89bb83417d7ff6ae73a617983269bd12a8`. This PR is opened as draft so upstream CI can run the repository's format/build/test gates before it is marked ready.