### PR TITLE
fix(binaural): scale the HRIR kernel length with the sample rate

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/convolver.rs
+++ b/omniphony-renderer/renderer/src/binaural/convolver.rs
@@ -1,6 +1,10 @@
 //! Direct-form FIR convolver for one ear of one object.
 //!
-//! Length is fixed at [`HRIR_LEN`]. The input history persists across
+//! Capacity is [`HRIR_LEN`]; the number of taps actually run is the length
+//! of the kernel handed to [`set_coeffs`](EarConvolver::set_coeffs) /
+//! [`set_coeffs_smooth`](EarConvolver::set_coeffs_smooth) — the set's
+//! [`hrir_len`](super::hrir::hrir_len) for the engine rate — so the cost
+//! scales with the rate rather than the span shrinking. The input history persists across
 //! coefficient swaps, so updating the HRIR between frames (as the object or
 //! head moves) keeps the *state* continuous — and a kernel change is
 //! additionally crossfaded over a caller-chosen ramp
@@ -19,8 +23,8 @@
 //! per sample *per ear per object* — so its shape is deliberate on two counts:
 //!
 //! * **The history is linear and double-written**, not a ring walked backwards.
-//!   Each input lands at both `pos` and `pos + HRIR_LEN`, which makes
-//!   `hist[pos + 1 ..= pos + HRIR_LEN]` the last `HRIR_LEN` inputs in
+//!   Each input lands at both `pos` and `pos + len`, which makes
+//!   `hist[pos + 1 ..= pos + len]` the last `len` inputs in
 //!   oldest→newest order, contiguous and ascending whatever `pos` is. The
 //!   kernel is stored reversed to match, so the loop is a plain forward dot
 //!   product over two contiguous slices — no wrap test and no descending index
@@ -64,7 +68,7 @@ const _: () = assert!(
 
 /// Forward dot product of a reversed kernel with the ascending history window.
 #[inline(always)]
-fn dot(coeffs: &[f32; HRIR_LEN], win: &[f32]) -> f32 {
+fn dot(coeffs: &[f32], win: &[f32]) -> f32 {
     let mut acc = [0.0f32; ACC_LANES];
     for (c, h) in coeffs
         .chunks_exact(ACC_LANES)
@@ -80,7 +84,7 @@ fn dot(coeffs: &[f32; HRIR_LEN], win: &[f32]) -> f32 {
 /// Both kernels of a running crossfade over the same window, in one pass — the
 /// history loads are shared between them.
 #[inline(always)]
-fn dot2(new_c: &[f32; HRIR_LEN], old_c: &[f32; HRIR_LEN], win: &[f32]) -> (f32, f32) {
+fn dot2(new_c: &[f32], old_c: &[f32], win: &[f32]) -> (f32, f32) {
     let mut acc_new = [0.0f32; ACC_LANES];
     let mut acc_old = [0.0f32; ACC_LANES];
     for ((cn, co), h) in new_c
@@ -98,12 +102,18 @@ fn dot2(new_c: &[f32; HRIR_LEN], old_c: &[f32; HRIR_LEN], win: &[f32]) -> (f32, 
 }
 
 pub struct EarConvolver {
-    /// Past inputs, each written twice (`pos` and `pos + HRIR_LEN`) so the
+    /// Past inputs, each written twice (`pos` and `pos + len`) so the
     /// live window is always a contiguous ascending slice. `pos` marks the
     /// primary slot of the most recent sample.
     hist: [f32; 2 * HRIR_LEN],
     pos: usize,
-    /// Current kernel, stored **reversed** (`rcoeffs[j] == coeffs[N - 1 - j]`)
+    /// Taps in use: the length of the last kernel set, `HRIR_LEN` until
+    /// then. Fixed for the life of a stream — it decides where the history
+    /// wraps, so it is adopted from the first kernel and expected to hold.
+    len: usize,
+    /// Whether any sample has been processed since the length was adopted.
+    started: bool,
+    /// Current kernel, stored **reversed** (`rcoeffs[j] == coeffs[len - 1 - j]`)
     /// to match the oldest→newest history window.
     rcoeffs: [f32; HRIR_LEN],
     /// Fade-out kernel of a running crossfade (valid while `fade_pos <
@@ -124,6 +134,8 @@ impl EarConvolver {
         Self {
             hist: [0.0; 2 * HRIR_LEN],
             pos: 0,
+            len: HRIR_LEN,
+            started: false,
             rcoeffs: [0.0; HRIR_LEN],
             prev_rcoeffs: [0.0; HRIR_LEN],
             fade_pos: 0,
@@ -131,12 +143,46 @@ impl EarConvolver {
         }
     }
 
+    /// Taps currently run per sample.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Never empty: a fresh convolver runs the full capacity of zeros.
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Adopt the kernel length. The history wraps at `len`, so a change
+    /// after samples have flowed would misalign the window; the length is
+    /// a property of the engine rate and is expected to be set once, on the
+    /// first kernel, before the first sample.
+    #[inline]
+    fn adopt_len(&mut self, len: usize) {
+        if len == self.len {
+            return;
+        }
+        debug_assert!(len > 0 && len <= HRIR_LEN && len.is_multiple_of(ACC_LANES));
+        debug_assert!(
+            !self.started,
+            "kernel length changed from {} to {len} on a running convolver",
+            self.len
+        );
+        self.len = len;
+        self.pos = 0;
+        self.hist.fill(0.0);
+        self.fade_pos = 0;
+        self.fade_len = 0;
+    }
+
     /// Replace the FIR kernel immediately (no crossfade). The history is
     /// untouched, so the *state* remains continuous through the swap, but the
     /// transfer function jumps — prefer [`set_coeffs_smooth`](Self::set_coeffs_smooth)
-    /// on live update paths.
+    /// on live update paths. `coeffs.len()` is the number of taps to run.
     #[inline]
-    pub fn set_coeffs(&mut self, coeffs: &[f32; HRIR_LEN]) {
+    pub fn set_coeffs(&mut self, coeffs: &[f32]) {
+        self.adopt_len(coeffs.len());
         for (dst, &c) in self.rcoeffs.iter_mut().zip(coeffs.iter().rev()) {
             *dst = c;
         }
@@ -147,8 +193,8 @@ impl EarConvolver {
     /// Whether `coeffs` is the kernel already loaded (compared in natural
     /// order against the reversed store — no temporary).
     #[inline]
-    fn kernel_is(&self, coeffs: &[f32; HRIR_LEN]) -> bool {
-        self.rcoeffs.iter().eq(coeffs.iter().rev())
+    fn kernel_is(&self, coeffs: &[f32]) -> bool {
+        coeffs.len() == self.len && self.rcoeffs[..self.len].iter().eq(coeffs.iter().rev())
     }
 
     /// Replace the FIR kernel, crossfading from the current one over the next
@@ -157,7 +203,7 @@ impl EarConvolver {
     /// compare and keeps the single dot product). Restarting mid-fade departs
     /// from the currently *effective* (blended) kernel, so back-to-back
     /// changes stay click-free too.
-    pub fn set_coeffs_smooth(&mut self, coeffs: &[f32; HRIR_LEN], fade_len: usize) {
+    pub fn set_coeffs_smooth(&mut self, coeffs: &[f32], fade_len: usize) {
         if self.kernel_is(coeffs) {
             return;
         }
@@ -165,14 +211,16 @@ impl EarConvolver {
             self.set_coeffs(coeffs);
             return;
         }
+        self.adopt_len(coeffs.len());
+        let len = self.len;
         if self.fade_pos < self.fade_len {
             // Freeze the running blend as the new fade-out kernel.
             let w = self.fade_pos as f32 / self.fade_len as f32;
-            for i in 0..HRIR_LEN {
+            for i in 0..len {
                 self.prev_rcoeffs[i] += (self.rcoeffs[i] - self.prev_rcoeffs[i]) * w;
             }
         } else {
-            self.prev_rcoeffs.copy_from_slice(&self.rcoeffs);
+            self.prev_rcoeffs[..len].copy_from_slice(&self.rcoeffs[..len]);
         }
         for (dst, &c) in self.rcoeffs.iter_mut().zip(coeffs.iter().rev()) {
             *dst = c;
@@ -184,25 +232,23 @@ impl EarConvolver {
     /// Push one input sample and return the filtered output.
     #[inline]
     pub fn process(&mut self, x: f32) -> f32 {
+        let len = self.len;
+        self.started = true;
         // Advance first, then write both copies: the window below is then the
-        // last HRIR_LEN inputs, oldest→newest, with `x` as its final element.
-        self.pos = if self.pos + 1 == HRIR_LEN {
-            0
-        } else {
-            self.pos + 1
-        };
+        // last `len` inputs, oldest→newest, with `x` as its final element.
+        self.pos = if self.pos + 1 == len { 0 } else { self.pos + 1 };
         self.hist[self.pos] = x;
-        self.hist[self.pos + HRIR_LEN] = x;
-        let win = &self.hist[self.pos + 1..self.pos + 1 + HRIR_LEN];
+        self.hist[self.pos + len] = x;
+        let win = &self.hist[self.pos + 1..self.pos + 1 + len];
 
         if self.fade_pos < self.fade_len {
             // Crossfade: both kernels over the shared history, linear blend.
             self.fade_pos += 1;
             let w = self.fade_pos as f32 / self.fade_len as f32;
-            let (acc_new, acc_old) = dot2(&self.rcoeffs, &self.prev_rcoeffs, win);
+            let (acc_new, acc_old) = dot2(&self.rcoeffs[..len], &self.prev_rcoeffs[..len], win);
             acc_old + (acc_new - acc_old) * w
         } else {
-            dot(&self.rcoeffs, win)
+            dot(&self.rcoeffs[..len], win)
         }
     }
 }
@@ -272,6 +318,26 @@ mod tests {
             }
             assert_eq!(hits, vec![tap], "tap {tap} landed at the wrong delay");
         }
+    }
+
+    /// A shorter kernel runs, wraps and delays on its own length: the last
+    /// tap of a 256-tap kernel lands at 255, through several laps of the
+    /// 256-slot history.
+    #[test]
+    fn a_shorter_kernel_wraps_on_its_own_length() {
+        let mut c = EarConvolver::new();
+        let mut k = [0.0; 256];
+        k[255] = 1.0;
+        c.set_coeffs(&k);
+        assert_eq!(c.len(), 256);
+        let mut hits = Vec::new();
+        for t in 0..(3 * 256) {
+            let y = c.process(if t == 0 { 1.0 } else { 0.0 });
+            if y != 0.0 {
+                hits.push((t, y));
+            }
+        }
+        assert_eq!(hits, vec![(255, 1.0)]);
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/hrir.rs
+++ b/omniphony-renderer/renderer/src/binaural/hrir.rs
@@ -8,9 +8,31 @@
 //! keeps all grid FIRs time-aligned so they can be linearly interpolated without
 //! comb-filtering.
 
-/// FIR length per ear. 128 taps @ 48 kHz (≈2.7 ms) captures the synthetic
-/// head-shadow response and a time-aligned measured (KEMAR) HRIR.
-pub const HRIR_LEN: usize = 128;
+/// Kernel **capacity** per ear, in taps: the fixed size of every
+/// [`HrirPair`] and of the convolver state. The number of taps actually
+/// convolved is [`hrir_len`], which scales with the sample rate so the
+/// kernel always spans the same [`HRIR_SPAN_S`] of response; this is the
+/// span at 192 kHz.
+pub const HRIR_LEN: usize = 512;
+
+/// Time span of the convolved kernel: 128 taps at 48 kHz (≈2.7 ms), which
+/// holds the head-shadow and pinna part of a time-aligned measured response.
+/// A fixed tap count instead would shrink to 1.3 ms at 96 kHz and 0.7 ms at
+/// 192 kHz, cutting the concha resonances (1–2 ms) mid-decay.
+pub const HRIR_SPAN_S: f32 = 128.0 / 48_000.0;
+
+/// Shortest kernel: the 48 kHz length, so rates at or below it are
+/// bit-for-bit what they were with a fixed 128-tap kernel.
+const HRIR_MIN_LEN: usize = 128;
+
+/// Taps convolved at `sample_rate`: [`HRIR_SPAN_S`] worth, rounded up to a
+/// multiple of 8 (the tap loop consumes the kernel in eight-lane chunks) and
+/// clamped to `[128, HRIR_LEN]`. 128 at 44.1 and 48 kHz, 240 at 88.2 kHz,
+/// 256 at 96 kHz, 472 at 176.4 kHz, 512 at 192 kHz.
+pub fn hrir_len(sample_rate: u32) -> usize {
+    let taps = (HRIR_SPAN_S * sample_rate as f32).ceil() as usize;
+    taps.next_multiple_of(8).clamp(HRIR_MIN_LEN, HRIR_LEN)
+}
 
 /// A left/right pair of (minimum-delay) impulse responses.
 #[derive(Clone)]
@@ -200,6 +222,10 @@ pub struct HrirSet {
     el_count: usize,
     el_min_deg: f32,
     el_max_deg: f32,
+    /// Taps in use per kernel ([`hrir_len`] at the build rate). Every pair
+    /// in `grid` is zero from this index on, and [`at`](Self::at) only
+    /// interpolates this many.
+    len: usize,
     /// Row-major `[el_idx * az_count + az_idx]`. Azimuth wraps; elevation clamps.
     grid: Vec<HrirPair>,
 }
@@ -243,12 +269,19 @@ impl HrirSet {
         let az_count = (360.0 / Self::AZ_STEP_DEG).round() as usize; // wrap: no duplicate at 360
         let el_count =
             ((Self::EL_MAX_DEG - Self::EL_MIN_DEG) / Self::EL_STEP_DEG).round() as usize + 1;
+        let len = hrir_len(sample_rate);
         let mut grid = Vec::with_capacity(az_count * el_count);
         for ei in 0..el_count {
             let el = Self::EL_MIN_DEG + ei as f32 * Self::EL_STEP_DEG;
             for ai in 0..az_count {
                 let az = ai as f32 * Self::AZ_STEP_DEG;
-                grid.push(provider.render(az, el, sample_rate));
+                let mut pair = provider.render(az, el, sample_rate);
+                // Providers fill the capacity; the set is what gets
+                // convolved, so truncate here — before the level
+                // normalization, which must weigh the taps in use.
+                pair.left[len..].fill(0.0);
+                pair.right[len..].fill(0.0);
+                grid.push(pair);
             }
         }
 
@@ -298,8 +331,20 @@ impl HrirSet {
             el_count,
             el_min_deg: Self::EL_MIN_DEG,
             el_max_deg: Self::EL_MAX_DEG,
+            len,
             grid,
         }
+    }
+
+    /// Taps in use per kernel — what the convolvers must run over.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// A set with no taps in use; never true of a built set.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Convenience constructor for the built-in synthetic model.
@@ -388,7 +433,9 @@ impl HrirSet {
         let w01 = (1.0 - fa) * fe;
         let w11 = fa * fe;
 
-        for n in 0..HRIR_LEN {
+        // Only the taps in use: past `len` every node is zero, and the
+        // convolvers never read that far.
+        for n in 0..self.len {
             out.left[n] =
                 w00 * p00.left[n] + w10 * p10.left[n] + w01 * p01.left[n] + w11 * p11.left[n];
             out.right[n] =
@@ -731,6 +778,52 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The kernel spans 2.67 ms at every rate: 128 taps up to 48 kHz (so
+    /// those rates are unchanged), then proportionally more, in multiples
+    /// of eight, up to the capacity at 192 kHz.
+    #[test]
+    fn kernel_length_follows_the_sample_rate() {
+        assert_eq!(hrir_len(44_100), 128);
+        assert_eq!(hrir_len(48_000), 128);
+        assert_eq!(hrir_len(88_200), 240);
+        assert_eq!(hrir_len(96_000), 256);
+        assert_eq!(hrir_len(176_400), 472);
+        assert_eq!(hrir_len(192_000), 512);
+        for fs in [44_100, 48_000, 88_200, 96_000, 176_400, 192_000] {
+            assert_eq!(
+                hrir_len(fs) % 8,
+                0,
+                "{fs}: not a multiple of the lane count"
+            );
+            assert!(hrir_len(fs) <= HRIR_LEN);
+        }
+    }
+
+    /// A set built at 96 kHz convolves 256 taps, and every node is zero past
+    /// them — the convolver's contract for the taps it does not read.
+    #[test]
+    fn a_96k_set_uses_256_taps_and_is_silent_beyond() {
+        let set = HrirSet::new(
+            &crate::binaural::measured::MeasuredHrirData::saf_kemar().resampled_to(96_000),
+            96_000,
+        );
+        assert_eq!(set.len(), 256);
+        assert!(set.grid.iter().all(|p| {
+            p.left[256..]
+                .iter()
+                .chain(&p.right[256..])
+                .all(|&x| x == 0.0)
+        }));
+        // The measured response really extends past the old 128-tap cut at
+        // this rate: taps 128..256 must carry energy somewhere on the grid.
+        let tail: f32 = set
+            .grid
+            .iter()
+            .map(|p| p.left[128..256].iter().map(|x| x * x).sum::<f32>())
+            .sum();
+        assert!(tail > 0.0, "nothing past tap 128 at 96 kHz");
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -838,9 +838,12 @@ impl BinauralRenderer {
                 // block — capped at HRIR_LEN samples for large offline blocks
                 // — so the transfer function never jumps at a block boundary
                 // (issue #155).
-                let fade = sample_length.min(HRIR_LEN);
-                dsp.conv_l.set_coeffs_smooth(&self.hrir_scratch.left, fade);
-                dsp.conv_r.set_coeffs_smooth(&self.hrir_scratch.right, fade);
+                let len = self.hrir.set.len();
+                let fade = sample_length.min(len);
+                dsp.conv_l
+                    .set_coeffs_smooth(&self.hrir_scratch.left[..len], fade);
+                dsp.conv_r
+                    .set_coeffs_smooth(&self.hrir_scratch.right[..len], fade);
             }
             dsp.delay_l.set_target_ms(itd_l * 1000.0, self.sample_rate);
             dsp.delay_r.set_target_ms(itd_r * 1000.0, self.sample_rate);


### PR DESCRIPTION
## What

The convolved kernel was 128 taps at every engine rate: 2.67 ms at 48 kHz, **1.33 ms at 96 kHz, 0.67 ms at 192 kHz**. `resampled_to` brought the measured set to the engine rate and `align_into` then kept a shrinking slice of it — above 48 kHz the concha resonances (1–2 ms) were cut mid-decay and the kernel's frequency resolution fell with them.

## How

- `HRIR_LEN` becomes the kernel **capacity** (512 taps = 2.67 ms at 192 kHz). The identifier is kept so `[f32; HRIR_LEN]` arrays and build-time loops across `hrir.rs`, `measured.rs`, `prtf.rs` compile unchanged and the other review PRs do not conflict.
- `hrir_len(sample_rate)`: the 2.67 ms span rounded up to a multiple of the tap loop's eight lanes, clamped to `[128, 512]`.

| rate | taps |
|---|---|
| 44.1 / 48 kHz | 128 (unchanged) |
| 88.2 kHz | 240 |
| 96 kHz | 256 |
| 176.4 kHz | 472 |
| 192 kHz | 512 |

- `HrirSet` truncates every node to that length **before** the level normalization (so it weighs the taps in use) and `at()` interpolates only that many.
- `EarConvolver` takes kernels as slices, adopts the length from the first kernel (debug-asserted fixed once samples flow) and wraps its double-written history on it, so the per-sample cost scales with the rate rather than the span shrinking. Memory per convolver goes from 1.5 KB to 6 KB, the grid from 0.5 MB to 2 MB.
- Tests: the length table; a 96 kHz KEMAR set uses 256 taps, is zero beyond, and carries energy past tap 128; a 256-tap kernel wraps and delays on its own length.

Rates ≤ 48 kHz are bit-for-bit unchanged: `null_binaural_kemar` passes against the untouched golden.

Not done here (follow-up): a short fade window at the truncation point. It would change the 48 kHz golden, and its effect (ripple from a hard cut at −40 dB) is small.

## Review series

Independent of the other PRs (edits `hrir.rs`, `convolver.rs` and three lines of `mod.rs` that none of the others touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
