### PR TITLE
perf(binaural): drop the per-sample divisions from the delay rings

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/reflections.rs
+++ b/omniphony-renderer/renderer/src/binaural/reflections.rs
@@ -37,8 +37,17 @@ const WALL_MARGIN_M: f32 = 0.05;
 /// completes in at most the delay span itself.
 const DELAY_RAMP_RATE: f32 = 1.0;
 
-/// One-pole smoothing coefficient for tap gains (~1.5 ms at 48 kHz).
-const GAIN_SMOOTH: f32 = 0.015;
+/// One-pole smoothing coefficient for tap gains at 48 kHz (~1.5 ms). Other
+/// rates get the coefficient with the same time constant, see
+/// [`gain_smooth_for`].
+const GAIN_SMOOTH_48K: f32 = 0.015;
+
+/// Per-sample gain smoothing coefficient at `sample_rate`, with the time
+/// constant of [`GAIN_SMOOTH_48K`]: the pole is raised to the rate ratio,
+/// so the fade takes the same milliseconds at 96 kHz as at 48.
+fn gain_smooth_for(sample_rate: u32) -> f32 {
+    1.0 - (1.0 - GAIN_SMOOTH_48K).powf(48_000.0 / sample_rate as f32)
+}
 
 /// Number of first-order images of a shoebox (one per wall).
 pub const NUM_REFLECTIONS: usize = 6;
@@ -100,14 +109,14 @@ struct Tap {
 
 impl Tap {
     #[inline]
-    fn step(&mut self) {
+    fn step(&mut self, gain_smooth: f32) {
         let d = self.delay_target - self.delay;
         if d.abs() <= DELAY_RAMP_RATE {
             self.delay = self.delay_target;
         } else {
             self.delay += DELAY_RAMP_RATE * d.signum();
         }
-        self.gain += (self.gain_target - self.gain) * GAIN_SMOOTH;
+        self.gain += (self.gain_target - self.gain) * gain_smooth;
     }
 }
 
@@ -119,6 +128,8 @@ pub struct ReflectionBank {
     taps_l: [Tap; NUM_REFLECTIONS],
     taps_r: [Tap; NUM_REFLECTIONS],
     sample_rate: u32,
+    /// Per-sample gain smoothing coefficient for this rate.
+    gain_smooth: f32,
 }
 
 impl ReflectionBank {
@@ -130,6 +141,7 @@ impl ReflectionBank {
             taps_l: Default::default(),
             taps_r: Default::default(),
             sample_rate,
+            gain_smooth: gain_smooth_for(sample_rate),
         }
     }
 
@@ -185,12 +197,13 @@ impl ReflectionBank {
 
         let mut l = 0.0f32;
         let mut r = 0.0f32;
+        let gain_smooth = self.gain_smooth;
         for i in 0..NUM_REFLECTIONS {
             let tl = &mut self.taps_l[i];
-            tl.step();
+            tl.step(gain_smooth);
             l += tl.gain * read_frac(&self.ring, cap, self.write_pos, tl.delay);
             let tr = &mut self.taps_r[i];
-            tr.step();
+            tr.step(gain_smooth);
             r += tr.gain * read_frac(&self.ring, cap, self.write_pos, tr.delay);
         }
 
@@ -204,13 +217,24 @@ impl ReflectionBank {
 
 /// Linear-interpolated read at `delay` samples behind `write_pos` (which still
 /// points at the sample just written).
+///
+/// `delay` is clamped to `cap − 2` by [`ReflectionBank::set_targets`] and
+/// ramps between such values, so the read sits less than one lap behind the
+/// write: one conditional subtraction wraps it. This runs twelve times per
+/// channel per sample; the three integer divisions it used to do per call
+/// were the dearest thing in the bank.
 #[inline]
 fn read_frac(ring: &[f32], cap: usize, write_pos: usize, delay: f32) -> f32 {
     let lo = delay.floor();
     let frac = delay - lo;
     let lo = lo as usize;
-    let idx0 = (write_pos + cap - lo % cap) % cap;
-    let idx1 = (idx0 + cap - 1) % cap;
+    debug_assert!(lo < cap);
+    let idx0 = if write_pos >= lo {
+        write_pos - lo
+    } else {
+        write_pos + cap - lo
+    };
+    let idx1 = if idx0 == 0 { cap - 1 } else { idx0 - 1 };
     ring[idx0] * (1.0 - frac) + ring[idx1] * frac
 }
 
@@ -313,6 +337,29 @@ mod tests {
                 assert!(l.abs() < 1e-3, "leak at {i}: {l}");
             }
         }
+    }
+
+    /// The gain fade is a time constant, not a sample count: the tap
+    /// reaches the same fraction of its target after the same milliseconds
+    /// at 48 and 96 kHz.
+    #[test]
+    fn gain_smoothing_is_rate_invariant() {
+        let settle_after_ms = |sample_rate: u32| -> f32 {
+            let mut bank = ReflectionBank::new(sample_rate);
+            bank.set_targets(0, 0.0, 1.0, 1.0);
+            let n = (sample_rate as f32 * 0.003) as usize; // 3 ms
+            let mut last = 0.0;
+            for _ in 0..n {
+                last = bank.process(1.0).0;
+            }
+            last
+        };
+        let (a, b) = (settle_after_ms(48_000), settle_after_ms(96_000));
+        assert!((a - b).abs() < 0.01, "48 kHz {a} vs 96 kHz {b} after 3 ms");
+        assert!(a > 0.8 && a < 0.95, "unexpected settling {a}");
+        // `1 − 0.985` in f32 lands one ulp under the literal 0.015: the
+        // 48 kHz coefficient is the published one to 1e-8.
+        assert!((gain_smooth_for(48_000) - GAIN_SMOOTH_48K).abs() < 1e-6);
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/reverb.rs
+++ b/omniphony-renderer/renderer/src/binaural/reverb.rs
@@ -57,9 +57,12 @@ const LENGTHS_48K: [usize; N] = [1031, 1327, 1523, 1801, 2053, 2311, 2617, 2903]
 const SIGNS_L: [f32; N] = [1.0, -1.0, 1.0, 1.0, -1.0, 1.0, -1.0, -1.0];
 const SIGNS_R: [f32; N] = [1.0, -1.0, -1.0, 1.0, 1.0, -1.0, -1.0, 1.0];
 
-/// One-pole HF damping coefficient in the feedback path (higher = darker
-/// tail; HF decays faster than the broadband RT60, like physical walls).
-const DAMPING: f32 = 0.35;
+/// One-pole HF damping coefficient in the feedback path at 48 kHz (higher =
+/// darker tail; HF decays faster than the broadband RT60, like physical
+/// walls). Other rates raise the pole to the rate ratio so the damping
+/// corner stays at the same frequency (≈8 kHz) instead of climbing with
+/// the rate.
+const DAMPING_48K: f32 = 0.35;
 
 /// Peak delay-line modulation depth in samples at 48 kHz (scaled with the
 /// engine rate). ±24 samples spreads each mode by ~±1–2 %, enough for a
@@ -104,6 +107,8 @@ pub struct Fdn {
     pre_len: usize,
     sample_rate: u32,
     rt60_cached: f32,
+    /// `1 − damping` for this rate, applied per line per sample.
+    damp_mix: f32,
 }
 
 impl Fdn {
@@ -142,6 +147,7 @@ impl Fdn {
             pre_len: 1,
             sample_rate,
             rt60_cached: 0.0,
+            damp_mix: 1.0 - DAMPING_48K.powf(48_000.0 / sample_rate as f32),
         }
     }
 
@@ -184,6 +190,8 @@ impl Fdn {
         let sr = self.sample_rate as f32;
         let depth = MOD_DEPTH_48K * sr / 48_000.0;
         let (xover_lp, xover_hp) = (self.xover_lp, self.xover_hp);
+        let damp_mix = self.damp_mix;
+        let pre_cap = self.predelay.len();
 
         let mut offset = 0usize;
         for chunk in bus.chunks(MOD_UPDATE) {
@@ -199,14 +207,25 @@ impl Fdn {
             }
 
             for (s, &input) in chunk.iter().enumerate() {
-                // Pre-delay (integer, fixed per block).
-                let read =
-                    (self.pre_pos + self.predelay.len() - self.pre_len) % self.predelay.len();
+                // Pre-delay (integer, fixed per block). `pre_len < pre_cap`,
+                // so the read is at most one lap behind: a conditional add
+                // wraps it, no division per sample.
+                let read = if self.pre_pos >= self.pre_len {
+                    self.pre_pos - self.pre_len
+                } else {
+                    self.pre_pos + pre_cap - self.pre_len
+                };
                 let x = self.predelay[read];
                 self.predelay[self.pre_pos] = input;
-                self.pre_pos = (self.pre_pos + 1) % self.predelay.len();
+                self.pre_pos += 1;
+                if self.pre_pos == pre_cap {
+                    self.pre_pos = 0;
+                }
 
                 // Read all line outputs at their (modulated) fractional delay.
+                // The modulated delay stays under `base + depth < cap`
+                // (the line has `margin` slots past its base length), so
+                // the same one-lap wrap applies.
                 let mut o = [0.0f32; N];
                 let mut sum = 0.0f32;
                 for i in 0..N {
@@ -215,7 +234,11 @@ impl Fdn {
                     let cap = self.lines[i].len();
                     let di = d as usize;
                     let frac = d - di as f32;
-                    let r0 = (self.pos[i] + cap - di) % cap;
+                    let r0 = if self.pos[i] >= di {
+                        self.pos[i] - di
+                    } else {
+                        self.pos[i] + cap - di
+                    };
                     let r1 = if r0 == 0 { cap - 1 } else { r0 - 1 };
                     let line = &self.lines[i];
                     o[i] = line[r0] * (1.0 - frac) + line[r1] * frac;
@@ -256,11 +279,14 @@ impl Fdn {
                 for i in 0..N {
                     let fb = o[i] - k;
                     // One-pole low-pass in the loop: HF dies faster than RT60.
-                    self.damp_state[i] += (fb - self.damp_state[i]) * (1.0 - DAMPING);
+                    self.damp_state[i] += (fb - self.damp_state[i]) * damp_mix;
                     let inject = if i % 2 == 0 { x } else { -x };
                     let cap = self.lines[i].len();
                     self.lines[i][self.pos[i]] = self.damp_state[i] * self.fb_gain[i] + inject;
-                    self.pos[i] = (self.pos[i] + 1) % cap;
+                    self.pos[i] += 1;
+                    if self.pos[i] == cap {
+                        self.pos[i] = 0;
+                    }
                 }
             }
             offset += chunk.len();
@@ -349,6 +375,23 @@ mod tests {
                 .sum();
             assert_eq!(d, 0.0, "{name} must be orthogonal to the injection");
         }
+    }
+
+    /// The damping pole follows the rate: at 48 kHz it is the published
+    /// coefficient exactly, and at 96 kHz the equivalent one-pole corner.
+    #[test]
+    fn damping_corner_is_rate_invariant() {
+        let corner_hz = |sample_rate: u32| -> f32 {
+            let fdn = Fdn::new(sample_rate);
+            let a = 1.0 - fdn.damp_mix;
+            -a.ln() * sample_rate as f32 / std::f32::consts::TAU
+        };
+        assert_eq!(Fdn::new(48_000).damp_mix, 1.0 - DAMPING_48K);
+        let (a, b) = (corner_hz(48_000), corner_hz(96_000));
+        assert!(
+            (a - b).abs() < 1.0,
+            "corner moved with the rate: {a} vs {b} Hz"
+        );
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/delay_line.rs
+++ b/omniphony-renderer/renderer/src/delay_line.rs
@@ -75,7 +75,10 @@ impl DelayLine {
             "push_history is only the identity while bypassed",
         );
         self.buf[self.write_pos] = input;
-        self.write_pos = (self.write_pos + 1) % self.buf.len();
+        self.write_pos += 1;
+        if self.write_pos == self.buf.len() {
+            self.write_pos = 0;
+        }
     }
 
     /// Process one sample through the delay line.
@@ -98,21 +101,31 @@ impl DelayLine {
             self.current += RAMP_RATE * delta.signum();
         }
 
-        // Fractional read (linear interpolation).
-        let mut read_f = (self.write_pos as f32 - self.current).rem_euclid(cap as f32);
-        // f32 edge: rem_euclid of a tiny negative (current a hair above
-        // write_pos) rounds to exactly `cap`, which floor()s to an
-        // out-of-bounds index. `cap` is the same position as 0 — wrap it.
+        // Fractional read (linear interpolation). `current` is clamped to
+        // `[0, cap - 2]`, so the read position is at most one lap behind the
+        // write position: one conditional add wraps it, with no division in
+        // the per-sample path (this runs twice per channel per sample for
+        // the ITD alone).
+        let mut read_f = self.write_pos as f32 - self.current;
+        if read_f < 0.0 {
+            read_f += cap as f32;
+        }
+        // f32 edge: a tiny negative (current a hair above write_pos) rounds
+        // to exactly `cap` after the add, which floor()s to an out-of-bounds
+        // index. `cap` is the same position as 0 — wrap it.
         if read_f >= cap as f32 {
             read_f = 0.0;
         }
         let i0 = read_f as usize;
-        let i1 = (i0 + 1) % cap;
+        let i1 = if i0 + 1 == cap { 0 } else { i0 + 1 };
         let frac = read_f - i0 as f32;
         let output = self.buf[i0] + frac * (self.buf[i1] - self.buf[i0]);
 
         // Advance write pointer.
-        self.write_pos = (self.write_pos + 1) % cap;
+        self.write_pos += 1;
+        if self.write_pos == cap {
+            self.write_pos = 0;
+        }
 
         output
     }
@@ -121,6 +134,30 @@ impl DelayLine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fractional delay reads back the impulse at the right place, on
+    /// every lap of the ring — the wrap of both the write pointer and the
+    /// read position is exercised many times over.
+    #[test]
+    fn fractional_delay_is_exact_across_ring_laps() {
+        let mut dl = DelayLine::new(30);
+        dl.set_target_ms(5.5 / 48.0, 48_000);
+        // Settle the ramp on silence.
+        for _ in 0..64 {
+            dl.process(0.0);
+        }
+        for lap in 0..7 {
+            let mut out = Vec::new();
+            for t in 0..40 {
+                out.push(dl.process(if t == 0 { 1.0 } else { 0.0 }));
+            }
+            // 5.5 samples: half the impulse at 5, half at 6, nothing else.
+            for (t, &y) in out.iter().enumerate() {
+                let expected = if t == 5 || t == 6 { 0.5 } else { 0.0 };
+                assert!((y - expected).abs() < 1e-6, "lap {lap} t {t}: {y}");
+            }
+        }
+    }
 
     /// Regression: a fractional target a hair above an integer write position
     /// makes `(write_pos - current)` a tiny negative; `rem_euclid(cap)` then


### PR DESCRIPTION
## What

Three ring buffers in the binaural per-sample path wrapped their indices with `%` against a runtime length:

| ring | divisions per sample | per channel |
|---|---|---|
| `DelayLine` (ITD) | 1 f32 `rem_euclid` + 2 `%` | × 2 lines |
| `ReflectionBank::read_frac` | 3 `%` per tap | × 12 taps = 36 |
| `Fdn` | 1 per line + 2 (pre-delay) | 10 (shared) |

An integer division by a variable costs 20–40 cycles. At 16 channels × 48 kHz the reflection bank alone ran ~28 million of them per second, around a convolver whose tap loop had been carefully made throughput-bound (#226).

Two smoothing constants were per-sample numbers independent of the rate, so their time constants halved at 96 kHz: the reflection taps' gain smoothing (`GAIN_SMOOTH = 0.015`) and the FDN's HF damping pole (`DAMPING = 0.35`).

## How

- Every one of those reads sits less than one lap behind its write pointer (delays are clamped to the ring length by their setters and ramp between such values), so one compare-and-add wraps them. Same indices come out: **bit-identical**. The delay-line path is covered by the KEMAR golden, which passes unchanged.
- `gain_smooth_for(fs) = 1 − 0.985^(48000/fs)` and `damp = 0.35^(48000/fs)`, computed once at construction. The FDN is bit-identical at 48 kHz (`powf(x, 1) = x`); the reflection coefficient lands one ulp under the old literal (`1 − 0.985` in f32 is 0.014999986).
- Tests: a fractional ITD delay read back exactly across seven ring laps; the reflection fade reaches the same level after 3 ms at 48 and 96 kHz; the FDN damping corner (≈8 kHz) is the same at both rates.

No timing number is claimed here — the change is a straight removal of divisions from loops that run per sample; the `perf-gate` feature is the place to measure it if wanted.

## Review series

Independent of the other PRs (`delay_line.rs`, `reflections.rs` outside `first_order_images`, `reverb.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
