### PR TITLE
fix(binaural): reference reflection delays to the clamped source

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -734,7 +734,18 @@ impl BinauralRenderer {
                     pos[1] as f32 * unit_scale_m,
                     pos[2] as f32 * unit_scale_m,
                 ];
-                let images = reflections::first_order_images(phys, reflections.room_size_m);
+                // The image sources are mirrors of the source *as pulled
+                // inside the room*, so the direct-path reference for their
+                // relative delays is that clamped source, not the raw one.
+                // With the raw distance, a source outside the room (any
+                // `unit_scale_m` ≥ 2 with the default room) had every
+                // reflection arrive early by the excess, and the near wall's
+                // at zero delay — a coincident copy of the direct sound.
+                let src_m = reflections::clamp_into_room(phys, reflections.room_size_m);
+                let d_src = (src_m[0] * src_m[0] + src_m[1] * src_m[1] + src_m[2] * src_m[2])
+                    .sqrt()
+                    .max(MIN_DISTANCE_M);
+                let images = reflections::first_order_images(src_m, reflections.room_size_m);
                 let c_sound = reflections::speed_of_sound();
                 for (i, img) in images.iter().enumerate() {
                     let d_img = (img[0] * img[0] + img[1] * img[1] + img[2] * img[2])
@@ -742,7 +753,7 @@ impl BinauralRenderer {
                         .max(MIN_DISTANCE_M);
                     // Relative to the direct path so the direct sound keeps
                     // zero added latency (A/V sync unchanged).
-                    let rel_delay_s = (d_img - dist_m).max(0.0) / c_sound;
+                    let rel_delay_s = (d_img - d_src).max(0.0) / c_sound;
                     // Head-relative direction → broadband ILD pan (no HRIR
                     // conv per reflection: one tap + one multiply per ear).
                     let ih = head_pose.rotate([img[0] as f64, img[1] as f64, img[2] as f64]);
@@ -1167,6 +1178,62 @@ mod tests {
             "reflections produced no late energy: {}",
             tail(&wet)
         );
+    }
+
+    /// A source outside the room (unit scale 3, default 4 m width) must not
+    /// get a reflection on top of its direct sound: the first samples of
+    /// the render carry the direct HRIR only, exactly as for the same
+    /// source with reflections off, and the wall copies land later.
+    #[test]
+    fn reflections_of_an_outside_source_do_not_coincide_with_the_direct() {
+        let n = 2_048;
+        let mut input = vec![0.0f32; n];
+        input[0] = 1.0;
+        let pos = [[1.0, 0.0, 0.0]]; // 3 m to the right at unit scale 3
+        let render = |enabled: bool| -> Vec<f32> {
+            let params = BinauralFrameParams {
+                unit_scale_m: 3.0,
+                reflections: BinauralReflections {
+                    enabled,
+                    room_size_m: [4.0, 5.0, 2.7],
+                    level: 0.5,
+                },
+                ..dry_params()
+            };
+            let mut out = vec![0.0f32; n * 2];
+            let mut r = BinauralRenderer::new(48_000);
+            r.render_frame(
+                &input,
+                1,
+                n,
+                &params,
+                &pos,
+                &[ChannelGain::flat(1.0)],
+                &[],
+                None,
+                &mut out,
+            );
+            out
+        };
+        let (dry, wet) = (render(false), render(true));
+        // The near wall's image sits 2·margin = 0.1 m beyond the clamped
+        // source: 14 samples at 48 kHz. Before that, wet == dry.
+        let head = 10 * 2;
+        let diff: f32 = dry[..head]
+            .iter()
+            .zip(&wet[..head])
+            .map(|(a, b)| (a - b).abs())
+            .sum();
+        assert!(
+            diff < 1e-6,
+            "a reflection coincides with the direct sound: {diff}"
+        );
+        let later: f32 = wet[head..]
+            .iter()
+            .zip(&dry[head..])
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum();
+        assert!(later > 1e-6, "no reflections at all: {later}");
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/reflections.rs
+++ b/omniphony-renderer/renderer/src/binaural/reflections.rs
@@ -43,18 +43,40 @@ const GAIN_SMOOTH: f32 = 0.015;
 /// Number of first-order images of a shoebox (one per wall).
 pub const NUM_REFLECTIONS: usize = 6;
 
+/// Half-extents of a `room` (full extents, metres), each axis clamped to
+/// [`MIN_ROOM_M`]..[`MAX_ROOM_M`].
+fn half_extents(room_m: [f32; 3]) -> [f32; 3] {
+    let mut half = [0.0f32; 3];
+    for a in 0..3 {
+        half[a] = (room_m[a].clamp(MIN_ROOM_M, MAX_ROOM_M)) * 0.5;
+    }
+    half
+}
+
+/// `src` (listener-relative metres, listener at the room centre) pulled just
+/// inside the walls of `room`, by [`WALL_MARGIN_M`]. The image-source
+/// geometry is only meaningful for a source inside the room; this is the
+/// source [`first_order_images`] actually mirrors, and therefore the one the
+/// direct-path reference (distance, hence the relative delays) must use too
+/// — a source that is outside the room and left there makes its own images
+/// arrive *before* it.
+pub fn clamp_into_room(src_m: [f32; 3], room_m: [f32; 3]) -> [f32; 3] {
+    let half = half_extents(room_m);
+    let mut s = src_m;
+    for a in 0..3 {
+        s[a] = s[a].clamp(-(half[a] - WALL_MARGIN_M), half[a] - WALL_MARGIN_M);
+    }
+    s
+}
+
 /// Mirror `src` (listener-relative metres, listener at the room centre)
 /// across each of the six walls of a `room` (full extents, metres).
 ///
-/// Sources outside the room are first clamped just inside the walls — the
-/// geometry stays valid for any `unit_scale_m`.
+/// Sources outside the room are first clamped just inside the walls (see
+/// [`clamp_into_room`]) — the geometry stays valid for any `unit_scale_m`.
 pub fn first_order_images(src_m: [f32; 3], room_m: [f32; 3]) -> [[f32; 3]; NUM_REFLECTIONS] {
-    let mut half = [0.0f32; 3];
-    let mut s = src_m;
-    for a in 0..3 {
-        half[a] = (room_m[a].clamp(MIN_ROOM_M, MAX_ROOM_M)) * 0.5;
-        s[a] = s[a].clamp(-(half[a] - WALL_MARGIN_M), half[a] - WALL_MARGIN_M);
-    }
+    let half = half_extents(room_m);
+    let s = clamp_into_room(src_m, room_m);
     let mut out = [[0.0f32; 3]; NUM_REFLECTIONS];
     for a in 0..3 {
         let mut pos = s;
@@ -198,6 +220,47 @@ mod tests {
         assert_eq!(images[3][1], -6.0);
         assert_eq!(images[4][2], 3.0);
         assert_eq!(images[5][2], -3.0);
+    }
+
+    /// Every image of a source is farther from the listener than the
+    /// (clamped) source itself, so every relative delay is positive — for a
+    /// source well outside the room included, where the raw distance would
+    /// exceed the near-wall image's.
+    #[test]
+    fn images_are_never_closer_than_the_clamped_source() {
+        let room = [4.0, 5.0, 2.7];
+        let dist = |p: [f32; 3]| (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt();
+        for src in [
+            [0.0f32, 1.0, 0.0],
+            [3.0, 0.0, 0.0],
+            [0.0, 4.0, 0.0],
+            [2.0, 3.0, 1.0],
+        ] {
+            let clamped = clamp_into_room(src, room);
+            let d_src = dist(clamped);
+            for (i, img) in first_order_images(src, room).iter().enumerate() {
+                let d_img = dist(*img);
+                // Mirroring pushes one coordinate outward (|2h − s| > |s|
+                // for |s| < h), so the image is strictly farther — by 2 ×
+                // the margin along the axis for a source against that wall,
+                // less in norm when the source is off that axis.
+                assert!(
+                    d_img > d_src + 1e-4,
+                    "src {src:?} image {i}: {d_img} not beyond the source at {d_src}"
+                );
+            }
+            if dist(src) > d_src {
+                // The raw distance would have put the near-wall image *ahead*.
+                let nearest = first_order_images(src, room)
+                    .iter()
+                    .map(|img| dist(*img))
+                    .fold(f32::MAX, f32::min);
+                assert!(
+                    nearest < dist(src),
+                    "{src:?}: the premise of the test fails"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

`first_order_images` pulls the source just inside the walls (5 cm margin) before mirroring it, but `render_frame` computed each image's relative delay against the **raw** source distance. As soon as the source sat outside the room — `unit_scale_m ≥ 2` with the default 4 × 5 × 2.7 m room, while `BINAURAL.md` recommends 3–4 — every reflection arrived early by the excess, and the near wall's image landed at **zero delay**: a coincident copy of the direct sound at −12 dB (source ADM (1,0,0) at scale 3), or a 7-sample comb of ±2 dB at scale 2.

## How

- `reflections::clamp_into_room` exposes the clamp; `render_frame` references the delays to that clamped source, the one the images are mirrors of. The near-wall reflection now sits at least 2 × margin (0.1 m, 14 samples at 48 kHz) behind the direct sound and every image is beyond the source.
- The raw distance still drives the air absorption and the reverb send, which are about where the source really is.
- Tests: geometric (every image strictly farther than the clamped source, for sources inside and outside the room), and end-to-end (a 3 m source in a 4 m room: the first samples of the wet render equal the dry one; the wall copies land later).

The golden scene has reflections off: unchanged.

## Review series

Stacked on #330 (`fix/binaural-per-sample-gain-ramp`). `fix/binaural-distance-cues-relative-to-direct` follows and builds on the clamped distance introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
