### PR TITLE
docs(binaural): describe the direct level and distance cues as they are

### DIFF
--- a/omniphony-renderer/BINAURAL.md
+++ b/omniphony-renderer/BINAURAL.md
@@ -11,11 +11,19 @@ Per channel, per block:
 ```
 position → rotate(head pose) → (azimuth, elevation, distance)
          → air-absorption low-pass (cutoff falls with distance)
-         → 1/d gain → per-ear ITD delay → per-ear HRIR convolution
-         → + 6 first-order shoebox reflections (delay + ILD pan per ear)
-         → + shared late-reverb tail (stereo FDN, distance-driven DRR)
+         → per-ear ITD delay → per-ear HRIR convolution   (authored level, no 1/d)
+         → + 6 first-order shoebox reflections (delay + ILD pan per ear,
+             level relative to the direct: d_source / d_image)
+         → + shared late-reverb tail (stereo FDN, send ∝ distance)
          → mix into [L, R]
 ```
+
+The direct path applies **no distance attenuation**: object and bed levels
+are authored by the mixer (Atmos object gain) and are respected as such.
+Distance is carried by the *cues* around the direct sound instead — the
+reflections and the reverb send are expressed relative to it, so their ratio
+to the direct sound falls with distance the way it does in a room, and the
+air absorption dulls far sources.
 
 Measured cost: ~0.09 ms per 40-sample block for a 16-channel Atmos stream
 (~11 % of the realtime budget), reflections included.
@@ -129,14 +137,23 @@ directly instead.
   level** and **Reflection level** by ear — too high colours dialogue and
   sounds echoey, too low collapses back into the head.
 - **Distance**: past ~1 m the brain judges distance mostly from the
-  direct/reverb ratio, not loudness. The reverberant field is
-  distance-independent (like a real room) while the direct falls as 1/d, so
-  raising `unit_scale_m` makes far objects genuinely *sound* far. Air
-  absorption adds the matching "far sounds dull" high-frequency roll-off
-  (bypassed within 3 m, ~14 kHz cutoff at 10 m, ~5 kHz at 30 m).
+  direct/reverb ratio, not loudness. The direct sound keeps its authored
+  level at any distance (there is no 1/d on it — the mixer set that level),
+  so the renderer moves the ratio from the other side: the reverb send grows
+  in proportion to the distance (unity at 1.5 m, capped at 6 m) and each
+  early reflection is levelled relative to the direct sound
+  (`d_source / d_image`), exactly as if the direct had fallen as 1/d and
+  been brought back up. Raising `unit_scale_m` therefore makes far objects
+  genuinely *sound* far without making them quieter. Air absorption adds
+  the matching "far sounds dull" high-frequency roll-off (bypassed within
+  3 m, ~14 kHz cutoff at 10 m, ~5 kHz at 30 m).
 - **Scale**: `unit_scale_m` sets how far "1 ADM unit" is in metres. At the
   default 1.0 the far wall of the mix is one metre from your nose — try 3–4
-  for a room-sized stage.
+  for a room-sized stage. Size the reflection room to contain the scene
+  (half-extents ≥ `unit_scale_m`, i.e. 6–8 m wide and deep for a scale of
+  3–4): the image-source model pulls a source that sits outside the room
+  back inside before mirroring it, which keeps the geometry valid but puts
+  the reflections where the wall is, not where the object is.
 - **ITD fit**: `head_radius_m` defaults to a KEMAR-ish 8.75 cm. If
   localisation feels smeared, measure ear-to-ear width and set half of it.
 - **HRTF**: the embedded measured KEMAR (`saf`) is the best generic default —

--- a/omniphony-renderer/renderer/src/live_params.rs
+++ b/omniphony-renderer/renderer/src/live_params.rs
@@ -495,7 +495,8 @@ pub struct BinauralReflections {
     pub enabled: bool,
     /// Room extents in metres: [width (x), depth (y), height (z)].
     pub room_size_m: [f32; 3],
-    /// Per-reflection wall gain (0..1) applied on top of the 1/d law.
+    /// Per-reflection wall gain (0..1) applied on top of the distance law
+    /// (`d_source / d_image`, the image's 1/d relative to the direct sound).
     pub level: f32,
 }
 
@@ -514,8 +515,9 @@ impl Default for BinauralReflections {
 /// Late-reverb (FDN) settings for the binaural stage. Models the LISTENING
 /// room — a small, dry, constant space like the room around a loudspeaker
 /// setup — not the scene's acoustics (those are in the content and pass
-/// through). The reverberant field level is distance-independent while the
-/// direct falls as 1/d, so the direct/reverb ratio carries distance.
+/// through). The direct sound keeps its authored level at any distance, so
+/// the per-source send grows in proportion to the distance instead: the
+/// direct/reverb ratio carries distance the way it does in a room.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BinauralReverb {
     /// Master enable for the late tail.
@@ -558,8 +560,9 @@ pub struct BinauralLiveParams {
     pub mode: BinauralMode,
     /// Headphone L/R output gain/mute (dedicated — see [`EarLiveParams`]).
     pub ears: [EarLiveParams; 2],
-    /// Metres represented by one ADM unit; scales physical distance for the
-    /// 1/d gain and ITD/ILD without altering object directions.
+    /// Metres represented by one ADM unit; scales the physical distance the
+    /// distance cues see (reflections, reverb send, air absorption) without
+    /// altering object directions or the direct level.
     pub unit_scale_m: f32,
     /// Effective head radius (m) for the Woodworth ITD model — half the
     /// inter-ear distance. Per-listener fit; default is KEMAR-ish.


### PR DESCRIPTION
## What

`BINAURAL.md` still drew a `→ 1/d gain →` stage in the pipeline and told the reader that "the direct falls as 1/d"; the `BinauralReverb` and `unit_scale_m` doc comments in `live_params.rs` said the same. That gain was removed in b42c8e1c (June): the direct path keeps the authored object level at any distance, and — with #332 — the reflections and the reverb send are expressed relative to it. Someone tuning `unit_scale_m` from the old text expected a loudness cue that does not exist.

## How

Doc only. The pipeline block, the **Distance** and **Scale** tips and the three doc comments describe the mechanism in place (authored level respected; reflection level `d_source / d_image`; reverb send ∝ distance, unity at 1.5 m, capped at 6 m; air absorption). The scale tip also says how to size the reflection room so it contains the scene (half-extents ≥ `unit_scale_m`), since the image-source model pulls an outside source back inside before mirroring it (#331).

## Review series

Based on #332 so the text lands with the behaviour it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
