### PR TITLE
feat(binaural): give each early reflection its own interaural delay

### DIFF
--- a/omniphony-renderer/BINAURAL.md
+++ b/omniphony-renderer/BINAURAL.md
@@ -12,8 +12,8 @@ Per channel, per block:
 position → rotate(head pose) → (azimuth, elevation, distance)
          → air-absorption low-pass (cutoff falls with distance)
          → per-ear ITD delay → per-ear HRIR convolution   (authored level, no 1/d)
-         → + 6 first-order shoebox reflections (delay + ILD pan per ear,
-             level relative to the direct: d_source / d_image)
+         → + 6 first-order shoebox reflections (per-ear delay incl. the image's
+             ITD + ILD pan, level relative to the direct: d_source / d_image)
          → + shared late-reverb tail (stereo FDN, send ∝ distance)
          → mix into [L, R]
 ```

--- a/omniphony-renderer/renderer/src/binaural/itd.rs
+++ b/omniphony-renderer/renderer/src/binaural/itd.rs
@@ -33,7 +33,14 @@ const SPEED_OF_SOUND: f32 = 343.0;
 pub fn ear_delays_seconds(azimuth_rad: f32, elevation_rad: f32, head_radius_m: f32) -> (f32, f32) {
     // Signed sine of the lateral angle: +1 at the right ear, −1 at the left,
     // 0 anywhere in the median plane (front, back, overhead alike).
-    let s = (elevation_rad.cos() * azimuth_rad.sin()).clamp(-1.0, 1.0);
+    ear_delays_from_lateral(elevation_rad.cos() * azimuth_rad.sin(), head_radius_m)
+}
+
+/// [`ear_delays_seconds`] for a direction given by the **sine of its lateral
+/// angle** — the `x` component of the unit head-relative vector, which a
+/// caller that already has the vector need not turn back into angles.
+pub fn ear_delays_from_lateral(lateral_sine: f32, head_radius_m: f32) -> (f32, f32) {
+    let s = lateral_sine.clamp(-1.0, 1.0);
     let lateral = s.abs().asin();
     let mag = (head_radius_m / SPEED_OF_SOUND) * (lateral + s.abs());
     if s >= 0.0 {

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -903,12 +903,17 @@ impl BinauralRenderer {
                     // zero added latency (A/V sync unchanged).
                     let rel_delay_s = (d_img - d_src).max(0.0) / c_sound;
                     // Head-relative direction → broadband ILD pan (no HRIR
-                    // conv per reflection: one tap + one multiply per ear).
+                    // conv per reflection: one tap + one multiply per ear)
+                    // and the image's own ITD, added to each ear's tap delay:
+                    // the reflections then lateralise by time like the direct
+                    // sound does, which an ILD pan alone cannot give and is
+                    // most of what makes them read as coming from a wall.
                     let ih = head_pose.rotate([img[0] as f64, img[1] as f64, img[2] as f64]);
                     let inorm = ((ih[0] * ih[0] + ih[1] * ih[1] + ih[2] * ih[2]) as f32)
                         .sqrt()
                         .max(1e-6);
                     let lat = (ih[0] as f32 / inorm).clamp(-1.0, 1.0);
+                    let (itd_l_img, itd_r_img) = itd::ear_delays_from_lateral(lat, head_radius_m);
                     const SHADOW: f32 = 0.5;
                     let g_r = ((1.0 + SHADOW * lat) / (1.0 + SHADOW)).sqrt();
                     let g_l = ((1.0 - SHADOW * lat) / (1.0 + SHADOW)).sqrt();
@@ -920,7 +925,13 @@ impl BinauralRenderer {
                     // distance — a receding source got *drier*.
                     let g_dist = (d_src / d_img).min(MAX_DISTANCE_GAIN);
                     let g = reflections.level.clamp(0.0, 1.0) * g_dist;
-                    bank.set_targets(i, rel_delay_s, g * g_l, g * g_r);
+                    bank.set_targets(
+                        i,
+                        rel_delay_s + itd_l_img,
+                        rel_delay_s + itd_r_img,
+                        g * g_l,
+                        g * g_r,
+                    );
                 }
             }
 
@@ -1577,6 +1588,58 @@ mod tests {
         assert!(
             far > near * 4.0 && far < near * 20.0,
             "reverb send off the 1/d law: 1 m {near:.3e} vs 3 m {far:.3e}"
+        );
+    }
+
+    /// A reflection arrives at the two ears with the interaural delay of its
+    /// own direction. Source at (0.9, 0.3, 0) in the default room: the first
+    /// image to land is the ceiling's (image at z = 2.7, 1.9 m beyond the
+    /// source: 267 samples), whose lateral sine is 0.9 / 2.86 = 0.31, i.e. an
+    /// ITD of 0.16 ms ≈ 8 samples with the left ear the far one. Before, both
+    /// ears received it at the same instant.
+    #[test]
+    fn reflections_carry_their_own_itd() {
+        let n = 1_024;
+        let mut input = vec![0.0f32; n];
+        input[0] = 1.0;
+        let pos = [[0.9, 0.3, 0.0]];
+        let render = |enabled: bool| -> Vec<f32> {
+            let params = BinauralFrameParams {
+                reflections: BinauralReflections {
+                    enabled,
+                    room_size_m: [4.0, 5.0, 2.7],
+                    level: 0.5,
+                },
+                ..dry_params()
+            };
+            let mut out = vec![0.0f32; n * 2];
+            let mut r = BinauralRenderer::new(48_000);
+            r.render_frame(
+                &input,
+                1,
+                n,
+                &params,
+                &pos,
+                &[ChannelGain::flat(1.0)],
+                &[],
+                None,
+                &mut out,
+            );
+            out
+        };
+        let (dry, wet) = (render(false), render(true));
+        // First sample where the wet render departs from the dry one, per ear.
+        let onset = |ear: usize| -> usize {
+            (0..n)
+                .find(|&s| (wet[s * 2 + ear] - dry[s * 2 + ear]).abs() > 1e-5)
+                .expect("no reflection energy at all")
+        };
+        let (l, r) = (onset(0), onset(1));
+        assert!((250..290).contains(&r), "right-ear first reflection at {r}");
+        let itd = l as i64 - r as i64;
+        assert!(
+            (5..=11).contains(&itd),
+            "left minus right onset {itd} samples, expected ≈ 8 (L={l}, R={r})"
         );
     }
 

--- a/omniphony-renderer/renderer/src/binaural/reflections.rs
+++ b/omniphony-renderer/renderer/src/binaural/reflections.rs
@@ -145,15 +145,25 @@ impl ReflectionBank {
         }
     }
 
-    /// Update one reflection's targets: relative delay (s) and per-ear gains.
-    /// Called once per block per reflection.
-    pub fn set_targets(&mut self, idx: usize, delay_s: f32, gain_l: f32, gain_r: f32) {
+    /// Update one reflection's targets: per-ear relative delays (s) and
+    /// per-ear gains. Called once per block per reflection. The two delays
+    /// differ by the interaural time difference of the image's direction —
+    /// the taps are separate per ear precisely so that a reflection can be
+    /// lateralised by time, the cue an ILD pan alone cannot give.
+    pub fn set_targets(
+        &mut self,
+        idx: usize,
+        delay_l_s: f32,
+        delay_r_s: f32,
+        gain_l: f32,
+        gain_r: f32,
+    ) {
         let max = (self.ring.len() - 2) as f32;
-        let d = (delay_s * self.sample_rate as f32).clamp(0.0, max);
-        for (tap, gain) in [
-            (&mut self.taps_l[idx], gain_l),
-            (&mut self.taps_r[idx], gain_r),
+        for (tap, delay_s, gain) in [
+            (&mut self.taps_l[idx], delay_l_s, gain_l),
+            (&mut self.taps_r[idx], delay_r_s, gain_r),
         ] {
+            let d = (delay_s * self.sample_rate as f32).clamp(0.0, max);
             tap.delay_target = d;
             tap.gain_target = gain;
             // While the tap is (near) silent a delay jump is inaudible — snap
@@ -177,14 +187,6 @@ impl ReflectionBank {
         self.write_pos += 1;
         if self.write_pos >= self.ring.len() {
             self.write_pos = 0;
-        }
-    }
-
-    /// Fade every tap out (e.g. when the channel goes silent) so re-enabling
-    /// does not click.
-    pub fn mute_targets(&mut self) {
-        for t in self.taps_l.iter_mut().chain(self.taps_r.iter_mut()) {
-            t.gain_target = 0.0;
         }
     }
 
@@ -318,7 +320,7 @@ mod tests {
         let mut bank = ReflectionBank::new(48_000);
         // One active tap: 10-sample delay, gain 0.5 on the left only. Pre-set
         // current = target by letting it settle on silence first.
-        bank.set_targets(0, 10.0 / 48_000.0, 0.5, 0.0);
+        bank.set_targets(0, 10.0 / 48_000.0, 10.0 / 48_000.0, 0.5, 0.0);
         for _ in 0..4_000 {
             bank.process(0.0);
         }
@@ -346,7 +348,7 @@ mod tests {
     fn gain_smoothing_is_rate_invariant() {
         let settle_after_ms = |sample_rate: u32| -> f32 {
             let mut bank = ReflectionBank::new(sample_rate);
-            bank.set_targets(0, 0.0, 1.0, 1.0);
+            bank.set_targets(0, 0.0, 0.0, 1.0, 1.0);
             let n = (sample_rate as f32 * 0.003) as usize; // 3 ms
             let mut last = 0.0;
             for _ in 0..n {
@@ -362,17 +364,48 @@ mod tests {
         assert!((gain_smooth_for(48_000) - GAIN_SMOOTH_48K).abs() < 1e-6);
     }
 
+    /// The two ears of one reflection read the ring at their own delays: an
+    /// impulse comes out of the left tap at its delay and of the right tap
+    /// at the other — the interaural difference of the reflection.
+    #[test]
+    fn ears_read_at_their_own_delays() {
+        let mut bank = ReflectionBank::new(48_000);
+        bank.set_targets(0, 10.0 / 48_000.0, 24.0 / 48_000.0, 0.5, 0.5);
+        for _ in 0..4_000 {
+            bank.process(0.0);
+        }
+        let mut outs = Vec::new();
+        outs.push(bank.process(1.0));
+        for _ in 0..30 {
+            outs.push(bank.process(0.0));
+        }
+        assert!(
+            (outs[10].0 - 0.5).abs() < 1e-3,
+            "left at 10: {}",
+            outs[10].0
+        );
+        assert!(
+            (outs[24].1 - 0.5).abs() < 1e-3,
+            "right at 24: {}",
+            outs[24].1
+        );
+        assert!(
+            outs[10].1.abs() < 1e-3 && outs[24].0.abs() < 1e-3,
+            "ears bled"
+        );
+    }
+
     #[test]
     fn gain_changes_are_smoothed() {
         let mut bank = ReflectionBank::new(48_000);
-        bank.set_targets(0, 0.0, 1.0, 1.0);
+        bank.set_targets(0, 0.0, 0.0, 1.0, 1.0);
         for _ in 0..4_000 {
             bank.process(1.0); // settle: DC input, gain 1
         }
         let (settled, _) = bank.process(1.0);
         assert!((settled - 1.0).abs() < 1e-2);
         // Drop the gain target to 0: output must move gradually, not jump.
-        bank.set_targets(0, 0.0, 0.0, 0.0);
+        bank.set_targets(0, 0.0, 0.0, 0.0, 0.0);
         let (next, _) = bank.process(1.0);
         assert!(next > 0.9, "gain jumped instead of smoothing: {next}");
     }


### PR DESCRIPTION
## What (S2-01)

An early reflection was a broadband ILD pan over two taps sharing one delay: level told the ears which side it came from, time did not. The taps are already separate per ear (`taps_l`, `taps_r`), so the interaural delay of the image's direction — the same Woodworth formula as the direct path, evaluated from the lateral sine the pan already computes — is added to each ear's tap delay. **No extra ring read, no extra multiply**: the reflections now lateralise by time like the direct sound, which is most of what makes them read as coming from a wall rather than from inside the head.

## How

- `itd::ear_delays_from_lateral(lateral_sine, r)`: the formula for a caller that has the direction vector; `ear_delays_seconds` delegates to it.
- `ReflectionBank::set_targets(idx, delay_l_s, delay_r_s, gain_l, gain_r)`; `render_frame` passes `rel_delay + itd_ear(image)` per ear.
- `mute_targets()`, dead since #329, removed.
- `BINAURAL.md` pipeline line updated.

## Tests

- Bank: the two ears of one tap read the ring at their own delays (10 vs 24 samples).
- End to end: source at (0.9, 0.3, 0) in the default room; the ceiling image lands first (267 samples) with lateral sine 0.31 → the left ear must receive it 5–11 samples after the right (8 predicted). Before this PR both onsets coincided.
- Golden unchanged (reflections off in the scene). 359 renderer tests pass.

## Listening

Externalisation with reflections on, before/after. This is the first PR of the series-2 lot 1; independent of the others (`fix`-chain of series 1 is merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
