### PR TITLE
feat(binaural): shade the pinna colouration by each ear's exposure

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/hrir.rs
+++ b/omniphony-renderer/renderer/src/binaural/hrir.rs
@@ -119,6 +119,34 @@ impl SyntheticHrir {
     }
 }
 
+/// How much of a source each ear "sees", `(left, right)` in `[0, 1]`: the
+/// exposure the head model shades by, `(1 ∓ lateral) / 2`, with `lateral`
+/// the sine of the lateral angle. 0.5 for both ears anywhere in the median
+/// plane, 1 for the ear on the source's side of the interaural axis.
+pub fn ear_exposure(az_deg: f32, el_deg: f32) -> (f32, f32) {
+    let lateral = (az_deg.to_radians().sin() * el_deg.to_radians().cos()).clamp(-1.0, 1.0);
+    (0.5 * (1.0 - lateral), 0.5 * (1.0 + lateral))
+}
+
+/// Pinna colouration left on the ear that faces away from the source.
+///
+/// The pinna's cavities are what carve the elevation notches, and they face
+/// outward: the shadowed ear's pinna receives only what diffracts around the
+/// head, and its notches are correspondingly shallow. The parametric models
+/// used to apply their full colouration to both ears in every direction —
+/// right near the median plane, wrong at 90°, where the hidden ear was
+/// coloured as if it saw the source.
+pub const PINNA_SHADOW_FLOOR: f32 = 0.3;
+
+/// Factor on the pinna depth for an ear of the given exposure: 1 in the
+/// median plane (exposure 0.5) and on the facing side, falling linearly to
+/// [`PINNA_SHADOW_FLOOR`] for the fully shadowed ear. Continuous, and the
+/// mirror of the source mirrors the factors.
+#[inline]
+pub fn pinna_shade(exposure: f32) -> f32 {
+    (PINNA_SHADOW_FLOOR + (1.0 - PINNA_SHADOW_FLOOR) * 2.0 * exposure).min(1.0)
+}
+
 impl HrirProvider for SyntheticHrir {
     fn render(&self, az_deg: f32, el_deg: f32, sample_rate: u32) -> HrirPair {
         let az = az_deg.to_radians();
@@ -268,8 +296,10 @@ impl HrirProvider for ParametricPinnaHrir {
         }
         let (taus, rear_scale) = Self::echo_train(az_deg, el_deg, sample_rate, &self.d);
         let depth = self.depth * rear_scale;
-        pair.left = Self::apply_pinna(&pair.left, &taus, depth);
-        pair.right = Self::apply_pinna(&pair.right, &taus, depth);
+        // Each ear gets the echoes to the extent it faces the source.
+        let (exp_l, exp_r) = ear_exposure(az_deg, el_deg);
+        pair.left = Self::apply_pinna(&pair.left, &taus, depth * pinna_shade(exp_l));
+        pair.right = Self::apply_pinna(&pair.right, &taus, depth * pinna_shade(exp_r));
         pair
     }
 }
@@ -777,6 +807,42 @@ mod tests {
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f32, f32::max);
         assert!(max_diff < 0.05, "discontinuity at the zenith: {max_diff}");
+    }
+
+    /// The shadowed ear keeps a shallower version of the pinna colouration;
+    /// the median plane is untouched (both ears at exposure 0.5 → factor 1).
+    #[test]
+    fn pinna_is_shallower_on_the_shadowed_ear() {
+        assert_eq!(pinna_shade(0.5), 1.0);
+        assert_eq!(pinna_shade(1.0), 1.0);
+        assert!((pinna_shade(0.0) - PINNA_SHADOW_FLOOR).abs() < 1e-6);
+        let pinna = ParametricPinnaHrir {
+            d: ParametricPinnaHrir::D_PB_NH,
+            depth: 1.0,
+        };
+        // Colouration energy relative to the ear's own head-shadow base, so
+        // the shadowed ear's lower level does not enter the comparison.
+        let colour = |az: f32, ear: fn(&HrirPair) -> &[f32; HRIR_LEN]| -> f32 {
+            let p = pinna.render(az, 0.0, 48_000);
+            let s = SyntheticHrir.render(az, 0.0, 48_000);
+            let diff: f32 = ear(&p)
+                .iter()
+                .zip(ear(&s).iter())
+                .map(|(a, b)| (a - b) * (a - b))
+                .sum();
+            diff / energy(ear(&s))
+        };
+        // Source hard right: the right ear's colouration is the full one, the
+        // left ear's is scaled by the floor (energy ratio ≈ floor² = 0.09).
+        let (right, left) = (colour(90.0, |p| &p.right), colour(90.0, |p| &p.left));
+        let ratio = left / right;
+        assert!(
+            ratio < 0.2 && ratio > 0.04,
+            "shadowed/facing colouration energy ratio {ratio}, expected ≈ 0.09"
+        );
+        // Median plane: both ears equally coloured.
+        let (fl, fr) = (colour(0.0, |p| &p.left), colour(0.0, |p| &p.right));
+        assert!((fl - fr).abs() < 1e-6 * fl.max(1e-12));
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/prtf.rs
+++ b/omniphony-renderer/renderer/src/binaural/prtf.rs
@@ -17,7 +17,7 @@
 //! are NOT the exact (unpublished) order-5 polynomials — a representative
 //! generic set, individualizable later from a pinna photo.
 
-use super::hrir::{HRIR_LEN, HrirPair, HrirProvider, SyntheticHrir};
+use super::hrir::{HRIR_LEN, HrirPair, HrirProvider, SyntheticHrir, ear_exposure, pinna_shade};
 
 const PI: f32 = std::f32::consts::PI;
 
@@ -116,8 +116,9 @@ impl SpagnolPrtfHrir {
     }
 
     /// Resonance (parallel) + notch (cascade) blocks on one ear's head-shadow
-    /// IR, then dry/wet-mixed by `depth`.
-    fn apply(&self, base: &[f32; HRIR_LEN], b: &PrtfBlocks) -> [f32; HRIR_LEN] {
+    /// IR, then dry/wet-mixed by `depth` (this ear's, see
+    /// [`pinna_shade`]).
+    fn apply(&self, base: &[f32; HRIR_LEN], b: &PrtfBlocks, depth: f32) -> [f32; HRIR_LEN] {
         // Resonance block: H_res1 (unity + peak) in parallel with H_res2 (pure
         // bandpass), summed.
         let r1 = b.res1.process(base);
@@ -129,7 +130,7 @@ impl SpagnolPrtfHrir {
         // Reflection block: three notches in series.
         let wet = b.n3.process(&b.n2.process(&b.n1.process(&res)));
         // Dry/wet mix — `depth` is the amount of pinna coloration.
-        let d = self.depth.clamp(0.0, 1.0);
+        let d = depth.clamp(0.0, 1.0);
         let mut out = [0.0f32; HRIR_LEN];
         for n in 0..HRIR_LEN {
             out[n] = (1.0 - d) * base[n] + d * wet[n];
@@ -173,8 +174,12 @@ impl HrirProvider for SpagnolPrtfHrir {
             n3: Biquad::peak_notch(cf(10000.0 + 4000.0 * t), nd, bw, fs, true),
         };
 
-        pair.left = self.apply(&pair.left, &blocks);
-        pair.right = self.apply(&pair.right, &blocks);
+        // Each ear gets the pinna colouration to the extent it faces the
+        // source; the blocks themselves are shared (the PRTF is azimuth-
+        // invariant near the median plane).
+        let (exp_l, exp_r) = ear_exposure(az_deg, el_deg);
+        pair.left = self.apply(&pair.left, &blocks, self.depth * pinna_shade(exp_l));
+        pair.right = self.apply(&pair.right, &blocks, self.depth * pinna_shade(exp_r));
         pair
     }
 }
@@ -247,6 +252,31 @@ mod tests {
             sumsq_diff(&a.left, &b.left) > 1e-4,
             "freq_scale had no effect"
         );
+    }
+
+    /// The shadowed ear keeps a shallower version of the PRTF colouration
+    /// (dry/wet at the floor); the median plane is untouched.
+    #[test]
+    fn prtf_is_shallower_on_the_shadowed_ear() {
+        let m = SpagnolPrtfHrir {
+            depth: 1.0,
+            freq_scale: 1.0,
+        };
+        // Relative to each ear's own head-shadow base (see the pinna test).
+        let colour = |az: f32, ear: fn(&HrirPair) -> &[f32; HRIR_LEN]| -> f32 {
+            let p = m.render(az, 0.0, 48_000);
+            let s = SyntheticHrir.render(az, 0.0, 48_000);
+            let base: f32 = ear(&s).iter().map(|x| x * x).sum();
+            sumsq_diff(ear(&p), ear(&s)) / base
+        };
+        let (right, left) = (colour(90.0, |p| &p.right), colour(90.0, |p| &p.left));
+        let ratio = left / right;
+        assert!(
+            ratio < 0.2 && ratio > 0.04,
+            "shadowed/facing ratio {ratio}, expected ≈ 0.09"
+        );
+        let (fl, fr) = (colour(0.0, |p| &p.left), colour(0.0, |p| &p.right));
+        assert!((fl - fr).abs() < 1e-6 * fl.max(1e-12));
     }
 
     #[test]


### PR DESCRIPTION
## What (S2-02)

The pinna echoes (`pinna`, Brown-Duda) and the PRTF resonances/notches (`prtf`, Spagnol) were applied in full to **both** ears in every direction. Right near the median plane; wrong at 90°, where the ear on the far side of the head receives only what diffracts around it — its pinna faces away from the source and the notches it carves are shallow — yet it was coloured as if it saw the source.

## How

- `hrir::ear_exposure(az, el)` → `(left, right)`, the `(1 ∓ lateral)/2` the head model already shades by.
- `hrir::pinna_shade(exposure)`: 1 in the median plane (exposure 0.5) and on the facing side, linear down to `PINNA_SHADOW_FLOOR = 0.3` for the fully shadowed ear. A constant, not a setting.
- `ParametricPinnaHrir::render` scales each ear's echo depth by it; `SpagnolPrtfHrir::apply` takes the per-ear depth for its dry/wet mix (the biquad blocks stay shared).
- Median plane untouched (both ears at exposure 0.5 → factor 1), so a frontal A/B against the previous models is identical; mirror symmetry preserved (existing gate).

## Tests

At 90°, the colouration energy relative to each ear's own head-shadow base is ≈ floor² (0.09) on the shadowed ear versus the facing one (asserted 0.04–0.2), for both models; at 0° both ears are equally coloured. 359 renderer tests pass; golden unaffected (KEMAR).

## Listening

Lateral sources in `pinna` and `prtf`: less "ghost" colouration on the hidden ear. Series 2, lot 1; `feat/binaural-live-head-radius` (S2-05) will be stacked on this branch (same render functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
