### PR TITLE
feat(binaural): build the parametric head models with the live head radius

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/hrir.rs
+++ b/omniphony-renderer/renderer/src/binaural/hrir.rs
@@ -81,7 +81,20 @@ pub trait HrirProvider {
 /// with the ITD, which is the cue that actually carries lateralisation down
 /// there. Self-contained (no measured data); the base of the parametric
 /// pinna models and the no-pinna A/B reference.
-pub struct SyntheticHrir;
+pub struct SyntheticHrir {
+    /// Head radius `a` for `ω₀ = c / a`: the same radius the ITD model uses,
+    /// so a listener who fits `head_radius_m` moves the shelf corner and
+    /// the interaural delay together.
+    pub head_radius_m: f32,
+}
+
+impl Default for SyntheticHrir {
+    fn default() -> Self {
+        Self {
+            head_radius_m: super::itd::DEFAULT_HEAD_RADIUS_M,
+        }
+    }
+}
 
 impl SyntheticHrir {
     /// `α_min` (Brown & Duda's recommended value): the deepest high-frequency
@@ -90,9 +103,6 @@ impl SyntheticHrir {
     /// `θ_min`: angle of the deepest shadow, past which the bright spot
     /// behind the head brings the level back up.
     const THETA_MIN_DEG: f32 = 150.0;
-    /// Head radius `a` for `ω₀ = c / a` (the ITD model's default; the live
-    /// ITD radius is not wired into the HRIR build).
-    const HEAD_RADIUS_M: f32 = super::itd::DEFAULT_HEAD_RADIUS_M;
     const SPEED_OF_SOUND: f32 = 343.0;
 
     /// `α(θ)`, with `cos_theta` the cosine of the angle from the ear's axis.
@@ -108,8 +118,8 @@ impl SyntheticHrir {
     /// with `p = exp(−2ω₀ / fs)`. The exponential term carries `1 − α` of
     /// the DC gain so the total is exactly 1; at high frequency only the
     /// impulse survives, leaving `α`.
-    fn shelf_ir(alpha: f32, sample_rate: u32, out: &mut [f32; HRIR_LEN]) {
-        let w0 = Self::SPEED_OF_SOUND / Self::HEAD_RADIUS_M;
+    fn shelf_ir(&self, alpha: f32, sample_rate: u32, out: &mut [f32; HRIR_LEN]) {
+        let w0 = Self::SPEED_OF_SOUND / self.head_radius_m.clamp(0.05, 0.15);
         let p = (-2.0 * w0 / sample_rate as f32).exp();
         let mut tail = (1.0 - alpha) * (1.0 - p);
         for (n, slot) in out.iter_mut().enumerate() {
@@ -155,8 +165,8 @@ impl HrirProvider for SyntheticHrir {
         // sine. The left ear sees the supplementary angle.
         let lateral = (az.sin() * el.cos()).clamp(-1.0, 1.0);
         let mut pair = HrirPair::zeroed();
-        Self::shelf_ir(Self::alpha(-lateral), sample_rate, &mut pair.left);
-        Self::shelf_ir(Self::alpha(lateral), sample_rate, &mut pair.right);
+        self.shelf_ir(Self::alpha(-lateral), sample_rate, &mut pair.left);
+        self.shelf_ir(Self::alpha(lateral), sample_rate, &mut pair.right);
         pair
     }
 }
@@ -187,6 +197,9 @@ pub struct ParametricPinnaHrir {
     pub d: [f32; 5],
     /// Echo strength in [0, 1]. 0 ⇒ head shadow only; 1 ⇒ full echoes.
     pub depth: f32,
+    /// Head radius of the underlying head-shadow stage (see
+    /// [`SyntheticHrir::head_radius_m`]).
+    pub head_radius_m: f32,
 }
 
 impl ParametricPinnaHrir {
@@ -290,7 +303,10 @@ impl ParametricPinnaHrir {
 impl HrirProvider for ParametricPinnaHrir {
     fn render(&self, az_deg: f32, el_deg: f32, sample_rate: u32) -> HrirPair {
         // Base: the analytic head shadow + ILD (identical to SyntheticHrir).
-        let mut pair = SyntheticHrir.render(az_deg, el_deg, sample_rate);
+        let head = SyntheticHrir {
+            head_radius_m: self.head_radius_m,
+        };
+        let mut pair = head.render(az_deg, el_deg, sample_rate);
         if self.depth <= 1e-4 {
             return pair; // degenerates to the plain synthetic head model
         }
@@ -438,9 +454,10 @@ impl HrirSet {
         self.len == 0
     }
 
-    /// Convenience constructor for the built-in synthetic model.
+    /// Convenience constructor for the built-in synthetic model at the
+    /// default head radius.
     pub fn synthetic(sample_rate: u32) -> Self {
-        Self::new(&SyntheticHrir, sample_rate)
+        Self::new(&SyntheticHrir::default(), sample_rate)
     }
 
     #[inline]
@@ -695,6 +712,7 @@ mod tests {
                     &ParametricPinnaHrir {
                         d: ParametricPinnaHrir::D_PB_NH,
                         depth: 1.0,
+                        head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
                     },
                     48_000,
                 ),
@@ -705,6 +723,7 @@ mod tests {
                     &crate::binaural::prtf::SpagnolPrtfHrir {
                         depth: 1.0,
                         freq_scale: 1.0,
+                        head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
                     },
                     48_000,
                 ),
@@ -732,9 +751,10 @@ mod tests {
         let p = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 0.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(30.0, 20.0, 48_000);
-        let s = SyntheticHrir.render(30.0, 20.0, 48_000);
+        let s = SyntheticHrir::default().render(30.0, 20.0, 48_000);
         assert_eq!(p.left, s.left);
         assert_eq!(p.right, s.right);
     }
@@ -747,8 +767,8 @@ mod tests {
         // On the median plane the bare synthetic model is front/back (near-)
         // identical (lateral = sin(az)·cos(el) ≈ 0 at az 0 and 180; only the
         // f32 sin(π) residual differs): effectively no front/back cue.
-        let s_front = SyntheticHrir.render(0.0, 0.0, 48_000);
-        let s_back = SyntheticHrir.render(180.0, 0.0, 48_000);
+        let s_front = SyntheticHrir::default().render(0.0, 0.0, 48_000);
+        let s_back = SyntheticHrir::default().render(180.0, 0.0, 48_000);
         let s_diff = sumsq_diff(&s_front.left, &s_back.left);
         assert!(
             s_diff < 1e-6,
@@ -760,6 +780,7 @@ mod tests {
         let pinna = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         let p_front = pinna.render(0.0, 0.0, 48_000);
         let p_back = pinna.render(180.0, 0.0, 48_000);
@@ -778,6 +799,7 @@ mod tests {
         let pinna = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         let level = pinna.render(180.0, 0.0, 48_000);
         let high = pinna.render(180.0, 40.0, 48_000);
@@ -797,6 +819,7 @@ mod tests {
         let pinna = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         let ahead = pinna.render(0.0, 89.0, 48_000);
         let behind = pinna.render(180.0, 89.0, 48_000);
@@ -819,12 +842,13 @@ mod tests {
         let pinna = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         // Colouration energy relative to the ear's own head-shadow base, so
         // the shadowed ear's lower level does not enter the comparison.
         let colour = |az: f32, ear: fn(&HrirPair) -> &[f32; HRIR_LEN]| -> f32 {
             let p = pinna.render(az, 0.0, 48_000);
-            let s = SyntheticHrir.render(az, 0.0, 48_000);
+            let s = SyntheticHrir::default().render(az, 0.0, 48_000);
             let diff: f32 = ear(&p)
                 .iter()
                 .zip(ear(&s).iter())
@@ -852,11 +876,13 @@ mod tests {
         let pbnh = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(0.0, 45.0, 48_000);
         let rd = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_RD,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(0.0, 45.0, 48_000);
         let diff: f32 = pbnh
@@ -876,6 +902,7 @@ mod tests {
         let pinna = ParametricPinnaHrir {
             d: ParametricPinnaHrir::D_PB_NH,
             depth: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         let a = pinna.render(0.0, 30.0, 48_000);
         let b = pinna.render(0.0, 30.5, 48_000);
@@ -901,12 +928,13 @@ mod tests {
     #[test]
     fn modelled_providers_are_left_right_symmetric() {
         let providers: Vec<(&str, Box<dyn HrirProvider>)> = vec![
-            ("synthetic", Box::new(SyntheticHrir)),
+            ("synthetic", Box::new(SyntheticHrir::default())),
             (
                 "pinna",
                 Box::new(ParametricPinnaHrir {
                     d: ParametricPinnaHrir::D_PB_NH,
                     depth: 1.0,
+                    head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
                 }),
             ),
             (
@@ -914,6 +942,7 @@ mod tests {
                 Box::new(crate::binaural::prtf::SpagnolPrtfHrir {
                     depth: 1.0,
                     freq_scale: 1.0,
+                    head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
                 }),
             ),
         ];
@@ -1003,7 +1032,7 @@ mod tests {
             (150.0, 0.0),
             (90.0, 45.0),
         ] {
-            let p = SyntheticHrir.render(az, el, 48_000);
+            let p = SyntheticHrir::default().render(az, el, 48_000);
             let dc_l: f32 = p.left.iter().sum();
             let dc_r: f32 = p.right.iter().sum();
             assert!((dc_l - 1.0).abs() < 1e-3, "({az}, {el}) left DC {dc_l}");
@@ -1021,7 +1050,7 @@ mod tests {
                 .map(|(n, &x)| if n % 2 == 0 { x } else { -x })
                 .sum()
         };
-        let p = SyntheticHrir.render(90.0, 0.0, 48_000);
+        let p = SyntheticHrir::default().render(90.0, 0.0, 48_000);
         let (l, r) = (nyquist(&p.left), nyquist(&p.right));
         // The exponential term still contributes (1 − α)(1 − p)/(1 + p) at
         // Nyquist, hence ≈ 1.92 rather than exactly α = 2.
@@ -1032,15 +1061,50 @@ mod tests {
         // The left ear is 180° from the source axis: past θ_min, in the
         // bright spot, α ≈ 0.24 — darker than the median plane's 0.72.
         assert!(l > 0.15 && l < 0.35, "contralateral HF gain {l}");
-        let m = SyntheticHrir.render(0.0, 0.0, 48_000);
+        let m = SyntheticHrir::default().render(0.0, 0.0, 48_000);
         let med = nyquist(&m.left);
         assert!(med > 0.6 && med < 0.85, "median-plane HF gain {med}");
         // Deepest shadow at θ_min = 150° from the ear axis, i.e. 60° past
         // the median plane on the far side.
-        let deep = SyntheticHrir.render(-60.0, 0.0, 48_000);
+        let deep = SyntheticHrir::default().render(-60.0, 0.0, 48_000);
         let d = nyquist(&deep.right);
         // α_min = 0.05 plus the same ≈ 0.08 tail term as above.
         assert!(d < 0.2, "θ_min shadow gain {d}");
+    }
+
+    /// The shelf corner follows the head radius: a larger head has a lower
+    /// corner (2ω₀ = 2c/a), so its shadowed-ear response holds more of its
+    /// energy in the exponential tail and less in the leading impulse.
+    #[test]
+    fn synthetic_shelf_corner_follows_the_head_radius() {
+        let small = SyntheticHrir {
+            head_radius_m: 0.07,
+        }
+        .render(90.0, 0.0, 48_000);
+        let large = SyntheticHrir {
+            head_radius_m: 0.10,
+        }
+        .render(90.0, 0.0, 48_000);
+        // Left ear is shadowed: h[0] = α + (1 − α)(1 − p), p = exp(−2c/(a·fs)).
+        // A larger a → larger p → smaller (1 − p) → smaller h[0].
+        assert!(
+            large.left[0] < small.left[0],
+            "{} vs {}",
+            large.left[0],
+            small.left[0]
+        );
+        // The tail decays as pⁿ: a larger head has the slower decay (lower
+        // corner 2c/a), and the ratio of consecutive taps is p itself.
+        let decay = |h: &[f32; HRIR_LEN]| h[2] / h[1];
+        let (p_small, p_large) = (decay(&small.left), decay(&large.left));
+        assert!(p_large > p_small, "decay {p_large} vs {p_small}");
+        let expected = |a: f32| (-2.0 * 343.0 / (a * 48_000.0)).exp();
+        assert!((p_small - expected(0.07)).abs() < 1e-3, "{p_small}");
+        assert!((p_large - expected(0.10)).abs() < 1e-3, "{p_large}");
+        assert_eq!(
+            SyntheticHrir::default().head_radius_m,
+            crate::binaural::itd::DEFAULT_HEAD_RADIUS_M
+        );
     }
 
     #[test]

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -106,6 +106,16 @@ pub enum HrirSource {
 }
 
 impl HrirSource {
+    /// Whether the grid built from this source depends on the head radius:
+    /// the analytic head-shadow stage of the parametric models does, a
+    /// measured set does not (its head is the one it was measured on).
+    pub fn uses_head_radius(&self) -> bool {
+        matches!(
+            self,
+            Self::Synthetic | Self::Pinna { .. } | Self::Prtf { .. }
+        )
+    }
+
     pub fn as_str(&self) -> &str {
         match self {
             Self::Synthetic => "synthetic",
@@ -358,6 +368,20 @@ impl Default for HrirStatus {
     }
 }
 
+/// Head radius quantised to the millimetre: the key a grid build is
+/// identified by alongside its source, so a live radius tweak rebuilds the
+/// parametric grids once per millimetre step, not once per sub-micron wiggle.
+fn head_radius_key(head_radius_m: f32) -> u16 {
+    (head_radius_m.clamp(0.0, 1.0) * 1000.0).round() as u16
+}
+
+/// A grid build request: what to build and, for the parametric sources, with
+/// which head.
+struct HrirRequest {
+    source: HrirSource,
+    head_radius_m: f32,
+}
+
 /// Receives each build's [`HrirStatus`]; the renderer's owner wires it to the
 /// state broadcast. Called on the rebuild worker (or, for the initial grid,
 /// on the constructing thread), never on the audio thread.
@@ -372,6 +396,9 @@ pub type HrirStatusSink = std::sync::Arc<dyn Fn(HrirStatus) + Send + Sync>;
 struct Grid {
     /// The source that was asked for — what `rebuild_pending` compares.
     requested: HrirSource,
+    /// Head radius the grid was built with, in millimetres. Only the
+    /// parametric sources depend on it; see [`HrirSource::uses_head_radius`].
+    head_radius_mm: u16,
     /// The source the set really came from (KEMAR after a failed SOFA load).
     effective: HrirSource,
     /// Why `effective` differs from `requested`, when it does.
@@ -397,11 +424,13 @@ pub struct BinauralRenderer {
     /// HRIR source last *requested* (the active grid may briefly lag it while
     /// the worker builds — see [`Self::ensure_source`]).
     source: HrirSource,
+    /// Head radius last requested, as a millimetre key.
+    head_radius_mm: u16,
     /// Finished grids from the rebuild worker, awaiting the audio-thread swap.
     incoming: std::sync::Arc<arc_swap::ArcSwapOption<Grid>>,
     /// Requests to the long-lived rebuild worker. Dropping the renderer drops
     /// the sender, which terminates the worker.
-    rebuild_tx: std::sync::mpsc::Sender<HrirSource>,
+    rebuild_tx: std::sync::mpsc::Sender<HrirRequest>,
     /// Grids the audio thread has swapped out, handed to the worker to be
     /// freed there: the last reference to a grid must not drop on the audio
     /// thread (half a megabyte and up).
@@ -446,7 +475,7 @@ impl BinauralRenderer {
         // renders, SOFA file I/O) must never run on the audio thread. The
         // worker drains request bursts to the latest one, builds, and
         // publishes into `incoming` for the audio thread to swap in.
-        let (rebuild_tx, rebuild_rx) = std::sync::mpsc::channel::<HrirSource>();
+        let (rebuild_tx, rebuild_rx) = std::sync::mpsc::channel::<HrirRequest>();
         let (retire_tx, retire_rx) = std::sync::mpsc::channel::<std::sync::Arc<Grid>>();
         {
             let slot = std::sync::Arc::clone(&incoming);
@@ -461,7 +490,7 @@ impl BinauralRenderer {
                         // Free whatever the audio thread has retired, here
                         // rather than there.
                         while retire_rx.try_recv().is_ok() {}
-                        let grid = Self::build_grid(req, sample_rate);
+                        let grid = Self::build_grid(req.source, req.head_radius_m, sample_rate);
                         // Reported before the grid is handed over, so the
                         // status is never behind what is being convolved.
                         sink(grid.status());
@@ -472,12 +501,14 @@ impl BinauralRenderer {
         }
         // The initial (default) grid is built synchronously: `new` runs on
         // a control thread, and the renderer must be usable immediately.
-        let initial = Self::build_grid(source.clone(), sample_rate);
+        let head_radius_m = itd::DEFAULT_HEAD_RADIUS_M;
+        let initial = Self::build_grid(source.clone(), head_radius_m, sample_rate);
         sink(initial.status());
         Self {
             sample_rate,
             hrir: std::sync::Arc::new(initial),
             source,
+            head_radius_mm: head_radius_key(head_radius_m),
             incoming,
             rebuild_tx,
             retire_tx,
@@ -513,12 +544,13 @@ impl BinauralRenderer {
     /// attribute its output to a specific HRIR set has to wait on this.
     pub fn rebuild_pending(&self) -> bool {
         self.source != self.hrir.requested
+            || (self.source.uses_head_radius() && self.head_radius_mm != self.hrir.head_radius_mm)
     }
 
     /// Build the grid for `requested`. A SOFA source that cannot be loaded
     /// falls back to the embedded KEMAR set; the grid then records both
     /// sources and the reason, for [`HrirStatus`].
-    fn build_grid(requested: HrirSource, sample_rate: u32) -> Grid {
+    fn build_grid(requested: HrirSource, head_radius_m: f32, sample_rate: u32) -> Grid {
         let (set, effective, error) = match &requested {
             HrirSource::Sofa(path) => match Self::load_sofa(path, sample_rate) {
                 Ok(set) => (set, requested.clone(), None),
@@ -527,25 +559,32 @@ impl BinauralRenderer {
                         "binaural: SOFA source '{path}' unavailable ({reason}); falling back to SAF KEMAR"
                     );
                     (
-                        Self::build_hrir(&HrirSource::SafKemar, sample_rate),
+                        Self::build_hrir(&HrirSource::SafKemar, head_radius_m, sample_rate),
                         HrirSource::SafKemar,
                         Some(reason),
                     )
                 }
             },
-            other => (Self::build_hrir(other, sample_rate), other.clone(), None),
+            other => (
+                Self::build_hrir(other, head_radius_m, sample_rate),
+                other.clone(),
+                None,
+            ),
         };
         Grid {
             requested,
+            head_radius_mm: head_radius_key(head_radius_m),
             effective,
             error,
             set,
         }
     }
 
-    fn build_hrir(source: &HrirSource, sample_rate: u32) -> HrirSet {
+    fn build_hrir(source: &HrirSource, head_radius_m: f32, sample_rate: u32) -> HrirSet {
         match source {
-            HrirSource::Synthetic => HrirSet::synthetic(sample_rate),
+            HrirSource::Synthetic => {
+                HrirSet::new(&hrir::SyntheticHrir { head_radius_m }, sample_rate)
+            }
             HrirSource::Pinna {
                 preset,
                 d_scale_pct,
@@ -557,6 +596,7 @@ impl BinauralRenderer {
                     &ParametricPinnaHrir {
                         d,
                         depth: *depth_pct as f32 / 100.0,
+                        head_radius_m,
                     },
                     sample_rate,
                 )
@@ -568,6 +608,7 @@ impl BinauralRenderer {
                 &SpagnolPrtfHrir {
                     depth: *depth_pct as f32 / 100.0,
                     freq_scale: *freq_scale_pct as f32 / 100.0,
+                    head_radius_m,
                 },
                 sample_rate,
             ),
@@ -605,13 +646,13 @@ impl BinauralRenderer {
         Err("SOFA support not built into this renderer (enable the 'sofa' feature)".to_string())
     }
 
-    /// Track the requested HRIR source. Called once per frame from the audio
+    /// Track the requested HRIR source and head radius. Called once per frame from the audio
     /// thread; the steady-state cost is one compare plus one atomic swap. On
     /// an actual change it only pushes a request to the rebuild worker — the
     /// grid build (allocations, provider renders, SOFA file I/O) never runs
     /// here (issue #153). Frames keep rendering with the previous grid until
     /// the worker's result lands.
-    pub fn ensure_source(&mut self, source: &HrirSource) {
+    pub fn ensure_source(&mut self, source: &HrirSource, head_radius_m: f32) {
         if let Some(grid) = self.incoming.swap(None) {
             let retired = std::mem::replace(&mut self.hrir, grid);
             // The old grid goes back to the worker to be freed; dropping it
@@ -622,11 +663,25 @@ impl BinauralRenderer {
             // the new grid answers differently for the same key.
             self.hrir_generation = self.hrir_generation.wrapping_add(1);
         }
-        if &self.source != source {
+        // The head radius only matters to the parametric sources: a measured
+        // set was measured on its own head, and a live radius tweak must not
+        // rebuild it for nothing.
+        let radius_mm = head_radius_key(head_radius_m);
+        let radius_moved = source.uses_head_radius() && radius_mm != self.head_radius_mm;
+        if &self.source != source || radius_moved {
             self.source = source.clone();
+            self.head_radius_mm = radius_mm;
             // `send` allocates one queue node — rare (a user-initiated source
-            // change), unlike the megabytes+I/O of the build it replaces.
-            let _ = self.rebuild_tx.send(source.clone());
+            // or radius change), unlike the megabytes+I/O of the build it
+            // replaces.
+            let _ = self.rebuild_tx.send(HrirRequest {
+                source: source.clone(),
+                head_radius_m,
+            });
+        } else if radius_mm != self.head_radius_mm {
+            // Measured source: remember the radius so a later switch to a
+            // parametric one builds with the current head, not a stale one.
+            self.head_radius_mm = radius_mm;
         }
     }
 
@@ -1314,18 +1369,51 @@ mod tests {
             "the initial build must report the default set"
         );
         let missing = HrirSource::Sofa("/nonexistent/listener.sofa".to_string());
-        r.ensure_source(&missing);
+        r.ensure_source(&missing, itd::DEFAULT_HEAD_RADIUS_M);
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         while r.rebuild_pending() {
             assert!(std::time::Instant::now() < deadline, "rebuild never landed");
             std::thread::sleep(std::time::Duration::from_millis(5));
-            r.ensure_source(&missing);
+            r.ensure_source(&missing, itd::DEFAULT_HEAD_RADIUS_M);
         }
         let last = seen.lock().unwrap().last().cloned().expect("a status");
         assert_eq!(last.requested, missing);
         assert_eq!(last.effective, HrirSource::SafKemar);
         let err = last.error.expect("the failure must carry a reason");
         assert!(!err.is_empty());
+    }
+
+    /// A head-radius change rebuilds a parametric grid (its shelf corner
+    /// depends on it) and leaves a measured one alone (it was measured on
+    /// its own head).
+    #[test]
+    fn head_radius_rebuilds_parametric_grids_only() {
+        let mut r = BinauralRenderer::new(48_000);
+        let g0 = r.hrir_grid_id();
+        // Measured (default KEMAR): a radius change is not a rebuild.
+        r.ensure_source(&HrirSource::SafKemar, 0.10);
+        assert!(
+            !r.rebuild_pending(),
+            "KEMAR must not rebuild on a radius change"
+        );
+        assert_eq!(r.hrir_grid_id(), g0);
+        // Parametric: it is.
+        let settle = |r: &mut BinauralRenderer, radius: f32| {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            r.ensure_source(&HrirSource::Synthetic, radius);
+            while r.rebuild_pending() {
+                assert!(std::time::Instant::now() < deadline, "rebuild never landed");
+                std::thread::sleep(std::time::Duration::from_millis(5));
+                r.ensure_source(&HrirSource::Synthetic, radius);
+            }
+            r.hrir_grid_id()
+        };
+        let g_small = settle(&mut r, 0.07);
+        assert_ne!(g_small, g0);
+        let g_same = settle(&mut r, 0.0703); // same millimetre: no rebuild
+        assert_eq!(g_same, g_small);
+        let g_large = settle(&mut r, 0.10);
+        assert_ne!(g_large, g_small);
     }
 
     /// A source switch must not stall rendering: the frame right after the
@@ -1355,7 +1443,7 @@ mod tests {
         };
 
         let initial_grid = r.hrir_grid_id();
-        r.ensure_source(&HrirSource::Synthetic);
+        r.ensure_source(&HrirSource::Synthetic, itd::DEFAULT_HEAD_RADIUS_M);
         // Immediately after the request the old grid must still be active and
         // rendering must work (the build happens on the worker).
         assert_eq!(r.hrir_grid_id(), initial_grid, "swap must be asynchronous");
@@ -1369,7 +1457,7 @@ mod tests {
                 "rebuilt grid never arrived"
             );
             std::thread::sleep(std::time::Duration::from_millis(5));
-            r.ensure_source(&HrirSource::Synthetic);
+            r.ensure_source(&HrirSource::Synthetic, itd::DEFAULT_HEAD_RADIUS_M);
         }
         assert!(render(&mut r) > 1e-9, "render broken after grid swap");
     }

--- a/omniphony-renderer/renderer/src/binaural/prtf.rs
+++ b/omniphony-renderer/renderer/src/binaural/prtf.rs
@@ -108,6 +108,9 @@ pub struct SpagnolPrtfHrir {
     /// and resonances (larger pinna), >1 raises them — crude 1-DOF
     /// individualization standing in for the photo-derived notch frequencies.
     pub freq_scale: f32,
+    /// Head radius of the underlying head-shadow stage (see
+    /// [`SyntheticHrir::head_radius_m`]).
+    pub head_radius_m: f32,
 }
 
 impl SpagnolPrtfHrir {
@@ -142,7 +145,10 @@ impl SpagnolPrtfHrir {
 impl HrirProvider for SpagnolPrtfHrir {
     fn render(&self, az_deg: f32, el_deg: f32, sample_rate: u32) -> HrirPair {
         // Base: analytic head shadow + ILD (identical to SyntheticHrir).
-        let mut pair = SyntheticHrir.render(az_deg, el_deg, sample_rate);
+        let head = SyntheticHrir {
+            head_radius_m: self.head_radius_m,
+        };
+        let mut pair = head.render(az_deg, el_deg, sample_rate);
         if self.depth <= 1e-4 {
             return pair;
         }
@@ -197,9 +203,10 @@ mod tests {
         let p = SpagnolPrtfHrir {
             depth: 0.0,
             freq_scale: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(0.0, 0.0, 48_000);
-        let s = SyntheticHrir.render(0.0, 0.0, 48_000);
+        let s = SyntheticHrir::default().render(0.0, 0.0, 48_000);
         assert_eq!(p.left, s.left);
         assert_eq!(p.right, s.right);
     }
@@ -211,9 +218,10 @@ mod tests {
         let p = SpagnolPrtfHrir {
             depth: 1.0,
             freq_scale: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(0.0, 0.0, 48_000);
-        let s = SyntheticHrir.render(0.0, 0.0, 48_000);
+        let s = SyntheticHrir::default().render(0.0, 0.0, 48_000);
         assert!(
             sumsq_diff(&p.left, &s.left) > 1e-3,
             "PRTF did not colour the spectrum"
@@ -226,6 +234,7 @@ mod tests {
         let m = SpagnolPrtfHrir {
             depth: 1.0,
             freq_scale: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         let lo = m.render(0.0, -45.0, 48_000);
         let hi = m.render(0.0, 45.0, 48_000);
@@ -241,11 +250,13 @@ mod tests {
         let a = SpagnolPrtfHrir {
             depth: 1.0,
             freq_scale: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(0.0, 0.0, 48_000);
         let b = SpagnolPrtfHrir {
             depth: 1.0,
             freq_scale: 1.3,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         }
         .render(0.0, 0.0, 48_000);
         assert!(
@@ -261,11 +272,12 @@ mod tests {
         let m = SpagnolPrtfHrir {
             depth: 1.0,
             freq_scale: 1.0,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         // Relative to each ear's own head-shadow base (see the pinna test).
         let colour = |az: f32, ear: fn(&HrirPair) -> &[f32; HRIR_LEN]| -> f32 {
             let p = m.render(az, 0.0, 48_000);
-            let s = SyntheticHrir.render(az, 0.0, 48_000);
+            let s = SyntheticHrir::default().render(az, 0.0, 48_000);
             let base: f32 = ear(&s).iter().map(|x| x * x).sum();
             sumsq_diff(ear(&p), ear(&s)) / base
         };
@@ -285,6 +297,7 @@ mod tests {
         let m = SpagnolPrtfHrir {
             depth: 1.0,
             freq_scale: 1.5,
+            head_radius_m: crate::binaural::itd::DEFAULT_HEAD_RADIUS_M,
         };
         for el in [-45.0, -20.0, 0.0, 20.0, 45.0, 70.0, 90.0] {
             let p = m.render(30.0, el, 48_000);

--- a/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
+++ b/omniphony-renderer/renderer/src/spatial_renderer/mod.rs
@@ -797,7 +797,8 @@ impl SpatialRenderer {
                 // Compare against the live source in place: no per-frame clone
                 // (the `Sofa` variant carries a heap path), and any rebuild is
                 // pushed to the worker inside `ensure_source`.
-                self.binaural.ensure_source(&g.binaural.hrir_source);
+                self.binaural
+                    .ensure_source(&g.binaural.hrir_source, g.binaural.head_radius_m);
                 (
                     crate::binaural::BinauralFrameParams {
                         head_pose: g.binaural.head_pose,


### PR DESCRIPTION
## What (S2-05)

`head_radius_m` is live-tunable for the ITD, but the analytic head-shadow stage under `synthetic`, `pinna` and `prtf` used the default 8.75 cm (noted in #326): the shelf corner `2c/a` and the interaural delay disagreed as soon as the listener fitted the radius.

## How

- `SyntheticHrir { head_radius_m }` (with `Default`); `ParametricPinnaHrir` and `SpagnolPrtfHrir` carry the radius through to it.
- The rebuild worker's request is `HrirRequest { source, head_radius_m }`; the grid records the radius as a millimetre key. `rebuild_pending` and `ensure_source(source, head_radius_m)` consider the radius **only for the parametric sources** (`HrirSource::uses_head_radius`): a measured set was measured on its own head, and a radius tweak while KEMAR is selected rebuilds nothing (the value is remembered for a later switch to a parametric source).
- Millimetre quantisation: a slider wiggle within the same millimetre does not rebuild.

## Tests

- The shelf's tail decay `p = h[2]/h[1]` equals `exp(−2c/(a·fs))` for 7 and 10 cm heads, and the shadowed ear's leading tap is smaller for the larger head.
- Renderer: a radius change on KEMAR does not rebuild (same grid identity); on `synthetic` it does, once per millimetre step.
- Golden unaffected (KEMAR). 361 renderer tests pass.

## Review series

Series 2, lot 1; stacked on #337 (`feat/binaural-pinna-per-ear-exposure`), which edits the same render functions. Listening not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
