### PR TITLE
feat(studio): show which HRTF set is actually playing

### DIFF
--- a/omniphony-studio/src/controls/binaural.js
+++ b/omniphony-studio/src/controls/binaural.js
@@ -7,11 +7,16 @@
 // guarded so a missing node never throws.
 
 import { invoke } from '@tauri-apps/api/core';
+import { t, tf } from '../i18n.js';
 import { initSofaBrowser, setActiveSofaPath } from './sofa-browser.js';
 import { setSpeakersGhosted } from '../speakers.js';
 import { applyEarState, initHeadphoneChannels } from './headphone-meter.js';
 
 const el = (id) => document.getElementById(id);
+
+// Renderer source ids → i18n suffix of their option label.
+const HRTF_SOURCE_I18N = { saf: 'kemar', synthetic: 'synthetic', pinna: 'pinna', prtf: 'prtf', sofa: 'sofa' };
+const hrtfSourceLabel = (source) => t(`binaural.hrtfSource.${HRTF_SOURCE_I18N[source] ?? source}`);
 
 // Guard against re-binding listeners if the panel is initialised twice.
 let bound = false;
@@ -394,12 +399,21 @@ export function applyBinauralState(b) {
       if (pinnaBox) pinnaBox.style.display = b.hrirSource === 'pinna' ? 'grid' : 'none';
       const prtfBox = el('binauralPrtfControls');
       if (prtfBox) prtfBox.style.display = b.hrirSource === 'prtf' ? 'grid' : 'none';
-      // Info line under the source zone: chosen file name, or the
-      // KEMAR-fallback notice while no file is selected yet.
+      // Info line under the source zone. First, the set actually in use when
+      // it is not the one selected: a SOFA file that failed to load falls
+      // back to KEMAR, and the renderer says so through `hrirEffective` /
+      // `hrirError` — without this line the panel claimed the file was
+      // playing. Otherwise the chosen file name, or the no-file notice.
       setActiveSofaPath(typeof b.hrtfSofaPath === 'string' ? b.hrtfSofaPath : '');
       const info = el('binauralSofaInfo');
       if (info) {
-        if (b.hrirSource !== 'sofa') {
+        const effective = typeof b.hrirEffective === 'string' ? b.hrirEffective : b.hrirSource;
+        if (effective !== b.hrirSource) {
+          info.style.display = '';
+          info.textContent = tf('binaural.hrtfFallback', { effective: hrtfSourceLabel(effective) });
+          info.title = typeof b.hrirError === 'string' ? b.hrirError : '';
+          info.style.color = '#e8c46a';
+        } else if (b.hrirSource !== 'sofa') {
           info.style.display = 'none';
         } else {
           const path = typeof b.hrtfSofaPath === 'string' ? b.hrtfSofaPath : '';

--- a/omniphony-studio/src/i18n/de.json
+++ b/omniphony-studio/src/i18n/de.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF (Spagnol)",
   "binaural.hrtfSource.sofa": "SOFA-Datei",
   "binaural.sofaBrowseTitle": "Die HRTF-Datenbank von sofacoustics.org durchsuchen",
+  "binaural.hrtfFallback": "{effective} aktiv: die gewählte HRTF konnte nicht geladen werden (Grund per Mauszeiger).",
   "binaural.headRadius": "Kopfradius (cm)",
   "binaural.pinnaPreset": "Ohrmuschel-Preset (D)",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/en.json
+++ b/omniphony-studio/src/i18n/en.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF (Spagnol)",
   "binaural.hrtfSource.sofa": "SOFA file",
   "binaural.sofaBrowseTitle": "Browse the sofacoustics.org HRTF database",
+  "binaural.hrtfFallback": "{effective} in use: the selected HRTF could not be loaded (hover for the reason).",
   "binaural.headRadius": "Head radius (cm)",
   "binaural.pinnaPreset": "Pinna preset (D)",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/es.json
+++ b/omniphony-studio/src/i18n/es.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF (Spagnol)",
   "binaural.hrtfSource.sofa": "Archivo SOFA",
   "binaural.sofaBrowseTitle": "Explorar la base de datos de HRTF de sofacoustics.org",
+  "binaural.hrtfFallback": "{effective} en uso: no se pudo cargar la HRTF seleccionada (pase el ratón para ver el motivo).",
   "binaural.headRadius": "Radio de la cabeza (cm)",
   "binaural.pinnaPreset": "Preajuste de pabellón (D)",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/fr.json
+++ b/omniphony-studio/src/i18n/fr.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF (Spagnol)",
   "binaural.hrtfSource.sofa": "Fichier SOFA",
   "binaural.sofaBrowseTitle": "Parcourir la base de données HRTF de sofacoustics.org",
+  "binaural.hrtfFallback": "{effective} en service : la HRTF choisie n'a pas pu être chargée (survolez pour la raison).",
   "binaural.headRadius": "Rayon de tête (cm)",
   "binaural.pinnaPreset": "Préréglage pavillon (D)",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/it.json
+++ b/omniphony-studio/src/i18n/it.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF (Spagnol)",
   "binaural.hrtfSource.sofa": "File SOFA",
   "binaural.sofaBrowseTitle": "Sfoglia il database HRTF di sofacoustics.org",
+  "binaural.hrtfFallback": "{effective} in uso: la HRTF selezionata non è stata caricata (passa il mouse per il motivo).",
   "binaural.headRadius": "Raggio della testa (cm)",
   "binaural.pinnaPreset": "Preset padiglione (D)",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/ja.json
+++ b/omniphony-studio/src/i18n/ja.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF（Spagnol）",
   "binaural.hrtfSource.sofa": "SOFA ファイル",
   "binaural.sofaBrowseTitle": "sofacoustics.org の HRTF データベースを参照",
+  "binaural.hrtfFallback": "{effective} を使用中：選択した HRTF を読み込めませんでした（理由はマウスオーバーで表示）。",
   "binaural.headRadius": "頭の半径（cm）",
   "binaural.pinnaPreset": "耳介プリセット（D）",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/pt-BR.json
+++ b/omniphony-studio/src/i18n/pt-BR.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF (Spagnol)",
   "binaural.hrtfSource.sofa": "Arquivo SOFA",
   "binaural.sofaBrowseTitle": "Navegar pelo banco de dados de HRTF do sofacoustics.org",
+  "binaural.hrtfFallback": "{effective} em uso: não foi possível carregar a HRTF selecionada (passe o mouse para ver o motivo).",
   "binaural.headRadius": "Raio da cabeça (cm)",
   "binaural.pinnaPreset": "Predefinição de pavilhão (D)",
   "binaural.pinnaPreset.pbnh": "PB & NH",

--- a/omniphony-studio/src/i18n/zh-CN.json
+++ b/omniphony-studio/src/i18n/zh-CN.json
@@ -780,6 +780,7 @@
   "binaural.hrtfSource.prtf": "PRTF（Spagnol）",
   "binaural.hrtfSource.sofa": "SOFA 文件",
   "binaural.sofaBrowseTitle": "浏览 sofacoustics.org 的 HRTF 数据库",
+  "binaural.hrtfFallback": "正在使用 {effective}：所选 HRTF 无法加载（悬停查看原因）。",
   "binaural.headRadius": "头部半径（cm）",
   "binaural.pinnaPreset": "耳廓预设（D）",
   "binaural.pinnaPreset.pbnh": "PB & NH",


### PR DESCRIPTION
## What (S2-07)

#334 made the renderer report `hrirEffective` (the set convolved) and `hrirError` (why it differs from `hrirSource`) in the `binaural` state object. Studio still showed the selected source as if it were playing, so a listener comparing two HRTFs could audition KEMAR under the other file's name — the user-facing half of review point 12.

## How

- `controls/binaural.js`: the info line under the HRTF selector shows, in amber, `"<effective set> in use: the selected HRTF could not be loaded (hover for the reason)"` whenever `hrirEffective !== hrirSource`, with `hrirError` as the tooltip. The file-name / no-file lines are unchanged otherwise. The effective set is named through the existing option labels (`binaural.hrtfSource.*`), so it is translated for free.
- One new i18n key, `binaural.hrtfFallback`, in the eight locales. `npm run i18n:check`: all locales in parity. The Japanese and Chinese strings deserve a native review, like the rest of the binaural section.
- The binaural state reaches the panel as pass-through JSON (`serde_json::Value` in `app_state.rs`), so no serde layer change.

Checks: `node --check`, `npm run i18n:check`, `npx vite build` pass. No renderer change. Not verifiable in a browser preview here (the state comes over OSC through the Tauri listener); please glance at it with a wrong SOFA path selected.

## Review series

Series 2, lot 1 (last of the seven). Independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
