### PR TITLE
test(binaural): interaural delay by frequency against Kuhn and Woodworth (S2-14)

### DIFF
--- a/omniphony-renderer/renderer/src/binaural/itd.rs
+++ b/omniphony-renderer/renderer/src/binaural/itd.rs
@@ -9,7 +9,7 @@
 /// `BinauralLiveParams::head_radius_m` for per-listener ITD fit.
 pub const DEFAULT_HEAD_RADIUS_M: f32 = 0.0875;
 /// Speed of sound (m/s).
-const SPEED_OF_SOUND: f32 = 343.0;
+pub(super) const SPEED_OF_SOUND: f32 = 343.0;
 
 /// Per-ear delays in seconds for a source at the given azimuth/elevation.
 ///

--- a/omniphony-renderer/renderer/src/binaural/validation.rs
+++ b/omniphony-renderer/renderer/src/binaural/validation.rs
@@ -21,7 +21,7 @@ use dsp_fixtures::scene::{
     HrirSource, render_single_object_binaural, render_single_object_binaural_at,
 };
 
-use super::itd::{DEFAULT_HEAD_RADIUS_M, ear_delays_seconds};
+use super::itd::{DEFAULT_HEAD_RADIUS_M, SPEED_OF_SOUND, ear_delays_seconds};
 
 /// 128 blocks of 40 samples = 5120 samples, ample for a ±64-sample search.
 const BLOCKS: usize = 128;
@@ -261,4 +261,149 @@ fn hrir_providers_return_time_aligned_pairs() {
         worst.1,
         worst.2
     );
+}
+
+// ── Interaural delay by frequency ───────────────────────────────────────────
+
+/// Segment length of the Welch cross-spectrum below: 11.7 Hz bins at 48 kHz,
+/// so the interaural phase moves well under a radian per bin (0.07 rad for
+/// a 0.9 ms delay) and unwraps without ambiguity.
+const CROSS_SPECTRUM_SEGMENT: usize = 4096;
+
+/// Interaural phase delay (s, positive = the left ear is the later one) of
+/// the render of `source` at `azimuth_deg` on the horizon, read at each of
+/// `freqs_hz` off the cross-spectrum of the two output channels.
+///
+/// Welch estimate — Hann segments of [`CROSS_SPECTRUM_SEGMENT`] samples at
+/// half overlap, cross-spectra averaged — whose phase is unwrapped from DC
+/// (zero there: both ears pass the bass with a positive gain) and linearly
+/// interpolated at the requested frequency. The excitation is the same for
+/// both ears, so its own spectrum cancels: the phase is that of `H_L·H_R*`,
+/// the delay line, the HRIR pair and the fractional-delay interpolation
+/// included, whatever the excitation.
+fn interaural_phase_delays(azimuth_deg: f32, source: HrirSource, freqs_hz: &[f32]) -> Vec<f32> {
+    use realfft::RealFftPlanner;
+    use realfft::num_complex::Complex;
+    use std::f32::consts::{PI, TAU};
+
+    const SEG: usize = CROSS_SPECTRUM_SEGMENT;
+    // Twice the lag-test length: four full segments at half overlap.
+    let (left, right) = render_single_object_binaural(azimuth_deg, 2 * BLOCKS, source);
+    let mut planner = RealFftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(SEG);
+    let window: Vec<f32> = (0..SEG)
+        .map(|i| 0.5 - 0.5 * (TAU * i as f32 / SEG as f32).cos())
+        .collect();
+    let mut cross = vec![Complex::new(0.0f32, 0.0); SEG / 2 + 1];
+    let (mut in_l, mut in_r) = (fft.make_input_vec(), fft.make_input_vec());
+    let (mut sp_l, mut sp_r) = (fft.make_output_vec(), fft.make_output_vec());
+    let mut start = 0usize;
+    let mut segments = 0usize;
+    while start + SEG <= left.len() {
+        for i in 0..SEG {
+            in_l[i] = left[start + i] * window[i];
+            in_r[i] = right[start + i] * window[i];
+        }
+        fft.process(&mut in_l, &mut sp_l).expect("left FFT");
+        fft.process(&mut in_r, &mut sp_r).expect("right FFT");
+        for (c, (l, r)) in cross.iter_mut().zip(sp_l.iter().zip(&sp_r)) {
+            *c += l * r.conj();
+        }
+        start += SEG / 2;
+        segments += 1;
+    }
+    assert!(segments >= 2, "render too short for the cross-spectrum");
+
+    // Unwrapped phase, anchored at zero at DC.
+    let mut phase = Vec::with_capacity(cross.len());
+    let mut prev = 0.0f32;
+    let mut acc = 0.0f32;
+    for (k, c) in cross.iter().enumerate() {
+        let p = if k == 0 { 0.0 } else { c.arg() };
+        let mut d = p - prev;
+        while d > PI {
+            d -= TAU;
+        }
+        while d < -PI {
+            d += TAU;
+        }
+        acc += d;
+        prev = p;
+        phase.push(acc);
+    }
+    freqs_hz
+        .iter()
+        .map(|&f| {
+            let x = f * SEG as f32 / SAMPLE_RATE;
+            let k = x.floor() as usize;
+            let t = x - k as f32;
+            let phi = phase[k] * (1.0 - t) + phase[k + 1] * t;
+            // L = R·e^{−jωτ} for a left ear later by τ ⇒ arg(L·R*) = −ωτ.
+            -phi / (TAU * f)
+        })
+        .collect()
+}
+
+/// Frequencies the ITD is read at: one in the range where a sphere's ITD is
+/// Kuhn's low-frequency value, one where it has settled on Woodworth's.
+const ITD_LOW_HZ: f32 = 500.0;
+const ITD_HIGH_HZ: f32 = 3_000.0;
+
+/// The ITD of a rigid sphere is not one number: below ~1.5 kHz it is
+/// Kuhn's `3·(a/c)·sin θ` (1977), 765 µs at 90° for the default head, and
+/// only above that does it settle on Woodworth's `(a/c)·(θ + sin θ)`,
+/// 656 µs. The engine applies Woodworth as a broadband delay, so the
+/// low-frequency excess can only come from the HRIR pair's own phase — the
+/// minimum-phase KEMAR responses, or the Brown-Duda shelf of the analytic
+/// head, each of which carries a low-frequency group delay of its own.
+///
+/// This is the measurement the series-2 plan (S2-14) asks for before any
+/// correction: the interaural phase delay of the actual render at 90°, at
+/// 500 Hz against Kuhn and at 3 kHz against Woodworth, for both bundled
+/// providers. The bounds are wide (±20 %): the point is the printed
+/// figures, and a provider that lost its low-frequency delay altogether
+/// (fell to Woodworth's 656 µs, −14 %) or gained a spurious one.
+///
+/// Measured when the gate was written: synthetic 829 µs at 500 Hz (Kuhn
+/// +8.4 %) and 695 µs at 3 kHz (Woodworth +5.9 %); saf 816 µs (+6.6 %) and
+/// 754 µs (+14.9 %). Both providers already carry the whole low-frequency
+/// excess — and a little more — so the correction the plan held in reserve
+/// (a first-order all-pass on the far ear) has nothing to add.
+#[test]
+fn interaural_delay_by_frequency_tracks_kuhn_and_woodworth() {
+    let r_c = DEFAULT_HEAD_RADIUS_M / SPEED_OF_SOUND;
+    let woodworth = r_c * (std::f32::consts::FRAC_PI_2 + 1.0);
+    let kuhn = 3.0 * r_c;
+    for (name, source) in [
+        ("synthetic", HrirSource::Synthetic),
+        ("saf", HrirSource::SafKemar),
+    ] {
+        let d = interaural_phase_delays(90.0, source, &[ITD_LOW_HZ, ITD_HIGH_HZ]);
+        let (low, high) = (d[0], d[1]);
+        let pct = |x: f32, r: f32| 100.0 * (x / r - 1.0);
+        println!(
+            "[measure] itd_by_frequency {name}: {ITD_LOW_HZ:.0} Hz {:.0} µs (Kuhn {:.0} µs, \
+             {:+.1} %), {ITD_HIGH_HZ:.0} Hz {:.0} µs (Woodworth {:.0} µs, {:+.1} %)",
+            low * 1e6,
+            kuhn * 1e6,
+            pct(low, kuhn),
+            high * 1e6,
+            woodworth * 1e6,
+            pct(high, woodworth)
+        );
+        assert!(
+            pct(low, kuhn).abs() <= 20.0,
+            "{name}: low-frequency ITD {:.0} µs is {:+.1} % off Kuhn's {:.0} µs",
+            low * 1e6,
+            pct(low, kuhn),
+            kuhn * 1e6
+        );
+        assert!(
+            pct(high, woodworth).abs() <= 20.0,
+            "{name}: high-frequency ITD {:.0} µs is {:+.1} % off Woodworth's {:.0} µs",
+            high * 1e6,
+            pct(high, woodworth),
+            woodworth * 1e6
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Series 2, lot 3, **S2-14 — first half (measurement)**.

A rigid sphere's ITD is frequency-dependent: Kuhn's `3·(a/c)·sin θ` below ~1.5 kHz (765 µs at 90° for the default head), Woodworth's `(a/c)·(θ + sin θ)` above (656 µs). The engine applies Woodworth as a broadband delay, so any low-frequency excess must come from the HRIR pair's own phase. The plan asked for a measurement before deciding on a correction.

- New validation gate `interaural_delay_by_frequency_tracks_kuhn_and_woodworth`: the interaural phase delay of the actual render at 90°, read off the Welch cross-spectrum of the two output channels (delay line, HRIR pair and fractional-delay interpolation included), at 500 Hz against Kuhn and at 3 kHz against Woodworth, for `synthetic` and `saf`. Prints `[measure]` lines; bounds ±20 %.
- `itd::SPEED_OF_SOUND` exposed to the binaural module.

## Measurement

| provider | 500 Hz | vs Kuhn 765 µs | 3 kHz | vs Woodworth 656 µs |
|---|---|---|---|---|
| synthetic | 829 µs | +8.4 % | 695 µs | +5.9 % |
| saf (KEMAR) | 816 µs | +6.6 % | 754 µs | +14.9 % |

Both providers already carry the whole low-frequency excess (the Brown-Duda shelf's group delay on the far ear; the minimum-phase KEMAR pair's own). **The second half of S2-14 (a first-order all-pass on the far ear) is therefore not warranted** and is not opened. The gate stays to catch a provider that loses its low-frequency delay.

## Tests

`cargo test -p renderer --lib`: 382 passed, 2 ignored. Golden unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

