### PR TITLE
feat(binaural): grow the reflection room to contain the scene (S2-16)

### DIFF
--- a/omniphony-renderer/BINAURAL.md
+++ b/omniphony-renderer/BINAURAL.md
@@ -72,7 +72,7 @@ in Studio and over OSC (addresses listed at the end).
 | `head_tracking.osc_address` | — | OSC address carrying the orientation (empty disables tracking) |
 | `head_tracking.format` | `auto` | `auto` / `quat` / `rotvec` / `euler` |
 | `reflections.enabled` | `false` | shoebox early reflections (externalization) |
-| `reflections.room_width_m` | `4.0` | room extent, x (clamped 1–20 m) |
+| `reflections.room_width_m` | `4.0` | room extent, x (clamped 1–20 m). The three extents are minimums: the room grows to contain the scene (see *Scale* below) |
 | `reflections.room_depth_m` | `5.0` | room extent, y |
 | `reflections.room_height_m` | `2.7` | room extent, z |
 | `reflections.level` | `0.5` | per-reflection wall gain (0–1) |
@@ -164,11 +164,14 @@ directly instead.
   3 m, ~14 kHz cutoff at 10 m, ~5 kHz at 30 m).
 - **Scale**: `unit_scale_m` sets how far "1 ADM unit" is in metres. At the
   default 1.0 the far wall of the mix is one metre from your nose — try 3–4
-  for a room-sized stage. Size the reflection room to contain the scene
-  (half-extents ≥ `unit_scale_m`, i.e. 6–8 m wide and deep for a scale of
-  3–4): the image-source model pulls a source that sits outside the room
-  back inside before mirroring it, which keeps the geometry valid but puts
-  the reflections where the wall is, not where the object is.
+  for a room-sized stage. The reflection room grows on its own to contain
+  the scene: each half-extent is floored at `unit_scale_m + 0.35 m` (6.7 m
+  on every axis at a scale of 3, capped at 20 m), so the dimensions you set
+  are a minimum — a room smaller than the scene it holds has no physical
+  reading. Past the 20 m cap the image-source model pulls a source that
+  sits outside the room back inside before mirroring it, which keeps the
+  geometry valid but puts the reflections where the wall is, not where the
+  object is.
 - **ITD fit**: `head_radius_m` defaults to a KEMAR-ish 8.75 cm. If
   localisation feels smeared, measure ear-to-ear width and set half of it.
 - **HRTF**: the embedded measured KEMAR (`saf`) is the best generic default —

--- a/omniphony-renderer/renderer/src/binaural/mod.rs
+++ b/omniphony-renderer/renderer/src/binaural/mod.rs
@@ -790,6 +790,11 @@ impl BinauralRenderer {
 
         // Late-reverb bus: per-channel sends accumulate here; the shared FDN
         // turns the mono sum into a decorrelated stereo tail after the loop.
+        // The reflection room, grown to contain the scene (see
+        // `reflections::room_containing_scene`): once per frame, for every
+        // channel's image sources below.
+        let room_m = reflections::room_containing_scene(reflections.room_size_m, unit_scale_m);
+
         let reverb_active = reverb.enabled;
         if reverb_active {
             self.fdn.set_params(reverb.rt60_s, reverb.predelay_ms);
@@ -1000,15 +1005,15 @@ impl BinauralRenderer {
                 // The image sources are mirrors of the source *as pulled
                 // inside the room*, so the direct-path reference for their
                 // relative delays is that clamped source, not the raw one.
-                // With the raw distance, a source outside the room (any
-                // `unit_scale_m` ≥ 2 with the default room) had every
-                // reflection arrive early by the excess, and the near wall's
-                // at zero delay — a coincident copy of the direct sound.
-                let src_m = reflections::clamp_into_room(phys, reflections.room_size_m);
+                // With the raw distance, a source outside the room (a scene
+                // past the 20 m cap of the grown room) had every reflection
+                // arrive early by the excess, and the near wall's at zero
+                // delay — a coincident copy of the direct sound.
+                let src_m = reflections::clamp_into_room(phys, room_m);
                 let d_src = (src_m[0] * src_m[0] + src_m[1] * src_m[1] + src_m[2] * src_m[2])
                     .sqrt()
                     .max(MIN_DISTANCE_M);
-                let images = reflections::first_order_images(src_m, reflections.room_size_m);
+                let images = reflections::first_order_images(src_m, room_m);
                 let c_sound = reflections::speed_of_sound();
                 for (i, img) in images.iter().enumerate() {
                     let d_img = (img[0] * img[0] + img[1] * img[1] + img[2] * img[2])
@@ -1614,19 +1619,22 @@ mod tests {
         );
     }
 
-    /// A source outside the room (unit scale 3, default 4 m width) must not
-    /// get a reflection on top of its direct sound: the first samples of
-    /// the render carry the direct HRIR only, exactly as for the same
-    /// source with reflections off, and the wall copies land later.
+    /// A source outside the room must not get a reflection on top of its
+    /// direct sound: the first samples of the render carry the direct HRIR
+    /// only, exactly as for the same source with reflections off, and the
+    /// wall copies land later. The room grows with the scene (see
+    /// `room_containing_scene`), so a source only gets outside past the
+    /// 20 m cap: unit scale 12 puts it 12 m out in a room capped at 10 m
+    /// of half-extent.
     #[test]
     fn reflections_of_an_outside_source_do_not_coincide_with_the_direct() {
         let n = 2_048;
         let mut input = vec![0.0f32; n];
         input[0] = 1.0;
-        let pos = [[1.0, 0.0, 0.0]]; // 3 m to the right at unit scale 3
+        let pos = [[1.0, 0.0, 0.0]]; // 12 m to the right at unit scale 12
         let render = |enabled: bool| -> Vec<f32> {
             let params = BinauralFrameParams {
-                unit_scale_m: 3.0,
+                unit_scale_m: 12.0,
                 reflections: BinauralReflections {
                     enabled,
                     room_size_m: [4.0, 5.0, 2.7],
@@ -1669,6 +1677,58 @@ mod tests {
             .map(|(a, b)| (a - b) * (a - b))
             .sum();
         assert!(later > 1e-6, "no reflections at all: {later}");
+    }
+
+    /// The room grows to contain the scene: at unit scale 3 in the default
+    /// 4 × 5 × 2.7 m room a source at the ADM boundary (3 m to the right)
+    /// used to be pulled back to the 2 m wall, with the wall's image 0.1 m
+    /// behind it. Now the room is 6.7 m wide, the source is 0.35 m from
+    /// the wall, and the nearest image trails the direct sound by 0.7 m —
+    /// 98 samples at 48 kHz — with nothing before it.
+    #[test]
+    fn room_grows_to_contain_the_scene() {
+        let n = 2_048;
+        let mut input = vec![0.0f32; n];
+        input[0] = 1.0;
+        let pos = [[1.0, 0.0, 0.0]];
+        let render = |enabled: bool| -> Vec<f32> {
+            let params = BinauralFrameParams {
+                unit_scale_m: 3.0,
+                reflections: BinauralReflections {
+                    enabled,
+                    room_size_m: [4.0, 5.0, 2.7],
+                    level: 0.5,
+                    wall_cutoff_hz: reflections::MAX_WALL_CUTOFF_HZ,
+                },
+                ..dry_params()
+            };
+            let mut out = vec![0.0f32; n * 2];
+            let mut r = BinauralRenderer::new(48_000);
+            r.render_frame(
+                &input,
+                1,
+                n,
+                &params,
+                &pos,
+                &[ChannelGain::flat(1.0)],
+                &[],
+                None,
+                &mut out,
+            );
+            out
+        };
+        let (dry, wet) = (render(false), render(true));
+        let first_diff = wet
+            .chunks_exact(2)
+            .zip(dry.chunks_exact(2))
+            .position(|(w, d)| (w[0] - d[0]).abs() > 1e-6 || (w[1] - d[1]).abs() > 1e-6)
+            .expect("no reflections at all");
+        // 0.7 m of extra path = 98 samples, minus the smoothing of the
+        // tap gain ramping up over the first block.
+        assert!(
+            (80..=100).contains(&first_diff),
+            "nearest reflection lands at sample {first_diff}, expected ≈ 98 (0.7 m)"
+        );
     }
 
     /// Energy of an impulse render split at `split` samples: the direct

--- a/omniphony-renderer/renderer/src/binaural/reflections.rs
+++ b/omniphony-renderer/renderer/src/binaural/reflections.rs
@@ -28,6 +28,13 @@ pub const RING_CAPACITY_S: f32 = 0.25;
 pub const MIN_ROOM_M: f32 = 1.0;
 pub const MAX_ROOM_M: f32 = 20.0;
 
+/// Half-extent margin (m) the automatic room floor keeps beyond the scene
+/// (see [`room_containing_scene`]): an object at the ADM boundary is then
+/// this far from its wall, and the wall's image trails the direct sound by
+/// twice that — 0.7 m, ≈2 ms — instead of sitting on top of it. 0.35 makes
+/// the default 2.7 m ceiling exactly the floor at unit scale 1.
+pub const ROOM_FLOOR_MARGIN_M: f32 = 0.35;
+
 /// Margin (m) keeping the (clamped) source strictly inside the room so an
 /// image can never coincide with the listener.
 const WALL_MARGIN_M: f32 = 0.05;
@@ -79,6 +86,27 @@ fn half_extents(room_m: [f32; 3]) -> [f32; 3] {
         half[a] = (room_m[a].clamp(MIN_ROOM_M, MAX_ROOM_M)) * 0.5;
     }
     half
+}
+
+/// `room` (full extents, metres) grown, axis by axis, to contain the scene:
+/// the ADM cube spans `±unit_scale_m` on every world axis, and the walls are
+/// world-fixed (the head rotates, the scene does not), so each half-extent
+/// is floored at `unit_scale_m + ROOM_FLOOR_MARGIN_M`, within
+/// [`MAX_ROOM_M`]. An axis the user already sized larger is left alone.
+///
+/// Without the floor, a scene larger than the room had every boundary
+/// object pulled back to the wall by [`clamp_into_room`] — valid geometry,
+/// but the reflections of the wall rather than of the object, and from the
+/// nearest wall a near-coincident copy of the direct sound. The configured
+/// dimensions are therefore a *minimum*: a room smaller than the scene it
+/// holds has no physical reading anyway.
+pub fn room_containing_scene(room_m: [f32; 3], unit_scale_m: f32) -> [f32; 3] {
+    let floor = 2.0 * (unit_scale_m.max(0.0) + ROOM_FLOOR_MARGIN_M);
+    let mut out = room_m;
+    for extent in &mut out {
+        *extent = extent.max(floor).min(MAX_ROOM_M);
+    }
+    out
 }
 
 /// `src` (listener-relative metres, listener at the room centre) pulled just
@@ -334,6 +362,33 @@ mod tests {
                     "{src:?}: the premise of the test fails"
                 );
             }
+        }
+    }
+
+    /// The floor contains the ADM cube with its margin on every axis and
+    /// leaves a generous room alone.
+    #[test]
+    fn room_floor_contains_the_scene() {
+        let default = [4.0, 5.0, 2.7];
+        // Unit scale 1: the default room is already the floor on its height
+        // (2 × (1 + 0.35) = 2.7) and above it elsewhere — unchanged.
+        assert_eq!(room_containing_scene(default, 1.0), default);
+        // Unit scale 3: every axis grows to 6.7 m.
+        let grown = room_containing_scene(default, 3.0);
+        for (a, &g) in grown.iter().enumerate() {
+            assert!((g - 6.7).abs() < 1e-5, "axis {a}: {g}");
+        }
+        // A room the user sized larger keeps its dimensions.
+        let big = [12.0, 15.0, 8.0];
+        assert_eq!(room_containing_scene(big, 3.0), big);
+        // Capped at the largest room the bank models.
+        assert_eq!(room_containing_scene(default, 12.0), [MAX_ROOM_M; 3]);
+        // Every ADM-cube corner sits inside the grown room by the margin.
+        let s = 2.5;
+        let room = room_containing_scene(default, s);
+        for corner in [[s, s, s], [-s, s, -s], [s, -s, s]] {
+            let clamped = clamp_into_room(corner, room);
+            assert_eq!(clamped, corner, "corner {corner:?} was clamped");
         }
     }
 


### PR DESCRIPTION
## Summary

Series 2, lot 3, **S2-16 — automatic room floor**.

The image-source room was whatever the user configured; a scene larger than it (any `unit_scale_m` past 1 with the default 4 × 5 × 2.7 m room) had every boundary object pulled back to the wall before mirroring — the reflections of the wall rather than of the object, and a copy of the direct sound 0.1 m behind it from the nearest wall. The doc asked the user to size the room by hand.

- `reflections::room_containing_scene(room, unit_scale_m)`: each half-extent floored at `unit_scale_m + ROOM_FLOOR_MARGIN_M` (0.35 m), capped at 20 m. Applied once per frame in `render_frame`; per channel and per sample nothing changes.
- The plan wrote the floor as `√3·unit_scale_m + margin` (the scene's circumscribed sphere). The walls are world-fixed and the scene does not rotate with the head, so per-axis containment of the ADM cube is the exact condition; `√3` would have oversized every axis by 73 %.
- 0.35 m margin: a boundary object's nearest image trails the direct sound by 0.7 m (≈2 ms), and the default 2.7 m ceiling is exactly the floor at unit scale 1 — **the default room is unchanged at unit scale 1**. At scale 3 every axis becomes 6.7 m, the 6–8 m the doc used to recommend.
- BINAURAL.md: the room extents are documented as minimums; the *Scale* tip rewritten.

## Tests

- `room_floor_contains_the_scene` (reflections.rs): default unchanged at scale 1, 6.7 m at scale 3, generous room kept, 20 m cap, cube corners never clamped.
- `room_grows_to_contain_the_scene` (mod.rs): at scale 3 in the default room, the boundary source's nearest reflection lands ≈98 samples (0.7 m) after the direct sound, nothing before.
- `reflections_of_an_outside_source_do_not_coincide_with_the_direct` moved to unit scale 12 (past the cap) so the clamp path stays covered.

`cargo test -p renderer --lib`: 383 passed, 2 ignored. Golden unchanged (reflections off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
