### PR TITLE
fix(file-output): clean stop on a closed pipe, release the pacer on writer retirement

### DIFF
--- a/omniphony-renderer/audio_input/src/control.rs
+++ b/omniphony-renderer/audio_input/src/control.rs
@@ -213,6 +213,19 @@ impl InputControl {
         }
     }
 
+    /// Drop the installed pacer handle. Called from the decode lifecycle when
+    /// the audio writer that owns the pacer is retired (backend switch, device
+    /// or rate change, standby, stream restart), so the input thread stops
+    /// draining a FIFO nothing feeds any more into a ring nothing plays. Left
+    /// in place, every chunk would burn `drain_samples` failed pops and pushes
+    /// on the RT thread and pile phantom underruns into the pacer telemetry.
+    /// The next writer installs its own handle when it is built.
+    pub fn clear_output_pacer(&self) {
+        if let Ok(mut guard) = self.output_pacer.lock() {
+            *guard = None;
+        }
+    }
+
     /// Clone the currently-installed pacer handle, if any.
     pub fn output_pacer(&self) -> Option<audio_output::PacerHandle> {
         self.output_pacer

--- a/omniphony-renderer/audio_output/src/file_sink.rs
+++ b/omniphony-renderer/audio_output/src/file_sink.rs
@@ -14,7 +14,9 @@
 //! This is a **non-realtime** sink: there is no device clock, no adaptive
 //! resampling and no pacer. Flow control comes from blocking writes — when the
 //! downstream consumer (e.g. a network relay) stalls, the pipe fills and the
-//! write blocks, pacing the producer.
+//! write blocks, pacing the producer. A consumer that goes away instead of
+//! stalling makes the write fail with `BrokenPipe`; that is the end of the
+//! output rather than an error, and the decode layer ends the run on it.
 
 use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Write};

--- a/omniphony-renderer/src/cli/decode/handler.rs
+++ b/omniphony-renderer/src/cli/decode/handler.rs
@@ -251,6 +251,7 @@ impl DecodeHandler {
             &mut self.output,
             &mut self.runtime,
             self.audio_control.as_deref(),
+            self.input_control.as_deref(),
         )
         .sync_all()?;
         if self.output.audio_writer.is_none() {
@@ -552,7 +553,7 @@ impl DecodeHandler {
                 self.output.audio_writer_channels.unwrap_or(0),
                 effective_channel_count,
             );
-            if let Some(mut writer) = self.output.invalidate_writer() {
+            if let Some(mut writer) = self.output.invalidate_writer(self.input_control.as_deref()) {
                 let _ = writer.flush();
             }
             self.output.reset_realtime_output_tracking();
@@ -562,6 +563,7 @@ impl DecodeHandler {
             &mut self.output,
             &mut self.runtime,
             self.audio_control.as_deref(),
+            self.input_control.as_deref(),
         )
         .sync_all()?;
         // `sync_all` may have switched the active backend live (e.g. Studio
@@ -634,7 +636,7 @@ impl DecodeHandler {
             self.spatial.au_index
         );
 
-        if let Some(mut writer) = self.output.invalidate_writer() {
+        if let Some(mut writer) = self.output.invalidate_writer(self.input_control.as_deref()) {
             writer.flush()?;
         }
         self.reset_direct_trigger_wiring();
@@ -679,7 +681,7 @@ impl DecodeHandler {
 
     pub fn handle_decoder_flush_request(&mut self) {
         log::info!("Received flush request after decoder reset");
-        if let Some(mut writer) = self.output.invalidate_writer() {
+        if let Some(mut writer) = self.output.invalidate_writer(self.input_control.as_deref()) {
             if let Err(err) = writer.flush() {
                 log::warn!("Error flushing realtime output during decoder reset: {err}");
             }

--- a/omniphony-renderer/src/cli/decode/output.rs
+++ b/omniphony-renderer/src/cli/decode/output.rs
@@ -10,6 +10,42 @@ use audio_output::pipewire::{
 #[cfg(target_os = "linux")]
 use std::sync::{Arc, atomic::AtomicI64};
 
+/// The downstream consumer of the `file` sink closed its end of the pipe or
+/// FIFO. Not a fault of the render: the output simply has nowhere to go any
+/// more, and the run ends the way it does at the end of its input. Raised by
+/// [`AudioWriter::write_pcm_samples`] in place of the `BrokenPipe` it maps
+/// from, so the session loop can tell it apart from a real write error.
+#[derive(Debug)]
+pub struct OutputClosed;
+
+impl std::fmt::Display for OutputClosed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("output consumer closed the pipe")
+    }
+}
+
+impl std::error::Error for OutputClosed {}
+
+/// Classify a `file` sink write failure: a reader that went away (`EPIPE`)
+/// is the end of the output, anything else is a genuine write error.
+fn file_sink_error(err: std::io::Error) -> anyhow::Error {
+    if err.kind() == std::io::ErrorKind::BrokenPipe {
+        anyhow::Error::new(OutputClosed)
+    } else {
+        err.into()
+    }
+}
+
+/// Flush the `file` sink, treating a consumer that already went away as
+/// nothing left to deliver: the final flush of a run that ended on
+/// [`OutputClosed`] must not turn back into an error.
+fn flush_file_sink(writer: &mut audio_output::FileAudioWriter) -> Result<()> {
+    match writer.flush() {
+        Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        other => other.map_err(anyhow::Error::from),
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct AudioLatencySnapshot {
     /// Current end-to-end latency observed by the listener.
@@ -212,13 +248,13 @@ impl AudioWriter {
                 Ok(())
             }
             AudioWriter::File(file_writer) => {
-                if let Some(f32_slice) = samples.as_f32() {
-                    file_writer.write_samples(f32_slice)?;
+                let written = if let Some(f32_slice) = samples.as_f32() {
+                    file_writer.write_samples(f32_slice)
                 } else {
                     let samples_f32 = samples.to_f32();
-                    file_writer.write_samples(&samples_f32)?;
-                }
-                Ok(())
+                    file_writer.write_samples(&samples_f32)
+                };
+                written.map_err(file_sink_error)
             }
             AudioWriter::Unsupported => Err(anyhow!("No supported realtime output backend")),
         }
@@ -256,7 +292,7 @@ impl AudioWriter {
                 Ok(())
             }
             AudioWriter::File(mut w) => {
-                w.flush()?;
+                flush_file_sink(&mut w)?;
                 drop(w);
                 Ok(())
             }
@@ -276,10 +312,7 @@ impl AudioWriter {
                 w.flush()?;
                 Ok(())
             }
-            AudioWriter::File(file_writer) => {
-                file_writer.flush()?;
-                Ok(())
-            }
+            AudioWriter::File(file_writer) => flush_file_sink(file_writer),
             AudioWriter::Unsupported => Err(anyhow!("No supported realtime output backend")),
         }
     }
@@ -553,5 +586,83 @@ impl AudioWriter {
             AudioWriter::Pipewire(pw) => Some(pw.pending_input_triggers()),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use audio_output::{FileAudioWriter, FileSinkFormat};
+    use std::io::{self, Write};
+
+    /// A destination whose reader has gone: every write fails with `EPIPE`.
+    struct GoneReader;
+
+    impl Write for GoneReader {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A destination that fails for a reason unrelated to its reader.
+    struct FullDisk;
+
+    impl Write for FullDisk {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("no space left on device"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn file_writer_over(sink: impl Write + Send + 'static) -> AudioWriter {
+        AudioWriter::File(
+            FileAudioWriter::with_writer(Box::new(sink), FileSinkFormat::RawF32, 48_000, 2, None)
+                .expect("a raw sink has no header to write"),
+        )
+    }
+
+    /// Larger than the sink's own buffer, so the write reaches the destination
+    /// at once instead of sitting in the buffer until a later flush.
+    fn unbuffered_block() -> AudioSamples {
+        AudioSamples::F32(vec![0.0; 32 * 1024])
+    }
+
+    #[test]
+    fn a_reader_that_went_away_is_reported_as_output_closed() {
+        let mut writer = file_writer_over(GoneReader);
+        let err = writer
+            .write_pcm_samples(&unbuffered_block(), 2)
+            .expect_err("the closed pipe must surface");
+        assert!(err.is::<OutputClosed>(), "unexpected error: {err:#}");
+    }
+
+    #[test]
+    fn other_write_failures_stay_errors() {
+        let mut writer = file_writer_over(FullDisk);
+        let err = writer
+            .write_pcm_samples(&unbuffered_block(), 2)
+            .expect_err("a failed write must surface");
+        assert!(
+            !err.is::<OutputClosed>(),
+            "misread as a closed pipe: {err:#}"
+        );
+        assert!(err.downcast_ref::<io::Error>().is_some());
+    }
+
+    #[test]
+    fn flushing_towards_a_gone_reader_is_not_an_error() {
+        let mut writer = file_writer_over(GoneReader);
+        writer
+            .write_pcm_samples(&AudioSamples::F32(vec![0.0; 16]), 2)
+            .expect("a small block is buffered, not yet written");
+        writer.finish().expect("nothing left to deliver");
+        writer.close_and_drop().expect("nothing left to deliver");
     }
 }

--- a/omniphony-renderer/src/cli/decode/output_runtime_sync.rs
+++ b/omniphony-renderer/src/cli/decode/output_runtime_sync.rs
@@ -1,6 +1,7 @@
 use super::state::{OutputState, RuntimeOutputState};
 use crate::cli::command::{OutputBackend, OutputFileFormatArg};
 use anyhow::Result;
+use audio_input::InputControl;
 use audio_output::{AdaptiveResamplingConfig, AudioControl};
 use std::str::FromStr;
 
@@ -17,6 +18,9 @@ pub struct OutputRuntimeCoordinator<'a> {
     output: &'a mut OutputState,
     runtime: &'a mut RuntimeOutputState,
     audio_control: Option<&'a AudioControl>,
+    /// Loses its pacer handle whenever the writer is retired here; see
+    /// [`OutputState::invalidate_writer`].
+    input_control: Option<&'a InputControl>,
 }
 
 impl<'a> OutputRuntimeCoordinator<'a> {
@@ -24,11 +28,13 @@ impl<'a> OutputRuntimeCoordinator<'a> {
         output: &'a mut OutputState,
         runtime: &'a mut RuntimeOutputState,
         audio_control: Option<&'a AudioControl>,
+        input_control: Option<&'a InputControl>,
     ) -> Self {
         Self {
             output,
             runtime,
             audio_control,
+            input_control,
         }
     }
 
@@ -94,7 +100,7 @@ impl<'a> OutputRuntimeCoordinator<'a> {
     fn flush_and_invalidate_writer(&mut self) {
         match output_backend_supported_for_runtime_reset() {
             true => {
-                if let Some(mut writer) = self.output.invalidate_writer() {
+                if let Some(mut writer) = self.output.invalidate_writer(self.input_control) {
                     let _ = writer.flush();
                 }
                 self.output.reset_realtime_output_tracking();

--- a/omniphony-renderer/src/cli/decode/session_run.rs
+++ b/omniphony-renderer/src/cli/decode/session_run.rs
@@ -7,6 +7,7 @@ use super::decoder_thread::{
 use super::handler::DecodeHandler;
 use super::idle_feed::{IdleFeedInputs, IdleFeeder};
 use super::live_input::{LiveBridgeRuntimeConfig, spawn_live_input_manager};
+use super::output::OutputClosed;
 use super::state::FrameHandlerContext;
 use crate::cli::command::{Cli, EvaluationModeArg, OutputBackend, RenderArgSources, RenderArgs};
 use anyhow::Result;
@@ -482,7 +483,9 @@ fn run_standby_until_resume(
     handler: &mut DecodeHandler,
 ) {
     sys::shutdown::take_standby_request();
-    handler.output.audio_writer = None;
+    let _ = handler
+        .output
+        .invalidate_writer(handler.input_control.as_deref());
     // Discard any frames the decoder rendered while standing by so the decoder
     // thread never blocks on a full channel and no stale audio is played on
     // resume.
@@ -627,7 +630,12 @@ fn process_decoder_messages(
                     break;
                 }
                 handler.poll_runtime_state()?;
-                pump_idle_feed(&mut idle_feeder, handler, ctx, drain_tx)?;
+                if let Err(err) = pump_idle_feed(&mut idle_feeder, handler, ctx, drain_tx) {
+                    if end_run_if_output_closed(&err) {
+                        break;
+                    }
+                    return Err(err);
+                }
                 continue;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -640,7 +648,12 @@ fn process_decoder_messages(
                 if handler.should_accept_source(frame.source) {
                     idle_feeder.note_real_frame(std::time::Instant::now());
                 }
-                handle_audio_message(handler, frame, ctx)?
+                if let Err(err) = handle_audio_message(handler, frame, ctx) {
+                    if end_run_if_output_closed(&err) {
+                        break;
+                    }
+                    return Err(err);
+                }
             }
             Ok(DecoderMessage::FlushRequest(source)) => {
                 if handler.should_accept_source(source) {
@@ -661,6 +674,19 @@ fn process_decoder_messages(
     }
 
     Ok(())
+}
+
+/// A downstream consumer closing the `file` sink is the end of the output,
+/// not a fault: log it once, ask for a clean shutdown (the decoder thread is
+/// still reading its input and needs waking) and let the caller leave the
+/// loop. Any other error is left to propagate.
+fn end_run_if_output_closed(err: &anyhow::Error) -> bool {
+    if !err.is::<OutputClosed>() {
+        return false;
+    }
+    log::info!("Output consumer closed the pipe; stopping the render loop");
+    sys::shutdown::request_shutdown();
+    true
 }
 
 fn begin_shutdown_if_requested() -> bool {
@@ -689,7 +715,16 @@ fn complete_render_run(
     args: &RenderArgs,
     is_shutdown: bool,
 ) -> Result<()> {
-    match prepared.decode_thread.join() {
+    // Close the frame channel before joining. It is bounded, and the decoder
+    // may be blocked in `send` on a full one (file-sink backpressure at the
+    // moment the run stopped); with nothing receiving any more that send would
+    // never return, and neither would the join. A closed channel makes it
+    // fail, and the decoder stops on that.
+    let PreparedDecodeRun {
+        rx, decode_thread, ..
+    } = prepared;
+    drop(rx);
+    match decode_thread.join() {
         Ok(Ok(())) => {
             if is_shutdown {
                 log::info!("Decoder stopped cleanly");

--- a/omniphony-renderer/src/cli/decode/state.rs
+++ b/omniphony-renderer/src/cli/decode/state.rs
@@ -1,5 +1,6 @@
 use super::output::AudioWriter;
 use crate::cli::command::{OutputBackend, OutputFileFormatArg};
+use audio_input::InputControl;
 use audio_output::AdaptiveResamplingConfig;
 #[cfg(target_os = "linux")]
 use audio_output::pipewire::PipewireBufferConfig;
@@ -212,9 +213,22 @@ impl Default for OutputState {
 }
 
 impl OutputState {
-    pub fn invalidate_writer(&mut self) -> Option<AudioWriter> {
+    /// Retire the audio writer so the next frame builds a fresh one.
+    ///
+    /// The writer's cross-crate wiring goes with it: a PipeWire writer leaves
+    /// its pacer handle on the `InputControl`, and the input thread keeps
+    /// draining that handle on every chunk until something replaces it. The
+    /// control is taken here so the handle is cleared in the same step; the
+    /// next writer installs its own when it is built.
+    pub fn invalidate_writer(
+        &mut self,
+        input_control: Option<&InputControl>,
+    ) -> Option<AudioWriter> {
         self.output_init_failed = false;
         self.audio_writer_channels = None;
+        if let Some(control) = input_control {
+            control.clear_output_pacer();
+        }
         self.audio_writer.take()
     }
 

--- a/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
+++ b/omniphony-renderer/src/cli/decode/writer_lifecycle.rs
@@ -156,15 +156,6 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                     channel_names,
                 ) {
                     Ok(writer) => {
-                        // Wire the post-rendering pacer into the input
-                        // control before stashing the writer, so the input
-                        // PwStream callback can drain the FIFO on its next
-                        // tick.
-                        if let (Some(ic), Some(handle)) =
-                            (self.input_control, writer.pacer_handle())
-                        {
-                            ic.install_output_pacer(handle);
-                        }
                         self.output.audio_writer = Some(writer);
                         self.output.audio_writer_channels = Some(channel_count);
                         self.output.bootstrap_frames_seen = 0;
@@ -288,7 +279,7 @@ impl<'a> WriterLifecycleCoordinator<'a> {
         #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = (output_backend, sample_rate, channel_count);
 
-        match output_backend {
+        let writer = match output_backend {
             #[cfg(target_os = "linux")]
             OutputBackend::Pipewire => {
                 if let Some(reason) = bridge_input_loop_reason(
@@ -368,7 +359,17 @@ impl<'a> WriterLifecycleCoordinator<'a> {
                 )
             }
             OutputBackend::Unsupported => Err(anyhow!("No supported realtime output backend")),
+        }?;
+        // Wire the post-rendering pacer into the input control before the
+        // writer is handed back, so the input PwStream callback can drain the
+        // FIFO on its next tick. Done here rather than by the callers so every
+        // path that builds a writer (first frame, live switch, stream restart)
+        // installs the handle of the writer it is about to play through, and
+        // none leaves the input thread draining the one just retired.
+        if let (Some(control), Some(handle)) = (self.input_control, writer.pacer_handle()) {
+            control.install_output_pacer(handle);
         }
+        Ok(writer)
     }
 
     /// Build the cpal-backed realtime writer — ASIO on Windows, CoreAudio on


### PR DESCRIPTION
Follow-ups from #113, tracked in #116.

## 1. `BrokenPipe` on the `file` sink ends the run cleanly

When the consumer of the `file` sink closes its end (`... | head`, `ffmpeg` exiting, a relay dying on a FIFO), the `EPIPE` propagated from `write_all` up to the session loop as a hard error and the renderer left with `orender exiting with error`.

- `AudioWriter::write_pcm_samples` maps `ErrorKind::BrokenPipe` from the file sink to a typed `OutputClosed` error; any other I/O error keeps its meaning.
- `process_decoder_messages` recognises it on both write paths (decoded frames and the idle feed): logs one info line, calls `sys::shutdown::request_shutdown()` so the decoder thread wakes out of its input read, and leaves the loop. The run then goes through the normal shutdown teardown and exits 0.
- The final flush of the file sink (`finish` / `close_and_drop`) treats a `BrokenPipe` as nothing left to deliver, so the shutdown flush does not turn back into a warning.
- `complete_render_run` drops the frame receiver before joining the decoder thread. The channel is bounded and the decoder may be blocked in `send` on a full one (the file sink applies backpressure) with nobody receiving any more; the closed channel makes that send fail and the decoder stops on it. Without this the join could hang.

## 2. Pacer handle released when the writer is retired

`flush_and_invalidate_writer` (backend/device/rate switches), the width-change and stream-restart paths in the handler, and standby all dropped the writer but left its `PacerHandle` on `InputControl`. Both consumers of that handle (the PipeWire input RT callback and the pipe-bridge drain thread) kept calling `drain()` on it every chunk: thousands of failed pops/pushes per chunk on a dead FIFO and ring, and `diag_underrun_total` growing without bound, i.e. phantom underruns in the pacer telemetry while in `file` mode.

- `InputControl::clear_output_pacer()` added. `OutputState::invalidate_writer` now takes the `InputControl` and clears the handle in the same step; the signature change makes every retirement site pass it, and the standby path uses it too instead of a bare `= None`.
- The install moves from `create_audio_writer_if_needed` into `build_audio_writer`, so every path that builds a writer installs the handle of the writer it is about to play through. This also covers `handle_stream_restart`, which built a new PipeWire writer directly and never installed its handle, leaving the input thread draining the retired one.

## Verification

- `cargo fmt --check` and `cargo test -p omniphony-renderer -p audio_input -p audio_output` green. Three new unit tests cover the `OutputClosed` mapping, the non-`EPIPE` error path and the tolerant final flush.
- End to end: `orender render dumps/dts51_core.dts --output-backend file --output-file - --enable-vbap --no-osc | head -c 400000` exits 0 with one info line (`Output consumer closed the pipe; stopping the render loop`) followed by `Decoder stopped cleanly`. Same with a reader that sleeps 3 s before reading 100 kB (decoder blocked 2.7 s in `send` at the moment the pipe closed): clean exit, no hang.
- The Studio device→file switch on a live PipeWire session (the pacer clearing path) was not exercised in this session. The change there is the `clear_output_pacer()` call on retirement; the rebuild on switching back re-installs the handle as before.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
